### PR TITLE
Various fixes and new utilities

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -401,7 +401,7 @@ indentation = function () {
   }
   return(s);
 };
-var reserved = {"debugger": true, "not": true, "do": true, "delete": true, "try": true, "void": true, "catch": true, "repeat": true, "until": true, "this": true, "+": true, "elseif": true, "default": true, "while": true, "==": true, "%": true, "<": true, "switch": true, "local": true, "if": true, "true": true, "=": true, "nil": true, "/": true, "with": true, "-": true, "finally": true, "else": true, "return": true, "for": true, "throw": true, "typeof": true, "case": true, "then": true, "or": true, "and": true, "var": true, "break": true, ">": true, "function": true, "in": true, "instanceof": true, "end": true, "*": true, "new": true, ">=": true, "false": true, "<=": true, "continue": true};
+var reserved = {"instanceof": true, "return": true, "break": true, "end": true, ">=": true, "finally": true, "<=": true, "*": true, "for": true, "local": true, "if": true, "switch": true, "else": true, "default": true, "then": true, "=": true, "and": true, "true": true, "with": true, "until": true, "or": true, "function": true, "delete": true, "while": true, "case": true, "in": true, "nil": true, "catch": true, "elseif": true, "false": true, "try": true, "void": true, "repeat": true, "/": true, "<": true, "-": true, "+": true, "%": true, "var": true, "continue": true, "do": true, "==": true, "debugger": true, "typeof": true, "throw": true, "this": true, "not": true, "new": true, ">": true};
 reserved63 = function (x) {
   return(reserved[x]);
 };
@@ -462,8 +462,8 @@ _x58.lua = "not ";
 __x57["not"] = _x58;
 var __x59 = [];
 __x59["/"] = true;
-__x59["*"] = true;
 __x59["%"] = true;
+__x59["*"] = true;
 var __x60 = [];
 __x60["+"] = true;
 __x60["-"] = true;
@@ -473,10 +473,10 @@ _x62.js = "+";
 _x62.lua = "..";
 __x61.cat = _x62;
 var __x63 = [];
-__x63["<="] = true;
 __x63[">"] = true;
-__x63[">="] = true;
+__x63["<="] = true;
 __x63["<"] = true;
+__x63[">="] = true;
 var __x64 = [];
 var _x65 = [];
 _x65.js = "===";
@@ -645,8 +645,8 @@ var compile_special = function (form, stmt63) {
   var x = _id5[0];
   var args = cut(_id5, 1);
   var _id6 = getenv(x);
-  var special = _id6.special;
   var stmt = _id6.stmt;
+  var special = _id6.special;
   var self_tr63 = _id6.tr;
   var tr = terminator(stmt63 && !self_tr63);
   return(apply(special, args) + tr);
@@ -1020,7 +1020,7 @@ var compile_file = function (path) {
 load = function (path) {
   return(run(compile_file(path)));
 };
-setenv("do", {_stash: true, special: function () {
+setenv("do", {_stash: true, stmt: true, special: function () {
   var forms = unstash(Array.prototype.slice.call(arguments, 0));
   var s = "";
   var _x108 = forms;
@@ -1032,8 +1032,8 @@ setenv("do", {_stash: true, special: function () {
     _i12 = _i12 + 1;
   }
   return(s);
-}, stmt: true, tr: true});
-setenv("%if", {_stash: true, special: function (cond, cons, alt) {
+}, tr: true});
+setenv("%if", {_stash: true, stmt: true, special: function (cond, cons, alt) {
   var _cond1 = compile(cond);
   indent_level = indent_level + 1;
   var _x111 = compile(cons, {_stash: true, stmt: true});
@@ -1066,8 +1066,8 @@ setenv("%if", {_stash: true, special: function (cond, cons, alt) {
   } else {
     return(s + "\n");
   }
-}, stmt: true, tr: true});
-setenv("while", {_stash: true, special: function (cond, form) {
+}, tr: true});
+setenv("while", {_stash: true, stmt: true, special: function (cond, form) {
   var _cond3 = compile(cond);
   indent_level = indent_level + 1;
   var _x114 = compile(form, {_stash: true, stmt: true});
@@ -1079,8 +1079,8 @@ setenv("while", {_stash: true, special: function (cond, form) {
   } else {
     return(ind + "while " + _cond3 + " do\n" + body + ind + "end\n");
   }
-}, stmt: true, tr: true});
-setenv("%for", {_stash: true, special: function (t, k, form) {
+}, tr: true});
+setenv("%for", {_stash: true, stmt: true, special: function (t, k, form) {
   var _t1 = compile(t);
   var ind = indentation();
   indent_level = indent_level + 1;
@@ -1092,8 +1092,8 @@ setenv("%for", {_stash: true, special: function (t, k, form) {
   } else {
     return(ind + "for (" + k + " in " + _t1 + ") {\n" + body + ind + "}\n");
   }
-}, stmt: true, tr: true});
-setenv("%try", {_stash: true, special: function (form) {
+}, tr: true});
+setenv("%try", {_stash: true, stmt: true, special: function (form) {
   var e = unique("e");
   var ind = indentation();
   indent_level = indent_level + 1;
@@ -1106,33 +1106,33 @@ setenv("%try", {_stash: true, special: function (form) {
   indent_level = indent_level - 1;
   var h = _x126;
   return(ind + "try {\n" + body + ind + "}\n" + ind + "catch (" + e + ") {\n" + h + ind + "}\n");
-}, stmt: true, tr: true});
-setenv("%delete", {_stash: true, stmt: true, special: function (place) {
+}, tr: true});
+setenv("%delete", {_stash: true, special: function (place) {
   return(indentation() + "delete " + compile(place));
-}});
-setenv("break", {_stash: true, stmt: true, special: function () {
+}, stmt: true});
+setenv("break", {_stash: true, special: function () {
   return(indentation() + "break");
-}});
+}, stmt: true});
 setenv("%function", {_stash: true, special: function (args, body) {
   return(compile_function(args, body));
 }});
-setenv("%global-function", {_stash: true, special: function (name, args, body) {
+setenv("%global-function", {_stash: true, stmt: true, special: function (name, args, body) {
   if (target === "lua") {
     var x = compile_function(args, body, {_stash: true, name: name});
     return(indentation() + x);
   } else {
     return(compile(["set", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}, stmt: true, tr: true});
-setenv("%local-function", {_stash: true, special: function (name, args, body) {
+}, tr: true});
+setenv("%local-function", {_stash: true, stmt: true, special: function (name, args, body) {
   if (target === "lua") {
     var x = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
     return(indentation() + x);
   } else {
     return(compile(["%local", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}, stmt: true, tr: true});
-setenv("return", {_stash: true, stmt: true, special: function (x) {
+}, tr: true});
+setenv("return", {_stash: true, special: function (x) {
   var _e35;
   if (nil63(x)) {
     _e35 = "return";
@@ -1141,11 +1141,11 @@ setenv("return", {_stash: true, stmt: true, special: function (x) {
   }
   var _x136 = _e35;
   return(indentation() + _x136);
-}});
+}, stmt: true});
 setenv("new", {_stash: true, special: function (x) {
   return("new " + compile(x));
 }});
-setenv("error", {_stash: true, stmt: true, special: function (x) {
+setenv("error", {_stash: true, special: function (x) {
   var _e36;
   if (target === "js") {
     _e36 = "throw " + compile(["new", ["Error", x]]);
@@ -1154,8 +1154,8 @@ setenv("error", {_stash: true, stmt: true, special: function (x) {
   }
   var e = _e36;
   return(indentation() + e);
-}});
-setenv("%local", {_stash: true, stmt: true, special: function (name, value) {
+}, stmt: true});
+setenv("%local", {_stash: true, special: function (name, value) {
   var _id26 = compile(name);
   var value1 = compile(value);
   var _e37;
@@ -1174,8 +1174,8 @@ setenv("%local", {_stash: true, stmt: true, special: function (name, value) {
   var keyword = _e38;
   var ind = indentation();
   return(ind + keyword + _id26 + rh);
-}});
-setenv("set", {_stash: true, stmt: true, special: function (lh, rh) {
+}, stmt: true});
+setenv("set", {_stash: true, special: function (lh, rh) {
   var _lh1 = compile(lh);
   var _e39;
   if (nil63(rh)) {
@@ -1185,7 +1185,7 @@ setenv("set", {_stash: true, stmt: true, special: function (lh, rh) {
   }
   var _rh1 = compile(_e39);
   return(indentation() + _lh1 + " = " + _rh1);
-}});
+}, stmt: true});
 setenv("get", {_stash: true, special: function (t, k) {
   var _t3 = compile(t);
   var k1 = compile(k);

--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -401,7 +401,7 @@ indentation = function () {
   }
   return(s);
 };
-var reserved = {"instanceof": true, "return": true, "break": true, "end": true, ">=": true, "finally": true, "<=": true, "*": true, "for": true, "local": true, "if": true, "switch": true, "else": true, "default": true, "then": true, "=": true, "and": true, "true": true, "with": true, "until": true, "or": true, "function": true, "delete": true, "while": true, "case": true, "in": true, "nil": true, "catch": true, "elseif": true, "false": true, "try": true, "void": true, "repeat": true, "/": true, "<": true, "-": true, "+": true, "%": true, "var": true, "continue": true, "do": true, "==": true, "debugger": true, "typeof": true, "throw": true, "this": true, "not": true, "new": true, ">": true};
+var reserved = {"%": true, "+": true, "case": true, ">=": true, "try": true, "<=": true, "catch": true, "nil": true, "with": true, "throw": true, "false": true, "break": true, "<": true, "then": true, "=": true, "local": true, "elseif": true, "until": true, "var": true, "end": true, "default": true, "for": true, "void": true, "true": true, "*": true, "return": true, "if": true, "not": true, "==": true, "debugger": true, "while": true, "repeat": true, "or": true, "and": true, "function": true, "new": true, "/": true, "typeof": true, "this": true, "-": true, "switch": true, "continue": true, "delete": true, "do": true, "instanceof": true, ">": true, "in": true, "else": true, "finally": true};
 reserved63 = function (x) {
   return(reserved[x]);
 };
@@ -457,40 +457,40 @@ mapo = function (f, t) {
 };
 var __x57 = [];
 var _x58 = [];
-_x58.js = "!";
 _x58.lua = "not ";
+_x58.js = "!";
 __x57["not"] = _x58;
 var __x59 = [];
-__x59["/"] = true;
 __x59["%"] = true;
 __x59["*"] = true;
+__x59["/"] = true;
 var __x60 = [];
 __x60["+"] = true;
 __x60["-"] = true;
 var __x61 = [];
 var _x62 = [];
-_x62.js = "+";
 _x62.lua = "..";
+_x62.js = "+";
 __x61.cat = _x62;
 var __x63 = [];
-__x63[">"] = true;
-__x63["<="] = true;
 __x63["<"] = true;
+__x63[">"] = true;
 __x63[">="] = true;
+__x63["<="] = true;
 var __x64 = [];
 var _x65 = [];
-_x65.js = "===";
 _x65.lua = "==";
+_x65.js = "===";
 __x64["="] = _x65;
 var __x66 = [];
 var _x67 = [];
-_x67.js = "&&";
 _x67.lua = "and";
+_x67.js = "&&";
 __x66["and"] = _x67;
 var __x68 = [];
 var _x69 = [];
-_x69.js = "||";
 _x69.lua = "or";
+_x69.js = "||";
 __x68["or"] = _x69;
 var infix = [__x57, __x59, __x60, __x61, __x63, __x64, __x66, __x68];
 var unary63 = function (form) {
@@ -646,8 +646,8 @@ var compile_special = function (form, stmt63) {
   var args = cut(_id5, 1);
   var _id6 = getenv(x);
   var stmt = _id6.stmt;
-  var special = _id6.special;
   var self_tr63 = _id6.tr;
+  var special = _id6.special;
   var tr = terminator(stmt63 && !self_tr63);
   return(apply(special, args) + tr);
 };
@@ -1011,16 +1011,25 @@ eval = function (form) {
 var run_file = function (path) {
   return(run(read_file(path)));
 };
-var compile_file = function (path) {
-  var s = reader.stream(read_file(path));
+var expand_string = function (str) {
+  var s = reader.stream(str);
   var body = reader["read-all"](s);
-  var form = expand(join(["do"], body));
+  return(expand(join(["do"], body)));
+};
+var compile_string = function (str) {
+  var form = expand_string(str);
   return(compile(form, {_stash: true, stmt: true}));
+};
+var compile_file = function (path) {
+  return(compile_string(read_file(path)));
 };
 load = function (path) {
   return(run(compile_file(path)));
 };
-setenv("do", {_stash: true, stmt: true, special: function () {
+load_string = function (str) {
+  return(run(compile_string(str)));
+};
+setenv("do", {_stash: true, stmt: true, tr: true, special: function () {
   var forms = unstash(Array.prototype.slice.call(arguments, 0));
   var s = "";
   var _x108 = forms;
@@ -1032,8 +1041,8 @@ setenv("do", {_stash: true, stmt: true, special: function () {
     _i12 = _i12 + 1;
   }
   return(s);
-}, tr: true});
-setenv("%if", {_stash: true, stmt: true, special: function (cond, cons, alt) {
+}});
+setenv("%if", {_stash: true, stmt: true, tr: true, special: function (cond, cons, alt) {
   var _cond1 = compile(cond);
   indent_level = indent_level + 1;
   var _x111 = compile(cons, {_stash: true, stmt: true});
@@ -1066,8 +1075,8 @@ setenv("%if", {_stash: true, stmt: true, special: function (cond, cons, alt) {
   } else {
     return(s + "\n");
   }
-}, tr: true});
-setenv("while", {_stash: true, stmt: true, special: function (cond, form) {
+}});
+setenv("while", {_stash: true, stmt: true, tr: true, special: function (cond, form) {
   var _cond3 = compile(cond);
   indent_level = indent_level + 1;
   var _x114 = compile(form, {_stash: true, stmt: true});
@@ -1079,8 +1088,8 @@ setenv("while", {_stash: true, stmt: true, special: function (cond, form) {
   } else {
     return(ind + "while " + _cond3 + " do\n" + body + ind + "end\n");
   }
-}, tr: true});
-setenv("%for", {_stash: true, stmt: true, special: function (t, k, form) {
+}});
+setenv("%for", {_stash: true, stmt: true, tr: true, special: function (t, k, form) {
   var _t1 = compile(t);
   var ind = indentation();
   indent_level = indent_level + 1;
@@ -1092,8 +1101,8 @@ setenv("%for", {_stash: true, stmt: true, special: function (t, k, form) {
   } else {
     return(ind + "for (" + k + " in " + _t1 + ") {\n" + body + ind + "}\n");
   }
-}, tr: true});
-setenv("%try", {_stash: true, stmt: true, special: function (form) {
+}});
+setenv("%try", {_stash: true, stmt: true, tr: true, special: function (form) {
   var e = unique("e");
   var ind = indentation();
   indent_level = indent_level + 1;
@@ -1106,33 +1115,33 @@ setenv("%try", {_stash: true, stmt: true, special: function (form) {
   indent_level = indent_level - 1;
   var h = _x126;
   return(ind + "try {\n" + body + ind + "}\n" + ind + "catch (" + e + ") {\n" + h + ind + "}\n");
-}, tr: true});
-setenv("%delete", {_stash: true, special: function (place) {
+}});
+setenv("%delete", {_stash: true, stmt: true, special: function (place) {
   return(indentation() + "delete " + compile(place));
-}, stmt: true});
-setenv("break", {_stash: true, special: function () {
+}});
+setenv("break", {_stash: true, stmt: true, special: function () {
   return(indentation() + "break");
-}, stmt: true});
+}});
 setenv("%function", {_stash: true, special: function (args, body) {
   return(compile_function(args, body));
 }});
-setenv("%global-function", {_stash: true, stmt: true, special: function (name, args, body) {
+setenv("%global-function", {_stash: true, stmt: true, tr: true, special: function (name, args, body) {
   if (target === "lua") {
     var x = compile_function(args, body, {_stash: true, name: name});
     return(indentation() + x);
   } else {
     return(compile(["set", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}, tr: true});
-setenv("%local-function", {_stash: true, stmt: true, special: function (name, args, body) {
+}});
+setenv("%local-function", {_stash: true, stmt: true, tr: true, special: function (name, args, body) {
   if (target === "lua") {
     var x = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
     return(indentation() + x);
   } else {
     return(compile(["%local", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}, tr: true});
-setenv("return", {_stash: true, special: function (x) {
+}});
+setenv("return", {_stash: true, stmt: true, special: function (x) {
   var _e35;
   if (nil63(x)) {
     _e35 = "return";
@@ -1141,11 +1150,11 @@ setenv("return", {_stash: true, special: function (x) {
   }
   var _x136 = _e35;
   return(indentation() + _x136);
-}, stmt: true});
+}});
 setenv("new", {_stash: true, special: function (x) {
   return("new " + compile(x));
 }});
-setenv("error", {_stash: true, special: function (x) {
+setenv("error", {_stash: true, stmt: true, special: function (x) {
   var _e36;
   if (target === "js") {
     _e36 = "throw " + compile(["new", ["Error", x]]);
@@ -1154,8 +1163,8 @@ setenv("error", {_stash: true, special: function (x) {
   }
   var e = _e36;
   return(indentation() + e);
-}, stmt: true});
-setenv("%local", {_stash: true, special: function (name, value) {
+}});
+setenv("%local", {_stash: true, stmt: true, special: function (name, value) {
   var _id26 = compile(name);
   var value1 = compile(value);
   var _e37;
@@ -1174,8 +1183,8 @@ setenv("%local", {_stash: true, special: function (name, value) {
   var keyword = _e38;
   var ind = indentation();
   return(ind + keyword + _id26 + rh);
-}, stmt: true});
-setenv("set", {_stash: true, special: function (lh, rh) {
+}});
+setenv("set", {_stash: true, stmt: true, special: function (lh, rh) {
   var _lh1 = compile(lh);
   var _e39;
   if (nil63(rh)) {
@@ -1185,7 +1194,7 @@ setenv("set", {_stash: true, special: function (lh, rh) {
   }
   var _rh1 = compile(_e39);
   return(indentation() + _lh1 + " = " + _rh1);
-}, stmt: true});
+}});
 setenv("get", {_stash: true, special: function (t, k) {
   var _t3 = compile(t);
   var k1 = compile(k);
@@ -1270,8 +1279,12 @@ setenv("%object", {_stash: true, special: function () {
   return(s + "}");
 }});
 exports.eval = eval;
+exports.run = run;
 exports["run-file"] = run_file;
+exports["expand-string"] = expand_string;
+exports["compile-string"] = compile_string;
 exports["compile-file"] = compile_file;
 exports.load = load;
+exports["load-string"] = load_string;
 exports.expand = expand;
 exports.compile = compile;

--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -401,7 +401,7 @@ indentation = function () {
   }
   return(s);
 };
-var reserved = {"%": true, "+": true, "case": true, ">=": true, "try": true, "<=": true, "catch": true, "nil": true, "with": true, "throw": true, "false": true, "break": true, "<": true, "then": true, "=": true, "local": true, "elseif": true, "until": true, "var": true, "end": true, "default": true, "for": true, "void": true, "true": true, "*": true, "return": true, "if": true, "not": true, "==": true, "debugger": true, "while": true, "repeat": true, "or": true, "and": true, "function": true, "new": true, "/": true, "typeof": true, "this": true, "-": true, "switch": true, "continue": true, "delete": true, "do": true, "instanceof": true, ">": true, "in": true, "else": true, "finally": true};
+var reserved = {"case": true, "/": true, "%": true, "-": true, "+": true, "else": true, "end": true, "and": true, "return": true, "=": true, "in": true, "==": true, "true": true, "not": true, "until": true, "repeat": true, "do": true, "for": true, "typeof": true, "catch": true, "continue": true, "while": true, "finally": true, "*": true, "void": true, "false": true, "try": true, "or": true, "var": true, "new": true, "<=": true, "elseif": true, "default": true, "<": true, "this": true, "instanceof": true, "break": true, "nil": true, ">=": true, "throw": true, ">": true, "delete": true, "with": true, "function": true, "then": true, "if": true, "local": true, "debugger": true, "switch": true};
 reserved63 = function (x) {
   return(reserved[x]);
 };
@@ -457,8 +457,8 @@ mapo = function (f, t) {
 };
 var __x57 = [];
 var _x58 = [];
-_x58.lua = "not ";
 _x58.js = "!";
+_x58.lua = "not ";
 __x57["not"] = _x58;
 var __x59 = [];
 __x59["%"] = true;
@@ -469,28 +469,28 @@ __x60["+"] = true;
 __x60["-"] = true;
 var __x61 = [];
 var _x62 = [];
-_x62.lua = "..";
 _x62.js = "+";
+_x62.lua = "..";
 __x61.cat = _x62;
 var __x63 = [];
 __x63["<"] = true;
-__x63[">"] = true;
 __x63[">="] = true;
+__x63[">"] = true;
 __x63["<="] = true;
 var __x64 = [];
 var _x65 = [];
-_x65.lua = "==";
 _x65.js = "===";
+_x65.lua = "==";
 __x64["="] = _x65;
 var __x66 = [];
 var _x67 = [];
-_x67.lua = "and";
 _x67.js = "&&";
+_x67.lua = "and";
 __x66["and"] = _x67;
 var __x68 = [];
 var _x69 = [];
-_x69.lua = "or";
 _x69.js = "||";
+_x69.lua = "or";
 __x68["or"] = _x69;
 var infix = [__x57, __x59, __x60, __x61, __x63, __x64, __x66, __x68];
 var unary63 = function (form) {
@@ -646,8 +646,8 @@ var compile_special = function (form, stmt63) {
   var args = cut(_id5, 1);
   var _id6 = getenv(x);
   var stmt = _id6.stmt;
-  var self_tr63 = _id6.tr;
   var special = _id6.special;
+  var self_tr63 = _id6.tr;
   var tr = terminator(stmt63 && !self_tr63);
   return(apply(special, args) + tr);
 };
@@ -1029,7 +1029,7 @@ load = function (path) {
 load_string = function (str) {
   return(run(compile_string(str)));
 };
-setenv("do", {_stash: true, stmt: true, tr: true, special: function () {
+setenv("do", {_stash: true, special: function () {
   var forms = unstash(Array.prototype.slice.call(arguments, 0));
   var s = "";
   var _x108 = forms;
@@ -1041,8 +1041,8 @@ setenv("do", {_stash: true, stmt: true, tr: true, special: function () {
     _i12 = _i12 + 1;
   }
   return(s);
-}});
-setenv("%if", {_stash: true, stmt: true, tr: true, special: function (cond, cons, alt) {
+}, stmt: true, tr: true});
+setenv("%if", {_stash: true, special: function (cond, cons, alt) {
   var _cond1 = compile(cond);
   indent_level = indent_level + 1;
   var _x111 = compile(cons, {_stash: true, stmt: true});
@@ -1075,8 +1075,8 @@ setenv("%if", {_stash: true, stmt: true, tr: true, special: function (cond, cons
   } else {
     return(s + "\n");
   }
-}});
-setenv("while", {_stash: true, stmt: true, tr: true, special: function (cond, form) {
+}, stmt: true, tr: true});
+setenv("while", {_stash: true, special: function (cond, form) {
   var _cond3 = compile(cond);
   indent_level = indent_level + 1;
   var _x114 = compile(form, {_stash: true, stmt: true});
@@ -1088,8 +1088,8 @@ setenv("while", {_stash: true, stmt: true, tr: true, special: function (cond, fo
   } else {
     return(ind + "while " + _cond3 + " do\n" + body + ind + "end\n");
   }
-}});
-setenv("%for", {_stash: true, stmt: true, tr: true, special: function (t, k, form) {
+}, stmt: true, tr: true});
+setenv("%for", {_stash: true, special: function (t, k, form) {
   var _t1 = compile(t);
   var ind = indentation();
   indent_level = indent_level + 1;
@@ -1101,8 +1101,8 @@ setenv("%for", {_stash: true, stmt: true, tr: true, special: function (t, k, for
   } else {
     return(ind + "for (" + k + " in " + _t1 + ") {\n" + body + ind + "}\n");
   }
-}});
-setenv("%try", {_stash: true, stmt: true, tr: true, special: function (form) {
+}, stmt: true, tr: true});
+setenv("%try", {_stash: true, special: function (form) {
   var e = unique("e");
   var ind = indentation();
   indent_level = indent_level + 1;
@@ -1115,33 +1115,33 @@ setenv("%try", {_stash: true, stmt: true, tr: true, special: function (form) {
   indent_level = indent_level - 1;
   var h = _x126;
   return(ind + "try {\n" + body + ind + "}\n" + ind + "catch (" + e + ") {\n" + h + ind + "}\n");
-}});
-setenv("%delete", {_stash: true, stmt: true, special: function (place) {
+}, stmt: true, tr: true});
+setenv("%delete", {_stash: true, special: function (place) {
   return(indentation() + "delete " + compile(place));
-}});
-setenv("break", {_stash: true, stmt: true, special: function () {
+}, stmt: true});
+setenv("break", {_stash: true, special: function () {
   return(indentation() + "break");
-}});
+}, stmt: true});
 setenv("%function", {_stash: true, special: function (args, body) {
   return(compile_function(args, body));
 }});
-setenv("%global-function", {_stash: true, stmt: true, tr: true, special: function (name, args, body) {
+setenv("%global-function", {_stash: true, special: function (name, args, body) {
   if (target === "lua") {
     var x = compile_function(args, body, {_stash: true, name: name});
     return(indentation() + x);
   } else {
     return(compile(["set", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}});
-setenv("%local-function", {_stash: true, stmt: true, tr: true, special: function (name, args, body) {
+}, stmt: true, tr: true});
+setenv("%local-function", {_stash: true, special: function (name, args, body) {
   if (target === "lua") {
     var x = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
     return(indentation() + x);
   } else {
     return(compile(["%local", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}});
-setenv("return", {_stash: true, stmt: true, special: function (x) {
+}, stmt: true, tr: true});
+setenv("return", {_stash: true, special: function (x) {
   var _e35;
   if (nil63(x)) {
     _e35 = "return";
@@ -1150,11 +1150,11 @@ setenv("return", {_stash: true, stmt: true, special: function (x) {
   }
   var _x136 = _e35;
   return(indentation() + _x136);
-}});
+}, stmt: true});
 setenv("new", {_stash: true, special: function (x) {
   return("new " + compile(x));
 }});
-setenv("error", {_stash: true, stmt: true, special: function (x) {
+setenv("error", {_stash: true, special: function (x) {
   var _e36;
   if (target === "js") {
     _e36 = "throw " + compile(["new", ["Error", x]]);
@@ -1163,8 +1163,8 @@ setenv("error", {_stash: true, stmt: true, special: function (x) {
   }
   var e = _e36;
   return(indentation() + e);
-}});
-setenv("%local", {_stash: true, stmt: true, special: function (name, value) {
+}, stmt: true});
+setenv("%local", {_stash: true, special: function (name, value) {
   var _id26 = compile(name);
   var value1 = compile(value);
   var _e37;
@@ -1183,8 +1183,8 @@ setenv("%local", {_stash: true, stmt: true, special: function (name, value) {
   var keyword = _e38;
   var ind = indentation();
   return(ind + keyword + _id26 + rh);
-}});
-setenv("set", {_stash: true, stmt: true, special: function (lh, rh) {
+}, stmt: true});
+setenv("set", {_stash: true, special: function (lh, rh) {
   var _lh1 = compile(lh);
   var _e39;
   if (nil63(rh)) {
@@ -1194,7 +1194,7 @@ setenv("set", {_stash: true, stmt: true, special: function (lh, rh) {
   }
   var _rh1 = compile(_e39);
   return(indentation() + _lh1 + " = " + _rh1);
-}});
+}, stmt: true});
 setenv("get", {_stash: true, special: function (t, k) {
   var _t3 = compile(t);
   var k1 = compile(k);

--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -401,7 +401,7 @@ indentation = function () {
   }
   return(s);
 };
-var reserved = {"*": true, "until": true, "delete": true, "true": true, "instanceof": true, ">=": true, "try": true, "%": true, "debugger": true, "<=": true, "finally": true, "default": true, "repeat": true, "<": true, "if": true, "catch": true, "do": true, "in": true, "or": true, "new": true, "+": true, "/": true, "case": true, "-": true, "elseif": true, "throw": true, "this": true, "==": true, "function": true, "typeof": true, "false": true, "var": true, "not": true, "local": true, "and": true, "=": true, "continue": true, "then": true, "nil": true, "return": true, "end": true, "with": true, "else": true, "break": true, "switch": true, "for": true, "void": true, ">": true, "while": true};
+var reserved = {"case": true, "throw": true, "return": true, "=": true, "false": true, "and": true, "/": true, "else": true, "or": true, "*": true, "<=": true, "catch": true, "in": true, "break": true, "new": true, "then": true, "elseif": true, ">=": true, "true": true, "continue": true, "with": true, "nil": true, ">": true, "end": true, "<": true, "var": true, "typeof": true, "function": true, "local": true, "do": true, "until": true, "while": true, "try": true, "-": true, "delete": true, "repeat": true, "if": true, "not": true, "%": true, "==": true, "this": true, "void": true, "+": true, "instanceof": true, "for": true, "finally": true, "switch": true, "default": true, "debugger": true};
 reserved63 = function (x) {
   return(reserved[x]);
 };
@@ -457,40 +457,40 @@ mapo = function (f, t) {
 };
 var __x57 = [];
 var _x58 = [];
-_x58.lua = "not ";
 _x58.js = "!";
+_x58.lua = "not ";
 __x57["not"] = _x58;
 var __x59 = [];
-__x59["/"] = true;
 __x59["*"] = true;
+__x59["/"] = true;
 __x59["%"] = true;
 var __x60 = [];
 __x60["-"] = true;
 __x60["+"] = true;
 var __x61 = [];
 var _x62 = [];
-_x62.lua = "..";
 _x62.js = "+";
+_x62.lua = "..";
 __x61.cat = _x62;
 var __x63 = [];
-__x63["<"] = true;
-__x63["<="] = true;
 __x63[">"] = true;
 __x63[">="] = true;
+__x63["<"] = true;
+__x63["<="] = true;
 var __x64 = [];
 var _x65 = [];
-_x65.lua = "==";
 _x65.js = "===";
+_x65.lua = "==";
 __x64["="] = _x65;
 var __x66 = [];
 var _x67 = [];
-_x67.lua = "and";
 _x67.js = "&&";
+_x67.lua = "and";
 __x66["and"] = _x67;
 var __x68 = [];
 var _x69 = [];
-_x69.lua = "or";
 _x69.js = "||";
+_x69.lua = "or";
 __x68["or"] = _x69;
 var infix = [__x57, __x59, __x60, __x61, __x63, __x64, __x66, __x68];
 var unary63 = function (form) {
@@ -645,9 +645,9 @@ var compile_special = function (form, stmt63) {
   var x = _id5[0];
   var args = cut(_id5, 1);
   var _id6 = getenv(x);
+  var special = _id6.special;
   var stmt = _id6.stmt;
   var self_tr63 = _id6.tr;
-  var special = _id6.special;
   var tr = terminator(stmt63 && !self_tr63);
   return(apply(special, args) + tr);
 };
@@ -1029,7 +1029,7 @@ load = function (path) {
 load_string = function (str) {
   return(run(compile_string(str)));
 };
-setenv("do", {_stash: true, stmt: true, tr: true, special: function () {
+setenv("do", {_stash: true, special: function () {
   var forms = unstash(Array.prototype.slice.call(arguments, 0));
   var s = "";
   var _x108 = forms;
@@ -1041,8 +1041,8 @@ setenv("do", {_stash: true, stmt: true, tr: true, special: function () {
     _i12 = _i12 + 1;
   }
   return(s);
-}});
-setenv("%if", {_stash: true, stmt: true, tr: true, special: function (cond, cons, alt) {
+}, stmt: true, tr: true});
+setenv("%if", {_stash: true, special: function (cond, cons, alt) {
   var _cond1 = compile(cond);
   indent_level = indent_level + 1;
   var _x111 = compile(cons, {_stash: true, stmt: true});
@@ -1075,8 +1075,8 @@ setenv("%if", {_stash: true, stmt: true, tr: true, special: function (cond, cons
   } else {
     return(s + "\n");
   }
-}});
-setenv("while", {_stash: true, stmt: true, tr: true, special: function (cond, form) {
+}, stmt: true, tr: true});
+setenv("while", {_stash: true, special: function (cond, form) {
   var _cond3 = compile(cond);
   indent_level = indent_level + 1;
   var _x114 = compile(form, {_stash: true, stmt: true});
@@ -1088,8 +1088,8 @@ setenv("while", {_stash: true, stmt: true, tr: true, special: function (cond, fo
   } else {
     return(ind + "while " + _cond3 + " do\n" + body + ind + "end\n");
   }
-}});
-setenv("%for", {_stash: true, stmt: true, tr: true, special: function (t, k, form) {
+}, stmt: true, tr: true});
+setenv("%for", {_stash: true, special: function (t, k, form) {
   var _t1 = compile(t);
   var ind = indentation();
   indent_level = indent_level + 1;
@@ -1101,8 +1101,8 @@ setenv("%for", {_stash: true, stmt: true, tr: true, special: function (t, k, for
   } else {
     return(ind + "for (" + k + " in " + _t1 + ") {\n" + body + ind + "}\n");
   }
-}});
-setenv("%try", {_stash: true, stmt: true, tr: true, special: function (form) {
+}, stmt: true, tr: true});
+setenv("%try", {_stash: true, special: function (form) {
   var e = unique("e");
   var ind = indentation();
   indent_level = indent_level + 1;
@@ -1115,33 +1115,33 @@ setenv("%try", {_stash: true, stmt: true, tr: true, special: function (form) {
   indent_level = indent_level - 1;
   var h = _x126;
   return(ind + "try {\n" + body + ind + "}\n" + ind + "catch (" + e + ") {\n" + h + ind + "}\n");
-}});
-setenv("%delete", {_stash: true, stmt: true, special: function (place) {
+}, stmt: true, tr: true});
+setenv("%delete", {_stash: true, special: function (place) {
   return(indentation() + "delete " + compile(place));
-}});
-setenv("break", {_stash: true, stmt: true, special: function () {
+}, stmt: true});
+setenv("break", {_stash: true, special: function () {
   return(indentation() + "break");
-}});
+}, stmt: true});
 setenv("%function", {_stash: true, special: function (args, body) {
   return(compile_function(args, body));
 }});
-setenv("%global-function", {_stash: true, stmt: true, tr: true, special: function (name, args, body) {
+setenv("%global-function", {_stash: true, special: function (name, args, body) {
   if (target === "lua") {
     var x = compile_function(args, body, {_stash: true, name: name});
     return(indentation() + x);
   } else {
     return(compile(["set", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}});
-setenv("%local-function", {_stash: true, stmt: true, tr: true, special: function (name, args, body) {
+}, stmt: true, tr: true});
+setenv("%local-function", {_stash: true, special: function (name, args, body) {
   if (target === "lua") {
     var x = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
     return(indentation() + x);
   } else {
     return(compile(["%local", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}});
-setenv("return", {_stash: true, stmt: true, special: function (x) {
+}, stmt: true, tr: true});
+setenv("return", {_stash: true, special: function (x) {
   var _e35;
   if (nil63(x)) {
     _e35 = "return";
@@ -1150,11 +1150,11 @@ setenv("return", {_stash: true, stmt: true, special: function (x) {
   }
   var _x136 = _e35;
   return(indentation() + _x136);
-}});
+}, stmt: true});
 setenv("new", {_stash: true, special: function (x) {
   return("new " + compile(x));
 }});
-setenv("error", {_stash: true, stmt: true, special: function (x) {
+setenv("error", {_stash: true, special: function (x) {
   var _e36;
   if (target === "js") {
     _e36 = "throw " + compile(["new", ["Error", x]]);
@@ -1163,8 +1163,8 @@ setenv("error", {_stash: true, stmt: true, special: function (x) {
   }
   var e = _e36;
   return(indentation() + e);
-}});
-setenv("%local", {_stash: true, stmt: true, special: function (name, value) {
+}, stmt: true});
+setenv("%local", {_stash: true, special: function (name, value) {
   var _id26 = compile(name);
   var value1 = compile(value);
   var _e37;
@@ -1183,8 +1183,8 @@ setenv("%local", {_stash: true, stmt: true, special: function (name, value) {
   var keyword = _e38;
   var ind = indentation();
   return(ind + keyword + _id26 + rh);
-}});
-setenv("set", {_stash: true, stmt: true, special: function (lh, rh) {
+}, stmt: true});
+setenv("set", {_stash: true, special: function (lh, rh) {
   var _lh1 = compile(lh);
   var _e39;
   if (nil63(rh)) {
@@ -1194,7 +1194,7 @@ setenv("set", {_stash: true, stmt: true, special: function (lh, rh) {
   }
   var _rh1 = compile(_e39);
   return(indentation() + _lh1 + " = " + _rh1);
-}});
+}, stmt: true});
 setenv("get", {_stash: true, special: function (t, k) {
   var _t3 = compile(t);
   var k1 = compile(k);

--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -401,7 +401,7 @@ indentation = function () {
   }
   return(s);
 };
-var reserved = {"case": true, "/": true, "%": true, "-": true, "+": true, "else": true, "end": true, "and": true, "return": true, "=": true, "in": true, "==": true, "true": true, "not": true, "until": true, "repeat": true, "do": true, "for": true, "typeof": true, "catch": true, "continue": true, "while": true, "finally": true, "*": true, "void": true, "false": true, "try": true, "or": true, "var": true, "new": true, "<=": true, "elseif": true, "default": true, "<": true, "this": true, "instanceof": true, "break": true, "nil": true, ">=": true, "throw": true, ">": true, "delete": true, "with": true, "function": true, "then": true, "if": true, "local": true, "debugger": true, "switch": true};
+var reserved = {"this": true, "while": true, "catch": true, "return": true, "continue": true, "debugger": true, "do": true, "then": true, "until": true, ">": true, "*": true, "switch": true, "<": true, "function": true, "false": true, "repeat": true, "throw": true, "typeof": true, "instanceof": true, "new": true, "end": true, "<=": true, "or": true, ">=": true, "finally": true, "local": true, "default": true, "with": true, "nil": true, "elseif": true, "break": true, "if": true, "%": true, "case": true, "=": true, "+": true, "for": true, "in": true, "-": true, "void": true, "/": true, "var": true, "==": true, "delete": true, "try": true, "else": true, "and": true, "true": true, "not": true};
 reserved63 = function (x) {
   return(reserved[x]);
 };
@@ -457,40 +457,40 @@ mapo = function (f, t) {
 };
 var __x57 = [];
 var _x58 = [];
-_x58.js = "!";
 _x58.lua = "not ";
+_x58.js = "!";
 __x57["not"] = _x58;
 var __x59 = [];
+__x59["/"] = true;
 __x59["%"] = true;
 __x59["*"] = true;
-__x59["/"] = true;
 var __x60 = [];
 __x60["+"] = true;
 __x60["-"] = true;
 var __x61 = [];
 var _x62 = [];
-_x62.js = "+";
 _x62.lua = "..";
+_x62.js = "+";
 __x61.cat = _x62;
 var __x63 = [];
-__x63["<"] = true;
 __x63[">="] = true;
-__x63[">"] = true;
 __x63["<="] = true;
+__x63["<"] = true;
+__x63[">"] = true;
 var __x64 = [];
 var _x65 = [];
-_x65.js = "===";
 _x65.lua = "==";
+_x65.js = "===";
 __x64["="] = _x65;
 var __x66 = [];
 var _x67 = [];
-_x67.js = "&&";
 _x67.lua = "and";
+_x67.js = "&&";
 __x66["and"] = _x67;
 var __x68 = [];
 var _x69 = [];
-_x69.js = "||";
 _x69.lua = "or";
+_x69.js = "||";
 __x68["or"] = _x69;
 var infix = [__x57, __x59, __x60, __x61, __x63, __x64, __x66, __x68];
 var unary63 = function (form) {
@@ -1029,7 +1029,7 @@ load = function (path) {
 load_string = function (str) {
   return(run(compile_string(str)));
 };
-setenv("do", {_stash: true, special: function () {
+setenv("do", {_stash: true, stmt: true, special: function () {
   var forms = unstash(Array.prototype.slice.call(arguments, 0));
   var s = "";
   var _x108 = forms;
@@ -1041,8 +1041,8 @@ setenv("do", {_stash: true, special: function () {
     _i12 = _i12 + 1;
   }
   return(s);
-}, stmt: true, tr: true});
-setenv("%if", {_stash: true, special: function (cond, cons, alt) {
+}, tr: true});
+setenv("%if", {_stash: true, stmt: true, special: function (cond, cons, alt) {
   var _cond1 = compile(cond);
   indent_level = indent_level + 1;
   var _x111 = compile(cons, {_stash: true, stmt: true});
@@ -1075,8 +1075,8 @@ setenv("%if", {_stash: true, special: function (cond, cons, alt) {
   } else {
     return(s + "\n");
   }
-}, stmt: true, tr: true});
-setenv("while", {_stash: true, special: function (cond, form) {
+}, tr: true});
+setenv("while", {_stash: true, stmt: true, special: function (cond, form) {
   var _cond3 = compile(cond);
   indent_level = indent_level + 1;
   var _x114 = compile(form, {_stash: true, stmt: true});
@@ -1088,8 +1088,8 @@ setenv("while", {_stash: true, special: function (cond, form) {
   } else {
     return(ind + "while " + _cond3 + " do\n" + body + ind + "end\n");
   }
-}, stmt: true, tr: true});
-setenv("%for", {_stash: true, special: function (t, k, form) {
+}, tr: true});
+setenv("%for", {_stash: true, stmt: true, special: function (t, k, form) {
   var _t1 = compile(t);
   var ind = indentation();
   indent_level = indent_level + 1;
@@ -1101,8 +1101,8 @@ setenv("%for", {_stash: true, special: function (t, k, form) {
   } else {
     return(ind + "for (" + k + " in " + _t1 + ") {\n" + body + ind + "}\n");
   }
-}, stmt: true, tr: true});
-setenv("%try", {_stash: true, special: function (form) {
+}, tr: true});
+setenv("%try", {_stash: true, stmt: true, special: function (form) {
   var e = unique("e");
   var ind = indentation();
   indent_level = indent_level + 1;
@@ -1115,33 +1115,33 @@ setenv("%try", {_stash: true, special: function (form) {
   indent_level = indent_level - 1;
   var h = _x126;
   return(ind + "try {\n" + body + ind + "}\n" + ind + "catch (" + e + ") {\n" + h + ind + "}\n");
-}, stmt: true, tr: true});
-setenv("%delete", {_stash: true, special: function (place) {
+}, tr: true});
+setenv("%delete", {_stash: true, stmt: true, special: function (place) {
   return(indentation() + "delete " + compile(place));
-}, stmt: true});
-setenv("break", {_stash: true, special: function () {
+}});
+setenv("break", {_stash: true, stmt: true, special: function () {
   return(indentation() + "break");
-}, stmt: true});
+}});
 setenv("%function", {_stash: true, special: function (args, body) {
   return(compile_function(args, body));
 }});
-setenv("%global-function", {_stash: true, special: function (name, args, body) {
+setenv("%global-function", {_stash: true, stmt: true, special: function (name, args, body) {
   if (target === "lua") {
     var x = compile_function(args, body, {_stash: true, name: name});
     return(indentation() + x);
   } else {
     return(compile(["set", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}, stmt: true, tr: true});
-setenv("%local-function", {_stash: true, special: function (name, args, body) {
+}, tr: true});
+setenv("%local-function", {_stash: true, stmt: true, special: function (name, args, body) {
   if (target === "lua") {
     var x = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
     return(indentation() + x);
   } else {
     return(compile(["%local", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}, stmt: true, tr: true});
-setenv("return", {_stash: true, special: function (x) {
+}, tr: true});
+setenv("return", {_stash: true, stmt: true, special: function (x) {
   var _e35;
   if (nil63(x)) {
     _e35 = "return";
@@ -1150,11 +1150,11 @@ setenv("return", {_stash: true, special: function (x) {
   }
   var _x136 = _e35;
   return(indentation() + _x136);
-}, stmt: true});
+}});
 setenv("new", {_stash: true, special: function (x) {
   return("new " + compile(x));
 }});
-setenv("error", {_stash: true, special: function (x) {
+setenv("error", {_stash: true, stmt: true, special: function (x) {
   var _e36;
   if (target === "js") {
     _e36 = "throw " + compile(["new", ["Error", x]]);
@@ -1163,8 +1163,8 @@ setenv("error", {_stash: true, special: function (x) {
   }
   var e = _e36;
   return(indentation() + e);
-}, stmt: true});
-setenv("%local", {_stash: true, special: function (name, value) {
+}});
+setenv("%local", {_stash: true, stmt: true, special: function (name, value) {
   var _id26 = compile(name);
   var value1 = compile(value);
   var _e37;
@@ -1183,8 +1183,8 @@ setenv("%local", {_stash: true, special: function (name, value) {
   var keyword = _e38;
   var ind = indentation();
   return(ind + keyword + _id26 + rh);
-}, stmt: true});
-setenv("set", {_stash: true, special: function (lh, rh) {
+}});
+setenv("set", {_stash: true, stmt: true, special: function (lh, rh) {
   var _lh1 = compile(lh);
   var _e39;
   if (nil63(rh)) {
@@ -1194,7 +1194,7 @@ setenv("set", {_stash: true, special: function (lh, rh) {
   }
   var _rh1 = compile(_e39);
   return(indentation() + _lh1 + " = " + _rh1);
-}, stmt: true});
+}});
 setenv("get", {_stash: true, special: function (t, k) {
   var _t3 = compile(t);
   var k1 = compile(k);

--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -401,7 +401,7 @@ indentation = function () {
   }
   return(s);
 };
-var reserved = {"this": true, "while": true, "catch": true, "return": true, "continue": true, "debugger": true, "do": true, "then": true, "until": true, ">": true, "*": true, "switch": true, "<": true, "function": true, "false": true, "repeat": true, "throw": true, "typeof": true, "instanceof": true, "new": true, "end": true, "<=": true, "or": true, ">=": true, "finally": true, "local": true, "default": true, "with": true, "nil": true, "elseif": true, "break": true, "if": true, "%": true, "case": true, "=": true, "+": true, "for": true, "in": true, "-": true, "void": true, "/": true, "var": true, "==": true, "delete": true, "try": true, "else": true, "and": true, "true": true, "not": true};
+var reserved = {"*": true, "until": true, "delete": true, "true": true, "instanceof": true, ">=": true, "try": true, "%": true, "debugger": true, "<=": true, "finally": true, "default": true, "repeat": true, "<": true, "if": true, "catch": true, "do": true, "in": true, "or": true, "new": true, "+": true, "/": true, "case": true, "-": true, "elseif": true, "throw": true, "this": true, "==": true, "function": true, "typeof": true, "false": true, "var": true, "not": true, "local": true, "and": true, "=": true, "continue": true, "then": true, "nil": true, "return": true, "end": true, "with": true, "else": true, "break": true, "switch": true, "for": true, "void": true, ">": true, "while": true};
 reserved63 = function (x) {
   return(reserved[x]);
 };
@@ -462,21 +462,21 @@ _x58.js = "!";
 __x57["not"] = _x58;
 var __x59 = [];
 __x59["/"] = true;
-__x59["%"] = true;
 __x59["*"] = true;
+__x59["%"] = true;
 var __x60 = [];
-__x60["+"] = true;
 __x60["-"] = true;
+__x60["+"] = true;
 var __x61 = [];
 var _x62 = [];
 _x62.lua = "..";
 _x62.js = "+";
 __x61.cat = _x62;
 var __x63 = [];
-__x63[">="] = true;
-__x63["<="] = true;
 __x63["<"] = true;
+__x63["<="] = true;
 __x63[">"] = true;
+__x63[">="] = true;
 var __x64 = [];
 var _x65 = [];
 _x65.lua = "==";
@@ -646,8 +646,8 @@ var compile_special = function (form, stmt63) {
   var args = cut(_id5, 1);
   var _id6 = getenv(x);
   var stmt = _id6.stmt;
-  var special = _id6.special;
   var self_tr63 = _id6.tr;
+  var special = _id6.special;
   var tr = terminator(stmt63 && !self_tr63);
   return(apply(special, args) + tr);
 };
@@ -1029,7 +1029,7 @@ load = function (path) {
 load_string = function (str) {
   return(run(compile_string(str)));
 };
-setenv("do", {_stash: true, stmt: true, special: function () {
+setenv("do", {_stash: true, stmt: true, tr: true, special: function () {
   var forms = unstash(Array.prototype.slice.call(arguments, 0));
   var s = "";
   var _x108 = forms;
@@ -1041,8 +1041,8 @@ setenv("do", {_stash: true, stmt: true, special: function () {
     _i12 = _i12 + 1;
   }
   return(s);
-}, tr: true});
-setenv("%if", {_stash: true, stmt: true, special: function (cond, cons, alt) {
+}});
+setenv("%if", {_stash: true, stmt: true, tr: true, special: function (cond, cons, alt) {
   var _cond1 = compile(cond);
   indent_level = indent_level + 1;
   var _x111 = compile(cons, {_stash: true, stmt: true});
@@ -1075,8 +1075,8 @@ setenv("%if", {_stash: true, stmt: true, special: function (cond, cons, alt) {
   } else {
     return(s + "\n");
   }
-}, tr: true});
-setenv("while", {_stash: true, stmt: true, special: function (cond, form) {
+}});
+setenv("while", {_stash: true, stmt: true, tr: true, special: function (cond, form) {
   var _cond3 = compile(cond);
   indent_level = indent_level + 1;
   var _x114 = compile(form, {_stash: true, stmt: true});
@@ -1088,8 +1088,8 @@ setenv("while", {_stash: true, stmt: true, special: function (cond, form) {
   } else {
     return(ind + "while " + _cond3 + " do\n" + body + ind + "end\n");
   }
-}, tr: true});
-setenv("%for", {_stash: true, stmt: true, special: function (t, k, form) {
+}});
+setenv("%for", {_stash: true, stmt: true, tr: true, special: function (t, k, form) {
   var _t1 = compile(t);
   var ind = indentation();
   indent_level = indent_level + 1;
@@ -1101,8 +1101,8 @@ setenv("%for", {_stash: true, stmt: true, special: function (t, k, form) {
   } else {
     return(ind + "for (" + k + " in " + _t1 + ") {\n" + body + ind + "}\n");
   }
-}, tr: true});
-setenv("%try", {_stash: true, stmt: true, special: function (form) {
+}});
+setenv("%try", {_stash: true, stmt: true, tr: true, special: function (form) {
   var e = unique("e");
   var ind = indentation();
   indent_level = indent_level + 1;
@@ -1115,7 +1115,7 @@ setenv("%try", {_stash: true, stmt: true, special: function (form) {
   indent_level = indent_level - 1;
   var h = _x126;
   return(ind + "try {\n" + body + ind + "}\n" + ind + "catch (" + e + ") {\n" + h + ind + "}\n");
-}, tr: true});
+}});
 setenv("%delete", {_stash: true, stmt: true, special: function (place) {
   return(indentation() + "delete " + compile(place));
 }});
@@ -1125,22 +1125,22 @@ setenv("break", {_stash: true, stmt: true, special: function () {
 setenv("%function", {_stash: true, special: function (args, body) {
   return(compile_function(args, body));
 }});
-setenv("%global-function", {_stash: true, stmt: true, special: function (name, args, body) {
+setenv("%global-function", {_stash: true, stmt: true, tr: true, special: function (name, args, body) {
   if (target === "lua") {
     var x = compile_function(args, body, {_stash: true, name: name});
     return(indentation() + x);
   } else {
     return(compile(["set", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}, tr: true});
-setenv("%local-function", {_stash: true, stmt: true, special: function (name, args, body) {
+}});
+setenv("%local-function", {_stash: true, stmt: true, tr: true, special: function (name, args, body) {
   if (target === "lua") {
     var x = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
     return(indentation() + x);
   } else {
     return(compile(["%local", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}, tr: true});
+}});
 setenv("return", {_stash: true, stmt: true, special: function (x) {
   var _e35;
   if (nil63(x)) {

--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -401,7 +401,7 @@ indentation = function () {
   }
   return(s);
 };
-var reserved = {"case": true, "throw": true, "return": true, "=": true, "false": true, "and": true, "/": true, "else": true, "or": true, "*": true, "<=": true, "catch": true, "in": true, "break": true, "new": true, "then": true, "elseif": true, ">=": true, "true": true, "continue": true, "with": true, "nil": true, ">": true, "end": true, "<": true, "var": true, "typeof": true, "function": true, "local": true, "do": true, "until": true, "while": true, "try": true, "-": true, "delete": true, "repeat": true, "if": true, "not": true, "%": true, "==": true, "this": true, "void": true, "+": true, "instanceof": true, "for": true, "finally": true, "switch": true, "default": true, "debugger": true};
+var reserved = {"continue": true, "finally": true, "in": true, "/": true, "-": true, "+": true, "function": true, "this": true, "try": true, "%": true, "instanceof": true, ">": true, "<": true, "==": true, "until": true, "delete": true, "switch": true, "typeof": true, "new": true, "then": true, "break": true, "void": true, "or": true, "true": true, "not": true, "=": true, "local": true, "case": true, "default": true, "while": true, "*": true, "elseif": true, "false": true, "debugger": true, "var": true, "and": true, "end": true, "else": true, "catch": true, "do": true, "for": true, "nil": true, "with": true, ">=": true, "<=": true, "if": true, "repeat": true, "throw": true, "return": true};
 reserved63 = function (x) {
   return(reserved[x]);
 };
@@ -457,40 +457,40 @@ mapo = function (f, t) {
 };
 var __x57 = [];
 var _x58 = [];
-_x58.js = "!";
 _x58.lua = "not ";
+_x58.js = "!";
 __x57["not"] = _x58;
 var __x59 = [];
-__x59["*"] = true;
-__x59["/"] = true;
 __x59["%"] = true;
+__x59["/"] = true;
+__x59["*"] = true;
 var __x60 = [];
 __x60["-"] = true;
 __x60["+"] = true;
 var __x61 = [];
 var _x62 = [];
-_x62.js = "+";
 _x62.lua = "..";
+_x62.js = "+";
 __x61.cat = _x62;
 var __x63 = [];
-__x63[">"] = true;
-__x63[">="] = true;
-__x63["<"] = true;
 __x63["<="] = true;
+__x63["<"] = true;
+__x63[">="] = true;
+__x63[">"] = true;
 var __x64 = [];
 var _x65 = [];
-_x65.js = "===";
 _x65.lua = "==";
+_x65.js = "===";
 __x64["="] = _x65;
 var __x66 = [];
 var _x67 = [];
-_x67.js = "&&";
 _x67.lua = "and";
+_x67.js = "&&";
 __x66["and"] = _x67;
 var __x68 = [];
 var _x69 = [];
-_x69.js = "||";
 _x69.lua = "or";
+_x69.js = "||";
 __x68["or"] = _x69;
 var infix = [__x57, __x59, __x60, __x61, __x63, __x64, __x66, __x68];
 var unary63 = function (form) {
@@ -645,9 +645,9 @@ var compile_special = function (form, stmt63) {
   var x = _id5[0];
   var args = cut(_id5, 1);
   var _id6 = getenv(x);
-  var special = _id6.special;
-  var stmt = _id6.stmt;
   var self_tr63 = _id6.tr;
+  var stmt = _id6.stmt;
+  var special = _id6.special;
   var tr = terminator(stmt63 && !self_tr63);
   return(apply(special, args) + tr);
 };
@@ -704,8 +704,8 @@ var compile_infix = function (form) {
 compile_function = function (args, body) {
   var _r58 = unstash(Array.prototype.slice.call(arguments, 2));
   var _id12 = _r58;
-  var name = _id12.name;
   var prefix = _id12.prefix;
+  var name = _id12.name;
   var _e25;
   if (name) {
     _e25 = compile(name);
@@ -1029,7 +1029,7 @@ load = function (path) {
 load_string = function (str) {
   return(run(compile_string(str)));
 };
-setenv("do", {_stash: true, special: function () {
+setenv("do", {_stash: true, tr: true, special: function () {
   var forms = unstash(Array.prototype.slice.call(arguments, 0));
   var s = "";
   var _x108 = forms;
@@ -1041,8 +1041,8 @@ setenv("do", {_stash: true, special: function () {
     _i12 = _i12 + 1;
   }
   return(s);
-}, stmt: true, tr: true});
-setenv("%if", {_stash: true, special: function (cond, cons, alt) {
+}, stmt: true});
+setenv("%if", {_stash: true, tr: true, special: function (cond, cons, alt) {
   var _cond1 = compile(cond);
   indent_level = indent_level + 1;
   var _x111 = compile(cons, {_stash: true, stmt: true});
@@ -1075,8 +1075,8 @@ setenv("%if", {_stash: true, special: function (cond, cons, alt) {
   } else {
     return(s + "\n");
   }
-}, stmt: true, tr: true});
-setenv("while", {_stash: true, special: function (cond, form) {
+}, stmt: true});
+setenv("while", {_stash: true, tr: true, special: function (cond, form) {
   var _cond3 = compile(cond);
   indent_level = indent_level + 1;
   var _x114 = compile(form, {_stash: true, stmt: true});
@@ -1088,8 +1088,8 @@ setenv("while", {_stash: true, special: function (cond, form) {
   } else {
     return(ind + "while " + _cond3 + " do\n" + body + ind + "end\n");
   }
-}, stmt: true, tr: true});
-setenv("%for", {_stash: true, special: function (t, k, form) {
+}, stmt: true});
+setenv("%for", {_stash: true, tr: true, special: function (t, k, form) {
   var _t1 = compile(t);
   var ind = indentation();
   indent_level = indent_level + 1;
@@ -1101,8 +1101,8 @@ setenv("%for", {_stash: true, special: function (t, k, form) {
   } else {
     return(ind + "for (" + k + " in " + _t1 + ") {\n" + body + ind + "}\n");
   }
-}, stmt: true, tr: true});
-setenv("%try", {_stash: true, special: function (form) {
+}, stmt: true});
+setenv("%try", {_stash: true, tr: true, special: function (form) {
   var e = unique("e");
   var ind = indentation();
   indent_level = indent_level + 1;
@@ -1115,7 +1115,7 @@ setenv("%try", {_stash: true, special: function (form) {
   indent_level = indent_level - 1;
   var h = _x126;
   return(ind + "try {\n" + body + ind + "}\n" + ind + "catch (" + e + ") {\n" + h + ind + "}\n");
-}, stmt: true, tr: true});
+}, stmt: true});
 setenv("%delete", {_stash: true, special: function (place) {
   return(indentation() + "delete " + compile(place));
 }, stmt: true});
@@ -1125,22 +1125,22 @@ setenv("break", {_stash: true, special: function () {
 setenv("%function", {_stash: true, special: function (args, body) {
   return(compile_function(args, body));
 }});
-setenv("%global-function", {_stash: true, special: function (name, args, body) {
+setenv("%global-function", {_stash: true, tr: true, special: function (name, args, body) {
   if (target === "lua") {
     var x = compile_function(args, body, {_stash: true, name: name});
     return(indentation() + x);
   } else {
     return(compile(["set", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}, stmt: true, tr: true});
-setenv("%local-function", {_stash: true, special: function (name, args, body) {
+}, stmt: true});
+setenv("%local-function", {_stash: true, tr: true, special: function (name, args, body) {
   if (target === "lua") {
-    var x = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
+    var x = compile_function(args, body, {_stash: true, prefix: "local", name: name});
     return(indentation() + x);
   } else {
     return(compile(["%local", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}, stmt: true, tr: true});
+}, stmt: true});
 setenv("return", {_stash: true, special: function (x) {
   var _e35;
   if (nil63(x)) {

--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -401,12 +401,12 @@ indentation = function () {
   }
   return(s);
 };
-var reserved = {"continue": true, "finally": true, "in": true, "/": true, "-": true, "+": true, "function": true, "this": true, "try": true, "%": true, "instanceof": true, ">": true, "<": true, "==": true, "until": true, "delete": true, "switch": true, "typeof": true, "new": true, "then": true, "break": true, "void": true, "or": true, "true": true, "not": true, "=": true, "local": true, "case": true, "default": true, "while": true, "*": true, "elseif": true, "false": true, "debugger": true, "var": true, "and": true, "end": true, "else": true, "catch": true, "do": true, "for": true, "nil": true, "with": true, ">=": true, "<=": true, "if": true, "repeat": true, "throw": true, "return": true};
+var reserved = {"true": true, "return": true, "debugger": true, "=": true, "function": true, "*": true, "elseif": true, "then": true, "this": true, "catch": true, "case": true, "until": true, "continue": true, "delete": true, "<=": true, "else": true, ">=": true, "not": true, "+": true, "instanceof": true, "var": true, "for": true, "false": true, ">": true, "break": true, "try": true, "in": true, "repeat": true, "finally": true, "void": true, "nil": true, "end": true, "<": true, "and": true, "if": true, "with": true, "local": true, "or": true, "throw": true, "typeof": true, "do": true, "%": true, "/": true, "while": true, "-": true, "new": true, "default": true, "==": true, "switch": true};
 reserved63 = function (x) {
   return(reserved[x]);
 };
 var valid_code63 = function (n) {
-  return(number_code63(n) || n > 64 && n < 91 || n > 96 && n < 123 || n === 95);
+  return(number_code63(n) || n > 64 && n < 91 || n > 96 && n < 123 || n === 46 || n === 95);
 };
 valid_id63 = function (id) {
   if (none63(id) || reserved63(id)) {
@@ -461,9 +461,9 @@ _x58.lua = "not ";
 _x58.js = "!";
 __x57["not"] = _x58;
 var __x59 = [];
-__x59["%"] = true;
 __x59["/"] = true;
 __x59["*"] = true;
+__x59["%"] = true;
 var __x60 = [];
 __x60["-"] = true;
 __x60["+"] = true;
@@ -474,9 +474,9 @@ _x62.js = "+";
 __x61.cat = _x62;
 var __x63 = [];
 __x63["<="] = true;
-__x63["<"] = true;
-__x63[">="] = true;
 __x63[">"] = true;
+__x63[">="] = true;
+__x63["<"] = true;
 var __x64 = [];
 var _x65 = [];
 _x65.lua = "==";
@@ -645,8 +645,8 @@ var compile_special = function (form, stmt63) {
   var x = _id5[0];
   var args = cut(_id5, 1);
   var _id6 = getenv(x);
-  var self_tr63 = _id6.tr;
   var stmt = _id6.stmt;
+  var self_tr63 = _id6.tr;
   var special = _id6.special;
   var tr = terminator(stmt63 && !self_tr63);
   return(apply(special, args) + tr);
@@ -704,8 +704,8 @@ var compile_infix = function (form) {
 compile_function = function (args, body) {
   var _r58 = unstash(Array.prototype.slice.call(arguments, 2));
   var _id12 = _r58;
-  var prefix = _id12.prefix;
   var name = _id12.name;
+  var prefix = _id12.prefix;
   var _e25;
   if (name) {
     _e25 = compile(name);
@@ -1029,7 +1029,7 @@ load = function (path) {
 load_string = function (str) {
   return(run(compile_string(str)));
 };
-setenv("do", {_stash: true, tr: true, special: function () {
+setenv("do", {_stash: true, stmt: true, tr: true, special: function () {
   var forms = unstash(Array.prototype.slice.call(arguments, 0));
   var s = "";
   var _x108 = forms;
@@ -1041,8 +1041,8 @@ setenv("do", {_stash: true, tr: true, special: function () {
     _i12 = _i12 + 1;
   }
   return(s);
-}, stmt: true});
-setenv("%if", {_stash: true, tr: true, special: function (cond, cons, alt) {
+}});
+setenv("%if", {_stash: true, stmt: true, tr: true, special: function (cond, cons, alt) {
   var _cond1 = compile(cond);
   indent_level = indent_level + 1;
   var _x111 = compile(cons, {_stash: true, stmt: true});
@@ -1075,8 +1075,8 @@ setenv("%if", {_stash: true, tr: true, special: function (cond, cons, alt) {
   } else {
     return(s + "\n");
   }
-}, stmt: true});
-setenv("while", {_stash: true, tr: true, special: function (cond, form) {
+}});
+setenv("while", {_stash: true, stmt: true, tr: true, special: function (cond, form) {
   var _cond3 = compile(cond);
   indent_level = indent_level + 1;
   var _x114 = compile(form, {_stash: true, stmt: true});
@@ -1088,8 +1088,8 @@ setenv("while", {_stash: true, tr: true, special: function (cond, form) {
   } else {
     return(ind + "while " + _cond3 + " do\n" + body + ind + "end\n");
   }
-}, stmt: true});
-setenv("%for", {_stash: true, tr: true, special: function (t, k, form) {
+}});
+setenv("%for", {_stash: true, stmt: true, tr: true, special: function (t, k, form) {
   var _t1 = compile(t);
   var ind = indentation();
   indent_level = indent_level + 1;
@@ -1101,8 +1101,8 @@ setenv("%for", {_stash: true, tr: true, special: function (t, k, form) {
   } else {
     return(ind + "for (" + k + " in " + _t1 + ") {\n" + body + ind + "}\n");
   }
-}, stmt: true});
-setenv("%try", {_stash: true, tr: true, special: function (form) {
+}});
+setenv("%try", {_stash: true, stmt: true, tr: true, special: function (form) {
   var e = unique("e");
   var ind = indentation();
   indent_level = indent_level + 1;
@@ -1115,7 +1115,7 @@ setenv("%try", {_stash: true, tr: true, special: function (form) {
   indent_level = indent_level - 1;
   var h = _x126;
   return(ind + "try {\n" + body + ind + "}\n" + ind + "catch (" + e + ") {\n" + h + ind + "}\n");
-}, stmt: true});
+}});
 setenv("%delete", {_stash: true, special: function (place) {
   return(indentation() + "delete " + compile(place));
 }, stmt: true});
@@ -1125,22 +1125,22 @@ setenv("break", {_stash: true, special: function () {
 setenv("%function", {_stash: true, special: function (args, body) {
   return(compile_function(args, body));
 }});
-setenv("%global-function", {_stash: true, tr: true, special: function (name, args, body) {
+setenv("%global-function", {_stash: true, stmt: true, tr: true, special: function (name, args, body) {
   if (target === "lua") {
     var x = compile_function(args, body, {_stash: true, name: name});
     return(indentation() + x);
   } else {
     return(compile(["set", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}, stmt: true});
-setenv("%local-function", {_stash: true, tr: true, special: function (name, args, body) {
+}});
+setenv("%local-function", {_stash: true, stmt: true, tr: true, special: function (name, args, body) {
   if (target === "lua") {
-    var x = compile_function(args, body, {_stash: true, prefix: "local", name: name});
+    var x = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
     return(indentation() + x);
   } else {
     return(compile(["%local", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}, stmt: true});
+}});
 setenv("return", {_stash: true, special: function (x) {
   var _e35;
   if (nil63(x)) {

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -359,7 +359,7 @@ function indentation()
   end
   return(s)
 end
-local reserved = {["end"] = true, ["continue"] = true, ["if"] = true, ["in"] = true, ["false"] = true, ["with"] = true, ["catch"] = true, ["until"] = true, ["true"] = true, ["=="] = true, ["and"] = true, ["else"] = true, ["<"] = true, [">"] = true, ["*"] = true, ["instanceof"] = true, ["switch"] = true, ["debugger"] = true, ["or"] = true, ["try"] = true, ["local"] = true, ["repeat"] = true, ["new"] = true, ["default"] = true, ["="] = true, ["elseif"] = true, ["delete"] = true, ["while"] = true, ["case"] = true, ["var"] = true, ["for"] = true, ["nil"] = true, [">="] = true, ["break"] = true, ["throw"] = true, ["finally"] = true, ["typeof"] = true, ["then"] = true, ["do"] = true, ["<="] = true, ["this"] = true, ["return"] = true, ["/"] = true, ["function"] = true, ["%"] = true, ["+"] = true, ["not"] = true, ["-"] = true, ["void"] = true}
+local reserved = {["var"] = true, ["break"] = true, ["instanceof"] = true, [">="] = true, ["else"] = true, ["="] = true, ["function"] = true, ["true"] = true, ["elseif"] = true, ["switch"] = true, ["repeat"] = true, ["and"] = true, ["+"] = true, ["%"] = true, ["finally"] = true, ["local"] = true, ["or"] = true, ["delete"] = true, ["typeof"] = true, ["with"] = true, ["catch"] = true, ["do"] = true, ["until"] = true, ["then"] = true, ["end"] = true, ["in"] = true, ["=="] = true, ["new"] = true, [">"] = true, ["default"] = true, ["debugger"] = true, ["<"] = true, ["nil"] = true, ["void"] = true, ["not"] = true, ["return"] = true, ["while"] = true, ["case"] = true, ["if"] = true, ["this"] = true, ["for"] = true, ["*"] = true, ["<="] = true, ["false"] = true, ["throw"] = true, ["/"] = true, ["continue"] = true, ["-"] = true, ["try"] = true}
 function reserved63(x)
   return(reserved[x])
 end
@@ -412,12 +412,12 @@ _x58.lua = "not "
 _x58.js = "!"
 __x57["not"] = _x58
 local __x59 = {}
-__x59["%"] = true
 __x59["/"] = true
 __x59["*"] = true
+__x59["%"] = true
 local __x60 = {}
-__x60["-"] = true
 __x60["+"] = true
+__x60["-"] = true
 local __x61 = {}
 local _x62 = {}
 _x62.lua = ".."
@@ -425,9 +425,9 @@ _x62.js = "+"
 __x61.cat = _x62
 local __x63 = {}
 __x63["<="] = true
-__x63["<"] = true
-__x63[">="] = true
 __x63[">"] = true
+__x63[">="] = true
+__x63["<"] = true
 local __x64 = {}
 local _x65 = {}
 _x65.lua = "=="
@@ -591,9 +591,9 @@ local function compile_special(form, stmt63)
   local x = _id5[1]
   local args = cut(_id5, 1)
   local _id6 = getenv(x)
-  local stmt = _id6.stmt
-  local special = _id6.special
   local self_tr63 = _id6.tr
+  local special = _id6.special
+  local stmt = _id6.stmt
   local tr = terminator(stmt63 and not self_tr63)
   return(apply(special, args) .. tr)
 end
@@ -982,7 +982,7 @@ end
 function load_string(str)
   return(run(compile_string(str)))
 end
-setenv("do", {_stash = true, stmt = true, special = function (...)
+setenv("do", {_stash = true, tr = true, special = function (...)
   local forms = unstash({...})
   local s = ""
   local _x112 = forms
@@ -994,8 +994,8 @@ setenv("do", {_stash = true, stmt = true, special = function (...)
     _i12 = _i12 + 1
   end
   return(s)
-end, tr = true})
-setenv("%if", {_stash = true, stmt = true, special = function (cond, cons, alt)
+end, stmt = true})
+setenv("%if", {_stash = true, tr = true, special = function (cond, cons, alt)
   local _cond1 = compile(cond)
   indent_level = indent_level + 1
   local _x115 = compile(cons, {_stash = true, stmt = true})
@@ -1028,8 +1028,8 @@ setenv("%if", {_stash = true, stmt = true, special = function (cond, cons, alt)
   else
     return(s .. "\n")
   end
-end, tr = true})
-setenv("while", {_stash = true, stmt = true, special = function (cond, form)
+end, stmt = true})
+setenv("while", {_stash = true, tr = true, special = function (cond, form)
   local _cond3 = compile(cond)
   indent_level = indent_level + 1
   local _x118 = compile(form, {_stash = true, stmt = true})
@@ -1041,8 +1041,8 @@ setenv("while", {_stash = true, stmt = true, special = function (cond, form)
   else
     return(ind .. "while " .. _cond3 .. " do\n" .. body .. ind .. "end\n")
   end
-end, tr = true})
-setenv("%for", {_stash = true, stmt = true, special = function (t, k, form)
+end, stmt = true})
+setenv("%for", {_stash = true, tr = true, special = function (t, k, form)
   local _t1 = compile(t)
   local ind = indentation()
   indent_level = indent_level + 1
@@ -1054,8 +1054,8 @@ setenv("%for", {_stash = true, stmt = true, special = function (t, k, form)
   else
     return(ind .. "for (" .. k .. " in " .. _t1 .. ") {\n" .. body .. ind .. "}\n")
   end
-end, tr = true})
-setenv("%try", {_stash = true, stmt = true, special = function (form)
+end, stmt = true})
+setenv("%try", {_stash = true, tr = true, special = function (form)
   local e = unique("e")
   local ind = indentation()
   indent_level = indent_level + 1
@@ -1068,33 +1068,33 @@ setenv("%try", {_stash = true, stmt = true, special = function (form)
   indent_level = indent_level - 1
   local h = _x130
   return(ind .. "try {\n" .. body .. ind .. "}\n" .. ind .. "catch (" .. e .. ") {\n" .. h .. ind .. "}\n")
-end, tr = true})
-setenv("%delete", {_stash = true, stmt = true, special = function (place)
+end, stmt = true})
+setenv("%delete", {_stash = true, special = function (place)
   return(indentation() .. "delete " .. compile(place))
-end})
-setenv("break", {_stash = true, stmt = true, special = function ()
+end, stmt = true})
+setenv("break", {_stash = true, special = function ()
   return(indentation() .. "break")
-end})
+end, stmt = true})
 setenv("%function", {_stash = true, special = function (args, body)
   return(compile_function(args, body))
 end})
-setenv("%global-function", {_stash = true, stmt = true, special = function (name, args, body)
+setenv("%global-function", {_stash = true, tr = true, special = function (name, args, body)
   if target == "lua" then
     local x = compile_function(args, body, {_stash = true, name = name})
     return(indentation() .. x)
   else
     return(compile({"set", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
-end, tr = true})
-setenv("%local-function", {_stash = true, stmt = true, special = function (name, args, body)
+end, stmt = true})
+setenv("%local-function", {_stash = true, tr = true, special = function (name, args, body)
   if target == "lua" then
     local x = compile_function(args, body, {_stash = true, name = name, prefix = "local"})
     return(indentation() .. x)
   else
     return(compile({"%local", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
-end, tr = true})
-setenv("return", {_stash = true, stmt = true, special = function (x)
+end, stmt = true})
+setenv("return", {_stash = true, special = function (x)
   local _e27
   if nil63(x) then
     _e27 = "return"
@@ -1103,11 +1103,11 @@ setenv("return", {_stash = true, stmt = true, special = function (x)
   end
   local _x140 = _e27
   return(indentation() .. _x140)
-end})
+end, stmt = true})
 setenv("new", {_stash = true, special = function (x)
   return("new " .. compile(x))
 end})
-setenv("error", {_stash = true, stmt = true, special = function (x)
+setenv("error", {_stash = true, special = function (x)
   local _e28
   if target == "js" then
     _e28 = "throw " .. compile({"new", {"Error", x}})
@@ -1116,8 +1116,8 @@ setenv("error", {_stash = true, stmt = true, special = function (x)
   end
   local e = _e28
   return(indentation() .. e)
-end})
-setenv("%local", {_stash = true, stmt = true, special = function (name, value)
+end, stmt = true})
+setenv("%local", {_stash = true, special = function (name, value)
   local _id26 = compile(name)
   local value1 = compile(value)
   local _e29
@@ -1136,8 +1136,8 @@ setenv("%local", {_stash = true, stmt = true, special = function (name, value)
   local keyword = _e30
   local ind = indentation()
   return(ind .. keyword .. _id26 .. rh)
-end})
-setenv("set", {_stash = true, stmt = true, special = function (lh, rh)
+end, stmt = true})
+setenv("set", {_stash = true, special = function (lh, rh)
   local _lh1 = compile(lh)
   local _e31
   if nil63(rh) then
@@ -1147,7 +1147,7 @@ setenv("set", {_stash = true, stmt = true, special = function (lh, rh)
   end
   local _rh1 = compile(_e31)
   return(indentation() .. _lh1 .. " = " .. _rh1)
-end})
+end, stmt = true})
 setenv("get", {_stash = true, special = function (t, k)
   local _t3 = compile(t)
   local k1 = compile(k)
@@ -1217,4 +1217,4 @@ setenv("%object", {_stash = true, special = function (...)
   end
   return(s .. "}")
 end})
-return({["compile-string"] = compile_string, ["expand-string"] = expand_string, run = run, eval = eval, expand = expand, compile = compile, load = load, ["compile-file"] = compile_file, ["run-file"] = run_file, ["load-string"] = load_string})
+return({["load-string"] = load_string, eval = eval, ["expand-string"] = expand_string, run = run, ["compile-string"] = compile_string, load = load, ["compile-file"] = compile_file, expand = expand, ["run-file"] = run_file, compile = compile})

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -359,7 +359,7 @@ function indentation()
   end
   return(s)
 end
-local reserved = {["throw"] = true, ["else"] = true, ["false"] = true, ["elseif"] = true, ["end"] = true, ["<"] = true, ["delete"] = true, [">"] = true, ["return"] = true, ["new"] = true, ["typeof"] = true, ["*"] = true, ["until"] = true, ["then"] = true, [">="] = true, ["%"] = true, ["<="] = true, ["do"] = true, ["while"] = true, ["continue"] = true, ["or"] = true, ["not"] = true, ["function"] = true, ["local"] = true, ["and"] = true, ["case"] = true, ["true"] = true, ["nil"] = true, ["in"] = true, ["="] = true, ["default"] = true, ["break"] = true, ["void"] = true, ["-"] = true, ["/"] = true, ["for"] = true, ["var"] = true, ["try"] = true, ["debugger"] = true, ["this"] = true, ["+"] = true, ["switch"] = true, ["catch"] = true, ["=="] = true, ["finally"] = true, ["instanceof"] = true, ["if"] = true, ["with"] = true, ["repeat"] = true}
+local reserved = {["while"] = true, ["void"] = true, ["finally"] = true, ["try"] = true, ["return"] = true, ["do"] = true, ["else"] = true, ["delete"] = true, ["*"] = true, ["throw"] = true, ["="] = true, ["true"] = true, ["typeof"] = true, ["new"] = true, ["+"] = true, ["this"] = true, ["=="] = true, ["instanceof"] = true, ["/"] = true, ["case"] = true, ["debugger"] = true, ["var"] = true, ["end"] = true, ["not"] = true, ["until"] = true, ["%"] = true, ["break"] = true, ["elseif"] = true, ["<="] = true, ["repeat"] = true, ["<"] = true, [">="] = true, [">"] = true, ["switch"] = true, ["if"] = true, ["and"] = true, ["catch"] = true, ["local"] = true, ["continue"] = true, ["false"] = true, ["or"] = true, ["with"] = true, ["in"] = true, ["for"] = true, ["function"] = true, ["then"] = true, ["default"] = true, ["nil"] = true, ["-"] = true}
 function reserved63(x)
   return(reserved[x])
 end
@@ -408,40 +408,40 @@ function mapo(f, t)
 end
 local __x57 = {}
 local _x58 = {}
-_x58.lua = "not "
 _x58.js = "!"
+_x58.lua = "not "
 __x57["not"] = _x58
 local __x59 = {}
-__x59["%"] = true
-__x59["*"] = true
 __x59["/"] = true
+__x59["*"] = true
+__x59["%"] = true
 local __x60 = {}
 __x60["+"] = true
 __x60["-"] = true
 local __x61 = {}
 local _x62 = {}
-_x62.lua = ".."
 _x62.js = "+"
+_x62.lua = ".."
 __x61.cat = _x62
 local __x63 = {}
-__x63["<"] = true
-__x63[">="] = true
 __x63[">"] = true
 __x63["<="] = true
+__x63["<"] = true
+__x63[">="] = true
 local __x64 = {}
 local _x65 = {}
-_x65.lua = "=="
 _x65.js = "==="
+_x65.lua = "=="
 __x64["="] = _x65
 local __x66 = {}
 local _x67 = {}
-_x67.lua = "and"
 _x67.js = "&&"
+_x67.lua = "and"
 __x66["and"] = _x67
 local __x68 = {}
 local _x69 = {}
-_x69.lua = "or"
 _x69.js = "||"
+_x69.lua = "or"
 __x68["or"] = _x69
 local infix = {__x57, __x59, __x60, __x61, __x63, __x64, __x66, __x68}
 local function unary63(form)
@@ -591,9 +591,9 @@ local function compile_special(form, stmt63)
   local x = _id5[1]
   local args = cut(_id5, 1)
   local _id6 = getenv(x)
+  local special = _id6.special
   local stmt = _id6.stmt
   local self_tr63 = _id6.tr
-  local special = _id6.special
   local tr = terminator(stmt63 and not self_tr63)
   return(apply(special, args) .. tr)
 end
@@ -650,8 +650,8 @@ end
 function compile_function(args, body, ...)
   local _r58 = unstash({...})
   local _id12 = _r58
-  local name = _id12.name
   local prefix = _id12.prefix
+  local name = _id12.name
   local _e17
   if name then
     _e17 = compile(name)
@@ -985,7 +985,7 @@ setenv("do", {_stash = true, special = function (...)
     _i12 = _i12 + 1
   end
   return(s)
-end, tr = true, stmt = true})
+end, stmt = true, tr = true})
 setenv("%if", {_stash = true, special = function (cond, cons, alt)
   local _cond1 = compile(cond)
   indent_level = indent_level + 1
@@ -1019,7 +1019,7 @@ setenv("%if", {_stash = true, special = function (cond, cons, alt)
   else
     return(s .. "\n")
   end
-end, tr = true, stmt = true})
+end, stmt = true, tr = true})
 setenv("while", {_stash = true, special = function (cond, form)
   local _cond3 = compile(cond)
   indent_level = indent_level + 1
@@ -1032,7 +1032,7 @@ setenv("while", {_stash = true, special = function (cond, form)
   else
     return(ind .. "while " .. _cond3 .. " do\n" .. body .. ind .. "end\n")
   end
-end, tr = true, stmt = true})
+end, stmt = true, tr = true})
 setenv("%for", {_stash = true, special = function (t, k, form)
   local _t1 = compile(t)
   local ind = indentation()
@@ -1045,7 +1045,7 @@ setenv("%for", {_stash = true, special = function (t, k, form)
   else
     return(ind .. "for (" .. k .. " in " .. _t1 .. ") {\n" .. body .. ind .. "}\n")
   end
-end, tr = true, stmt = true})
+end, stmt = true, tr = true})
 setenv("%try", {_stash = true, special = function (form)
   local e = unique("e")
   local ind = indentation()
@@ -1059,7 +1059,7 @@ setenv("%try", {_stash = true, special = function (form)
   indent_level = indent_level - 1
   local h = _x130
   return(ind .. "try {\n" .. body .. ind .. "}\n" .. ind .. "catch (" .. e .. ") {\n" .. h .. ind .. "}\n")
-end, tr = true, stmt = true})
+end, stmt = true, tr = true})
 setenv("%delete", {_stash = true, special = function (place)
   return(indentation() .. "delete " .. compile(place))
 end, stmt = true})
@@ -1076,15 +1076,15 @@ setenv("%global-function", {_stash = true, special = function (name, args, body)
   else
     return(compile({"set", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
-end, tr = true, stmt = true})
+end, stmt = true, tr = true})
 setenv("%local-function", {_stash = true, special = function (name, args, body)
   if target == "lua" then
-    local x = compile_function(args, body, {_stash = true, name = name, prefix = "local"})
+    local x = compile_function(args, body, {_stash = true, prefix = "local", name = name})
     return(indentation() .. x)
   else
     return(compile({"%local", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
-end, tr = true, stmt = true})
+end, stmt = true, tr = true})
 setenv("return", {_stash = true, special = function (x)
   local _e27
   if nil63(x) then
@@ -1208,4 +1208,4 @@ setenv("%object", {_stash = true, special = function (...)
   end
   return(s .. "}")
 end})
-return({eval = eval, expand = expand, ["compile-file"] = compile_file, compile = compile, ["run-file"] = run_file, load = load})
+return({load = load, compile = compile, expand = expand, ["run-file"] = run_file, eval = eval, ["compile-file"] = compile_file})

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -359,12 +359,12 @@ function indentation()
   end
   return(s)
 end
-local reserved = {["var"] = true, ["break"] = true, ["instanceof"] = true, [">="] = true, ["else"] = true, ["="] = true, ["function"] = true, ["true"] = true, ["elseif"] = true, ["switch"] = true, ["repeat"] = true, ["and"] = true, ["+"] = true, ["%"] = true, ["finally"] = true, ["local"] = true, ["or"] = true, ["delete"] = true, ["typeof"] = true, ["with"] = true, ["catch"] = true, ["do"] = true, ["until"] = true, ["then"] = true, ["end"] = true, ["in"] = true, ["=="] = true, ["new"] = true, [">"] = true, ["default"] = true, ["debugger"] = true, ["<"] = true, ["nil"] = true, ["void"] = true, ["not"] = true, ["return"] = true, ["while"] = true, ["case"] = true, ["if"] = true, ["this"] = true, ["for"] = true, ["*"] = true, ["<="] = true, ["false"] = true, ["throw"] = true, ["/"] = true, ["continue"] = true, ["-"] = true, ["try"] = true}
+local reserved = {["new"] = true, [">="] = true, ["%"] = true, ["void"] = true, ["-"] = true, ["until"] = true, ["instanceof"] = true, ["elseif"] = true, ["finally"] = true, ["do"] = true, ["else"] = true, ["then"] = true, ["="] = true, ["true"] = true, ["function"] = true, ["while"] = true, ["try"] = true, ["continue"] = true, ["default"] = true, ["switch"] = true, ["var"] = true, ["case"] = true, ["with"] = true, ["not"] = true, ["*"] = true, ["repeat"] = true, ["=="] = true, ["nil"] = true, ["+"] = true, ["catch"] = true, ["debugger"] = true, ["/"] = true, ["if"] = true, ["end"] = true, ["<"] = true, ["or"] = true, ["delete"] = true, ["in"] = true, ["local"] = true, [">"] = true, ["false"] = true, ["typeof"] = true, ["this"] = true, ["for"] = true, ["break"] = true, ["return"] = true, ["throw"] = true, ["<="] = true, ["and"] = true}
 function reserved63(x)
   return(reserved[x])
 end
 local function valid_code63(n)
-  return(number_code63(n) or n > 64 and n < 91 or n > 96 and n < 123 or n == 95)
+  return(number_code63(n) or n > 64 and n < 91 or n > 96 and n < 123 or n == 46 or n == 95)
 end
 function valid_id63(id)
   if none63(id) or reserved63(id) then
@@ -408,40 +408,40 @@ function mapo(f, t)
 end
 local __x57 = {}
 local _x58 = {}
-_x58.lua = "not "
 _x58.js = "!"
+_x58.lua = "not "
 __x57["not"] = _x58
 local __x59 = {}
 __x59["/"] = true
-__x59["*"] = true
 __x59["%"] = true
+__x59["*"] = true
 local __x60 = {}
 __x60["+"] = true
 __x60["-"] = true
 local __x61 = {}
 local _x62 = {}
-_x62.lua = ".."
 _x62.js = "+"
+_x62.lua = ".."
 __x61.cat = _x62
 local __x63 = {}
-__x63["<="] = true
-__x63[">"] = true
 __x63[">="] = true
 __x63["<"] = true
+__x63["<="] = true
+__x63[">"] = true
 local __x64 = {}
 local _x65 = {}
-_x65.lua = "=="
 _x65.js = "==="
+_x65.lua = "=="
 __x64["="] = _x65
 local __x66 = {}
 local _x67 = {}
-_x67.lua = "and"
 _x67.js = "&&"
+_x67.lua = "and"
 __x66["and"] = _x67
 local __x68 = {}
 local _x69 = {}
-_x69.lua = "or"
 _x69.js = "||"
+_x69.lua = "or"
 __x68["or"] = _x69
 local infix = {__x57, __x59, __x60, __x61, __x63, __x64, __x66, __x68}
 local function unary63(form)
@@ -591,9 +591,9 @@ local function compile_special(form, stmt63)
   local x = _id5[1]
   local args = cut(_id5, 1)
   local _id6 = getenv(x)
+  local stmt = _id6.stmt
   local self_tr63 = _id6.tr
   local special = _id6.special
-  local stmt = _id6.stmt
   local tr = terminator(stmt63 and not self_tr63)
   return(apply(special, args) .. tr)
 end
@@ -650,8 +650,8 @@ end
 function compile_function(args, body, ...)
   local _r58 = unstash({...})
   local _id12 = _r58
-  local name = _id12.name
   local prefix = _id12.prefix
+  local name = _id12.name
   local _e17
   if name then
     _e17 = compile(name)
@@ -982,7 +982,7 @@ end
 function load_string(str)
   return(run(compile_string(str)))
 end
-setenv("do", {_stash = true, tr = true, special = function (...)
+setenv("do", {_stash = true, stmt = true, tr = true, special = function (...)
   local forms = unstash({...})
   local s = ""
   local _x112 = forms
@@ -994,8 +994,8 @@ setenv("do", {_stash = true, tr = true, special = function (...)
     _i12 = _i12 + 1
   end
   return(s)
-end, stmt = true})
-setenv("%if", {_stash = true, tr = true, special = function (cond, cons, alt)
+end})
+setenv("%if", {_stash = true, stmt = true, tr = true, special = function (cond, cons, alt)
   local _cond1 = compile(cond)
   indent_level = indent_level + 1
   local _x115 = compile(cons, {_stash = true, stmt = true})
@@ -1028,8 +1028,8 @@ setenv("%if", {_stash = true, tr = true, special = function (cond, cons, alt)
   else
     return(s .. "\n")
   end
-end, stmt = true})
-setenv("while", {_stash = true, tr = true, special = function (cond, form)
+end})
+setenv("while", {_stash = true, stmt = true, tr = true, special = function (cond, form)
   local _cond3 = compile(cond)
   indent_level = indent_level + 1
   local _x118 = compile(form, {_stash = true, stmt = true})
@@ -1041,8 +1041,8 @@ setenv("while", {_stash = true, tr = true, special = function (cond, form)
   else
     return(ind .. "while " .. _cond3 .. " do\n" .. body .. ind .. "end\n")
   end
-end, stmt = true})
-setenv("%for", {_stash = true, tr = true, special = function (t, k, form)
+end})
+setenv("%for", {_stash = true, stmt = true, tr = true, special = function (t, k, form)
   local _t1 = compile(t)
   local ind = indentation()
   indent_level = indent_level + 1
@@ -1054,8 +1054,8 @@ setenv("%for", {_stash = true, tr = true, special = function (t, k, form)
   else
     return(ind .. "for (" .. k .. " in " .. _t1 .. ") {\n" .. body .. ind .. "}\n")
   end
-end, stmt = true})
-setenv("%try", {_stash = true, tr = true, special = function (form)
+end})
+setenv("%try", {_stash = true, stmt = true, tr = true, special = function (form)
   local e = unique("e")
   local ind = indentation()
   indent_level = indent_level + 1
@@ -1068,7 +1068,7 @@ setenv("%try", {_stash = true, tr = true, special = function (form)
   indent_level = indent_level - 1
   local h = _x130
   return(ind .. "try {\n" .. body .. ind .. "}\n" .. ind .. "catch (" .. e .. ") {\n" .. h .. ind .. "}\n")
-end, stmt = true})
+end})
 setenv("%delete", {_stash = true, special = function (place)
   return(indentation() .. "delete " .. compile(place))
 end, stmt = true})
@@ -1078,22 +1078,22 @@ end, stmt = true})
 setenv("%function", {_stash = true, special = function (args, body)
   return(compile_function(args, body))
 end})
-setenv("%global-function", {_stash = true, tr = true, special = function (name, args, body)
+setenv("%global-function", {_stash = true, stmt = true, tr = true, special = function (name, args, body)
   if target == "lua" then
     local x = compile_function(args, body, {_stash = true, name = name})
     return(indentation() .. x)
   else
     return(compile({"set", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
-end, stmt = true})
-setenv("%local-function", {_stash = true, tr = true, special = function (name, args, body)
+end})
+setenv("%local-function", {_stash = true, stmt = true, tr = true, special = function (name, args, body)
   if target == "lua" then
-    local x = compile_function(args, body, {_stash = true, name = name, prefix = "local"})
+    local x = compile_function(args, body, {_stash = true, prefix = "local", name = name})
     return(indentation() .. x)
   else
     return(compile({"%local", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
-end, stmt = true})
+end})
 setenv("return", {_stash = true, special = function (x)
   local _e27
   if nil63(x) then
@@ -1217,4 +1217,4 @@ setenv("%object", {_stash = true, special = function (...)
   end
   return(s .. "}")
 end})
-return({["load-string"] = load_string, eval = eval, ["expand-string"] = expand_string, run = run, ["compile-string"] = compile_string, load = load, ["compile-file"] = compile_file, expand = expand, ["run-file"] = run_file, compile = compile})
+return({run = run, ["load-string"] = load_string, ["run-file"] = run_file, load = load, eval = eval, compile = compile, ["expand-string"] = expand_string, expand = expand, ["compile-string"] = compile_string, ["compile-file"] = compile_file})

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -359,7 +359,7 @@ function indentation()
   end
   return(s)
 end
-local reserved = {[">"] = true, ["var"] = true, ["nil"] = true, ["=="] = true, ["until"] = true, ["delete"] = true, ["not"] = true, ["void"] = true, ["false"] = true, ["finally"] = true, ["and"] = true, ["new"] = true, ["true"] = true, ["catch"] = true, ["or"] = true, ["instanceof"] = true, ["this"] = true, ["switch"] = true, ["then"] = true, ["end"] = true, ["else"] = true, ["repeat"] = true, ["local"] = true, ["*"] = true, ["="] = true, ["debugger"] = true, ["+"] = true, ["%"] = true, ["-"] = true, ["/"] = true, ["elseif"] = true, ["<"] = true, [">="] = true, ["continue"] = true, ["break"] = true, ["while"] = true, ["try"] = true, ["do"] = true, ["function"] = true, ["throw"] = true, ["if"] = true, ["case"] = true, ["with"] = true, ["return"] = true, ["in"] = true, ["typeof"] = true, ["for"] = true, ["default"] = true, ["<="] = true}
+local reserved = {["end"] = true, ["continue"] = true, ["if"] = true, ["in"] = true, ["false"] = true, ["with"] = true, ["catch"] = true, ["until"] = true, ["true"] = true, ["=="] = true, ["and"] = true, ["else"] = true, ["<"] = true, [">"] = true, ["*"] = true, ["instanceof"] = true, ["switch"] = true, ["debugger"] = true, ["or"] = true, ["try"] = true, ["local"] = true, ["repeat"] = true, ["new"] = true, ["default"] = true, ["="] = true, ["elseif"] = true, ["delete"] = true, ["while"] = true, ["case"] = true, ["var"] = true, ["for"] = true, ["nil"] = true, [">="] = true, ["break"] = true, ["throw"] = true, ["finally"] = true, ["typeof"] = true, ["then"] = true, ["do"] = true, ["<="] = true, ["this"] = true, ["return"] = true, ["/"] = true, ["function"] = true, ["%"] = true, ["+"] = true, ["not"] = true, ["-"] = true, ["void"] = true}
 function reserved63(x)
   return(reserved[x])
 end
@@ -408,40 +408,40 @@ function mapo(f, t)
 end
 local __x57 = {}
 local _x58 = {}
-_x58.js = "!"
 _x58.lua = "not "
+_x58.js = "!"
 __x57["not"] = _x58
 local __x59 = {}
 __x59["%"] = true
-__x59["*"] = true
 __x59["/"] = true
+__x59["*"] = true
 local __x60 = {}
-__x60["+"] = true
 __x60["-"] = true
+__x60["+"] = true
 local __x61 = {}
 local _x62 = {}
-_x62.js = "+"
 _x62.lua = ".."
+_x62.js = "+"
 __x61.cat = _x62
 local __x63 = {}
-__x63[">="] = true
-__x63[">"] = true
 __x63["<="] = true
 __x63["<"] = true
+__x63[">="] = true
+__x63[">"] = true
 local __x64 = {}
 local _x65 = {}
-_x65.js = "==="
 _x65.lua = "=="
+_x65.js = "==="
 __x64["="] = _x65
 local __x66 = {}
 local _x67 = {}
-_x67.js = "&&"
 _x67.lua = "and"
+_x67.js = "&&"
 __x66["and"] = _x67
 local __x68 = {}
 local _x69 = {}
-_x69.js = "||"
 _x69.lua = "or"
+_x69.js = "||"
 __x68["or"] = _x69
 local infix = {__x57, __x59, __x60, __x61, __x63, __x64, __x66, __x68}
 local function unary63(form)
@@ -591,8 +591,8 @@ local function compile_special(form, stmt63)
   local x = _id5[1]
   local args = cut(_id5, 1)
   local _id6 = getenv(x)
-  local special = _id6.special
   local stmt = _id6.stmt
+  local special = _id6.special
   local self_tr63 = _id6.tr
   local tr = terminator(stmt63 and not self_tr63)
   return(apply(special, args) .. tr)
@@ -650,8 +650,8 @@ end
 function compile_function(args, body, ...)
   local _r58 = unstash({...})
   local _id12 = _r58
-  local prefix = _id12.prefix
   local name = _id12.name
+  local prefix = _id12.prefix
   local _e17
   if name then
     _e17 = compile(name)
@@ -982,7 +982,7 @@ end
 function load_string(str)
   return(run(compile_string(str)))
 end
-setenv("do", {_stash = true, special = function (...)
+setenv("do", {_stash = true, stmt = true, special = function (...)
   local forms = unstash({...})
   local s = ""
   local _x112 = forms
@@ -994,8 +994,8 @@ setenv("do", {_stash = true, special = function (...)
     _i12 = _i12 + 1
   end
   return(s)
-end, stmt = true, tr = true})
-setenv("%if", {_stash = true, special = function (cond, cons, alt)
+end, tr = true})
+setenv("%if", {_stash = true, stmt = true, special = function (cond, cons, alt)
   local _cond1 = compile(cond)
   indent_level = indent_level + 1
   local _x115 = compile(cons, {_stash = true, stmt = true})
@@ -1028,8 +1028,8 @@ setenv("%if", {_stash = true, special = function (cond, cons, alt)
   else
     return(s .. "\n")
   end
-end, stmt = true, tr = true})
-setenv("while", {_stash = true, special = function (cond, form)
+end, tr = true})
+setenv("while", {_stash = true, stmt = true, special = function (cond, form)
   local _cond3 = compile(cond)
   indent_level = indent_level + 1
   local _x118 = compile(form, {_stash = true, stmt = true})
@@ -1041,8 +1041,8 @@ setenv("while", {_stash = true, special = function (cond, form)
   else
     return(ind .. "while " .. _cond3 .. " do\n" .. body .. ind .. "end\n")
   end
-end, stmt = true, tr = true})
-setenv("%for", {_stash = true, special = function (t, k, form)
+end, tr = true})
+setenv("%for", {_stash = true, stmt = true, special = function (t, k, form)
   local _t1 = compile(t)
   local ind = indentation()
   indent_level = indent_level + 1
@@ -1054,8 +1054,8 @@ setenv("%for", {_stash = true, special = function (t, k, form)
   else
     return(ind .. "for (" .. k .. " in " .. _t1 .. ") {\n" .. body .. ind .. "}\n")
   end
-end, stmt = true, tr = true})
-setenv("%try", {_stash = true, special = function (form)
+end, tr = true})
+setenv("%try", {_stash = true, stmt = true, special = function (form)
   local e = unique("e")
   local ind = indentation()
   indent_level = indent_level + 1
@@ -1068,33 +1068,33 @@ setenv("%try", {_stash = true, special = function (form)
   indent_level = indent_level - 1
   local h = _x130
   return(ind .. "try {\n" .. body .. ind .. "}\n" .. ind .. "catch (" .. e .. ") {\n" .. h .. ind .. "}\n")
-end, stmt = true, tr = true})
-setenv("%delete", {_stash = true, special = function (place)
+end, tr = true})
+setenv("%delete", {_stash = true, stmt = true, special = function (place)
   return(indentation() .. "delete " .. compile(place))
-end, stmt = true})
-setenv("break", {_stash = true, special = function ()
+end})
+setenv("break", {_stash = true, stmt = true, special = function ()
   return(indentation() .. "break")
-end, stmt = true})
+end})
 setenv("%function", {_stash = true, special = function (args, body)
   return(compile_function(args, body))
 end})
-setenv("%global-function", {_stash = true, special = function (name, args, body)
+setenv("%global-function", {_stash = true, stmt = true, special = function (name, args, body)
   if target == "lua" then
     local x = compile_function(args, body, {_stash = true, name = name})
     return(indentation() .. x)
   else
     return(compile({"set", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
-end, stmt = true, tr = true})
-setenv("%local-function", {_stash = true, special = function (name, args, body)
+end, tr = true})
+setenv("%local-function", {_stash = true, stmt = true, special = function (name, args, body)
   if target == "lua" then
-    local x = compile_function(args, body, {_stash = true, prefix = "local", name = name})
+    local x = compile_function(args, body, {_stash = true, name = name, prefix = "local"})
     return(indentation() .. x)
   else
     return(compile({"%local", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
-end, stmt = true, tr = true})
-setenv("return", {_stash = true, special = function (x)
+end, tr = true})
+setenv("return", {_stash = true, stmt = true, special = function (x)
   local _e27
   if nil63(x) then
     _e27 = "return"
@@ -1103,11 +1103,11 @@ setenv("return", {_stash = true, special = function (x)
   end
   local _x140 = _e27
   return(indentation() .. _x140)
-end, stmt = true})
+end})
 setenv("new", {_stash = true, special = function (x)
   return("new " .. compile(x))
 end})
-setenv("error", {_stash = true, special = function (x)
+setenv("error", {_stash = true, stmt = true, special = function (x)
   local _e28
   if target == "js" then
     _e28 = "throw " .. compile({"new", {"Error", x}})
@@ -1116,8 +1116,8 @@ setenv("error", {_stash = true, special = function (x)
   end
   local e = _e28
   return(indentation() .. e)
-end, stmt = true})
-setenv("%local", {_stash = true, special = function (name, value)
+end})
+setenv("%local", {_stash = true, stmt = true, special = function (name, value)
   local _id26 = compile(name)
   local value1 = compile(value)
   local _e29
@@ -1136,8 +1136,8 @@ setenv("%local", {_stash = true, special = function (name, value)
   local keyword = _e30
   local ind = indentation()
   return(ind .. keyword .. _id26 .. rh)
-end, stmt = true})
-setenv("set", {_stash = true, special = function (lh, rh)
+end})
+setenv("set", {_stash = true, stmt = true, special = function (lh, rh)
   local _lh1 = compile(lh)
   local _e31
   if nil63(rh) then
@@ -1147,7 +1147,7 @@ setenv("set", {_stash = true, special = function (lh, rh)
   end
   local _rh1 = compile(_e31)
   return(indentation() .. _lh1 .. " = " .. _rh1)
-end, stmt = true})
+end})
 setenv("get", {_stash = true, special = function (t, k)
   local _t3 = compile(t)
   local k1 = compile(k)
@@ -1217,4 +1217,4 @@ setenv("%object", {_stash = true, special = function (...)
   end
   return(s .. "}")
 end})
-return({compile = compile, ["compile-file"] = compile_file, ["run-file"] = run_file, eval = eval, ["load-string"] = load_string, run = run, load = load, ["compile-string"] = compile_string, expand = expand, ["expand-string"] = expand_string})
+return({["compile-string"] = compile_string, ["expand-string"] = expand_string, run = run, eval = eval, expand = expand, compile = compile, load = load, ["compile-file"] = compile_file, ["run-file"] = run_file, ["load-string"] = load_string})

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -359,7 +359,7 @@ function indentation()
   end
   return(s)
 end
-local reserved = {["<="] = true, ["function"] = true, ["for"] = true, ["switch"] = true, ["continue"] = true, ["else"] = true, ["var"] = true, ["local"] = true, ["default"] = true, [">="] = true, ["void"] = true, ["="] = true, ["case"] = true, ["/"] = true, ["this"] = true, ["-"] = true, ["break"] = true, ["do"] = true, ["*"] = true, ["new"] = true, ["debugger"] = true, ["typeof"] = true, ["repeat"] = true, ["delete"] = true, ["throw"] = true, ["in"] = true, ["or"] = true, ["while"] = true, ["false"] = true, ["end"] = true, ["then"] = true, ["finally"] = true, ["not"] = true, ["until"] = true, ["elseif"] = true, ["nil"] = true, ["if"] = true, ["return"] = true, ["=="] = true, ["<"] = true, [">"] = true, ["try"] = true, ["%"] = true, ["with"] = true, ["instanceof"] = true, ["catch"] = true, ["true"] = true, ["+"] = true, ["and"] = true}
+local reserved = {[">"] = true, ["var"] = true, ["nil"] = true, ["=="] = true, ["until"] = true, ["delete"] = true, ["not"] = true, ["void"] = true, ["false"] = true, ["finally"] = true, ["and"] = true, ["new"] = true, ["true"] = true, ["catch"] = true, ["or"] = true, ["instanceof"] = true, ["this"] = true, ["switch"] = true, ["then"] = true, ["end"] = true, ["else"] = true, ["repeat"] = true, ["local"] = true, ["*"] = true, ["="] = true, ["debugger"] = true, ["+"] = true, ["%"] = true, ["-"] = true, ["/"] = true, ["elseif"] = true, ["<"] = true, [">="] = true, ["continue"] = true, ["break"] = true, ["while"] = true, ["try"] = true, ["do"] = true, ["function"] = true, ["throw"] = true, ["if"] = true, ["case"] = true, ["with"] = true, ["return"] = true, ["in"] = true, ["typeof"] = true, ["for"] = true, ["default"] = true, ["<="] = true}
 function reserved63(x)
   return(reserved[x])
 end
@@ -424,9 +424,9 @@ _x62.js = "+"
 _x62.lua = ".."
 __x61.cat = _x62
 local __x63 = {}
-__x63["<="] = true
-__x63[">"] = true
 __x63[">="] = true
+__x63[">"] = true
+__x63["<="] = true
 __x63["<"] = true
 local __x64 = {}
 local _x65 = {}
@@ -591,9 +591,9 @@ local function compile_special(form, stmt63)
   local x = _id5[1]
   local args = cut(_id5, 1)
   local _id6 = getenv(x)
-  local self_tr63 = _id6.tr
   local special = _id6.special
   local stmt = _id6.stmt
+  local self_tr63 = _id6.tr
   local tr = terminator(stmt63 and not self_tr63)
   return(apply(special, args) .. tr)
 end
@@ -650,8 +650,8 @@ end
 function compile_function(args, body, ...)
   local _r58 = unstash({...})
   local _id12 = _r58
-  local name = _id12.name
   local prefix = _id12.prefix
+  local name = _id12.name
   local _e17
   if name then
     _e17 = compile(name)
@@ -982,7 +982,7 @@ end
 function load_string(str)
   return(run(compile_string(str)))
 end
-setenv("do", {_stash = true, tr = true, special = function (...)
+setenv("do", {_stash = true, special = function (...)
   local forms = unstash({...})
   local s = ""
   local _x112 = forms
@@ -994,8 +994,8 @@ setenv("do", {_stash = true, tr = true, special = function (...)
     _i12 = _i12 + 1
   end
   return(s)
-end, stmt = true})
-setenv("%if", {_stash = true, tr = true, special = function (cond, cons, alt)
+end, stmt = true, tr = true})
+setenv("%if", {_stash = true, special = function (cond, cons, alt)
   local _cond1 = compile(cond)
   indent_level = indent_level + 1
   local _x115 = compile(cons, {_stash = true, stmt = true})
@@ -1028,8 +1028,8 @@ setenv("%if", {_stash = true, tr = true, special = function (cond, cons, alt)
   else
     return(s .. "\n")
   end
-end, stmt = true})
-setenv("while", {_stash = true, tr = true, special = function (cond, form)
+end, stmt = true, tr = true})
+setenv("while", {_stash = true, special = function (cond, form)
   local _cond3 = compile(cond)
   indent_level = indent_level + 1
   local _x118 = compile(form, {_stash = true, stmt = true})
@@ -1041,8 +1041,8 @@ setenv("while", {_stash = true, tr = true, special = function (cond, form)
   else
     return(ind .. "while " .. _cond3 .. " do\n" .. body .. ind .. "end\n")
   end
-end, stmt = true})
-setenv("%for", {_stash = true, tr = true, special = function (t, k, form)
+end, stmt = true, tr = true})
+setenv("%for", {_stash = true, special = function (t, k, form)
   local _t1 = compile(t)
   local ind = indentation()
   indent_level = indent_level + 1
@@ -1054,8 +1054,8 @@ setenv("%for", {_stash = true, tr = true, special = function (t, k, form)
   else
     return(ind .. "for (" .. k .. " in " .. _t1 .. ") {\n" .. body .. ind .. "}\n")
   end
-end, stmt = true})
-setenv("%try", {_stash = true, tr = true, special = function (form)
+end, stmt = true, tr = true})
+setenv("%try", {_stash = true, special = function (form)
   local e = unique("e")
   local ind = indentation()
   indent_level = indent_level + 1
@@ -1068,7 +1068,7 @@ setenv("%try", {_stash = true, tr = true, special = function (form)
   indent_level = indent_level - 1
   local h = _x130
   return(ind .. "try {\n" .. body .. ind .. "}\n" .. ind .. "catch (" .. e .. ") {\n" .. h .. ind .. "}\n")
-end, stmt = true})
+end, stmt = true, tr = true})
 setenv("%delete", {_stash = true, special = function (place)
   return(indentation() .. "delete " .. compile(place))
 end, stmt = true})
@@ -1078,22 +1078,22 @@ end, stmt = true})
 setenv("%function", {_stash = true, special = function (args, body)
   return(compile_function(args, body))
 end})
-setenv("%global-function", {_stash = true, tr = true, special = function (name, args, body)
+setenv("%global-function", {_stash = true, special = function (name, args, body)
   if target == "lua" then
     local x = compile_function(args, body, {_stash = true, name = name})
     return(indentation() .. x)
   else
     return(compile({"set", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
-end, stmt = true})
-setenv("%local-function", {_stash = true, tr = true, special = function (name, args, body)
+end, stmt = true, tr = true})
+setenv("%local-function", {_stash = true, special = function (name, args, body)
   if target == "lua" then
-    local x = compile_function(args, body, {_stash = true, name = name, prefix = "local"})
+    local x = compile_function(args, body, {_stash = true, prefix = "local", name = name})
     return(indentation() .. x)
   else
     return(compile({"%local", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
-end, stmt = true})
+end, stmt = true, tr = true})
 setenv("return", {_stash = true, special = function (x)
   local _e27
   if nil63(x) then
@@ -1217,4 +1217,4 @@ setenv("%object", {_stash = true, special = function (...)
   end
   return(s .. "}")
 end})
-return({eval = eval, run = run, ["compile-string"] = compile_string, ["compile-file"] = compile_file, compile = compile, ["run-file"] = run_file, load = load, expand = expand, ["expand-string"] = expand_string, ["load-string"] = load_string})
+return({compile = compile, ["compile-file"] = compile_file, ["run-file"] = run_file, eval = eval, ["load-string"] = load_string, run = run, load = load, ["compile-string"] = compile_string, expand = expand, ["expand-string"] = expand_string})

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -359,7 +359,7 @@ function indentation()
   end
   return(s)
 end
-local reserved = {["while"] = true, ["void"] = true, ["finally"] = true, ["try"] = true, ["return"] = true, ["do"] = true, ["else"] = true, ["delete"] = true, ["*"] = true, ["throw"] = true, ["="] = true, ["true"] = true, ["typeof"] = true, ["new"] = true, ["+"] = true, ["this"] = true, ["=="] = true, ["instanceof"] = true, ["/"] = true, ["case"] = true, ["debugger"] = true, ["var"] = true, ["end"] = true, ["not"] = true, ["until"] = true, ["%"] = true, ["break"] = true, ["elseif"] = true, ["<="] = true, ["repeat"] = true, ["<"] = true, [">="] = true, [">"] = true, ["switch"] = true, ["if"] = true, ["and"] = true, ["catch"] = true, ["local"] = true, ["continue"] = true, ["false"] = true, ["or"] = true, ["with"] = true, ["in"] = true, ["for"] = true, ["function"] = true, ["then"] = true, ["default"] = true, ["nil"] = true, ["-"] = true}
+local reserved = {["with"] = true, ["elseif"] = true, ["do"] = true, ["=="] = true, ["local"] = true, ["for"] = true, ["function"] = true, ["this"] = true, ["/"] = true, ["debugger"] = true, ["else"] = true, [">"] = true, ["delete"] = true, ["throw"] = true, ["switch"] = true, ["until"] = true, ["not"] = true, ["<"] = true, ["*"] = true, ["%"] = true, ["instanceof"] = true, ["end"] = true, [">="] = true, ["and"] = true, ["<="] = true, ["false"] = true, ["finally"] = true, ["default"] = true, ["return"] = true, ["in"] = true, ["break"] = true, ["or"] = true, ["var"] = true, ["repeat"] = true, ["try"] = true, ["true"] = true, ["case"] = true, ["void"] = true, ["nil"] = true, ["while"] = true, ["typeof"] = true, ["new"] = true, ["catch"] = true, ["then"] = true, ["="] = true, ["if"] = true, ["+"] = true, ["continue"] = true, ["-"] = true}
 function reserved63(x)
   return(reserved[x])
 end
@@ -413,8 +413,8 @@ _x58.lua = "not "
 __x57["not"] = _x58
 local __x59 = {}
 __x59["/"] = true
-__x59["*"] = true
 __x59["%"] = true
+__x59["*"] = true
 local __x60 = {}
 __x60["+"] = true
 __x60["-"] = true
@@ -424,10 +424,10 @@ _x62.js = "+"
 _x62.lua = ".."
 __x61.cat = _x62
 local __x63 = {}
-__x63[">"] = true
-__x63["<="] = true
-__x63["<"] = true
 __x63[">="] = true
+__x63["<"] = true
+__x63["<="] = true
+__x63[">"] = true
 local __x64 = {}
 local _x65 = {}
 _x65.js = "==="
@@ -591,9 +591,9 @@ local function compile_special(form, stmt63)
   local x = _id5[1]
   local args = cut(_id5, 1)
   local _id6 = getenv(x)
-  local special = _id6.special
-  local stmt = _id6.stmt
   local self_tr63 = _id6.tr
+  local stmt = _id6.stmt
+  local special = _id6.special
   local tr = terminator(stmt63 and not self_tr63)
   return(apply(special, args) .. tr)
 end
@@ -964,14 +964,23 @@ end
 local function run_file(path)
   return(run(read_file(path)))
 end
-local function compile_file(path)
-  local s = reader.stream(read_file(path))
+local function expand_string(str)
+  local s = reader.stream(str)
   local body = reader["read-all"](s)
-  local form = expand(join({"do"}, body))
+  return(expand(join({"do"}, body)))
+end
+local function compile_string(str)
+  local form = expand_string(str)
   return(compile(form, {_stash = true, stmt = true}))
+end
+local function compile_file(path)
+  return(compile_string(read_file(path)))
 end
 function load(path)
   return(run(compile_file(path)))
+end
+function load_string(str)
+  return(run(compile_string(str)))
 end
 setenv("do", {_stash = true, special = function (...)
   local forms = unstash({...})
@@ -985,7 +994,7 @@ setenv("do", {_stash = true, special = function (...)
     _i12 = _i12 + 1
   end
   return(s)
-end, stmt = true, tr = true})
+end, tr = true, stmt = true})
 setenv("%if", {_stash = true, special = function (cond, cons, alt)
   local _cond1 = compile(cond)
   indent_level = indent_level + 1
@@ -1019,7 +1028,7 @@ setenv("%if", {_stash = true, special = function (cond, cons, alt)
   else
     return(s .. "\n")
   end
-end, stmt = true, tr = true})
+end, tr = true, stmt = true})
 setenv("while", {_stash = true, special = function (cond, form)
   local _cond3 = compile(cond)
   indent_level = indent_level + 1
@@ -1032,7 +1041,7 @@ setenv("while", {_stash = true, special = function (cond, form)
   else
     return(ind .. "while " .. _cond3 .. " do\n" .. body .. ind .. "end\n")
   end
-end, stmt = true, tr = true})
+end, tr = true, stmt = true})
 setenv("%for", {_stash = true, special = function (t, k, form)
   local _t1 = compile(t)
   local ind = indentation()
@@ -1045,7 +1054,7 @@ setenv("%for", {_stash = true, special = function (t, k, form)
   else
     return(ind .. "for (" .. k .. " in " .. _t1 .. ") {\n" .. body .. ind .. "}\n")
   end
-end, stmt = true, tr = true})
+end, tr = true, stmt = true})
 setenv("%try", {_stash = true, special = function (form)
   local e = unique("e")
   local ind = indentation()
@@ -1059,7 +1068,7 @@ setenv("%try", {_stash = true, special = function (form)
   indent_level = indent_level - 1
   local h = _x130
   return(ind .. "try {\n" .. body .. ind .. "}\n" .. ind .. "catch (" .. e .. ") {\n" .. h .. ind .. "}\n")
-end, stmt = true, tr = true})
+end, tr = true, stmt = true})
 setenv("%delete", {_stash = true, special = function (place)
   return(indentation() .. "delete " .. compile(place))
 end, stmt = true})
@@ -1076,7 +1085,7 @@ setenv("%global-function", {_stash = true, special = function (name, args, body)
   else
     return(compile({"set", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
-end, stmt = true, tr = true})
+end, tr = true, stmt = true})
 setenv("%local-function", {_stash = true, special = function (name, args, body)
   if target == "lua" then
     local x = compile_function(args, body, {_stash = true, prefix = "local", name = name})
@@ -1084,7 +1093,7 @@ setenv("%local-function", {_stash = true, special = function (name, args, body)
   else
     return(compile({"%local", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
-end, stmt = true, tr = true})
+end, tr = true, stmt = true})
 setenv("return", {_stash = true, special = function (x)
   local _e27
   if nil63(x) then
@@ -1208,4 +1217,4 @@ setenv("%object", {_stash = true, special = function (...)
   end
   return(s .. "}")
 end})
-return({load = load, compile = compile, expand = expand, ["run-file"] = run_file, eval = eval, ["compile-file"] = compile_file})
+return({["compile-string"] = compile_string, ["expand-string"] = expand_string, ["compile-file"] = compile_file, run = run, expand = expand, load = load, ["run-file"] = run_file, compile = compile, eval = eval, ["load-string"] = load_string})

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -359,7 +359,7 @@ function indentation()
   end
   return(s)
 end
-local reserved = {["%"] = true, ["continue"] = true, ["true"] = true, ["do"] = true, ["return"] = true, ["break"] = true, ["+"] = true, [">"] = true, ["in"] = true, ["<"] = true, ["/"] = true, ["and"] = true, ["-"] = true, ["=="] = true, ["end"] = true, ["debugger"] = true, ["else"] = true, ["try"] = true, ["until"] = true, ["finally"] = true, ["instanceof"] = true, ["*"] = true, ["catch"] = true, ["elseif"] = true, ["this"] = true, ["or"] = true, ["while"] = true, ["not"] = true, ["default"] = true, ["void"] = true, ["new"] = true, ["case"] = true, ["then"] = true, ["nil"] = true, ["local"] = true, [">="] = true, ["false"] = true, ["delete"] = true, ["<="] = true, ["with"] = true, ["repeat"] = true, ["var"] = true, ["switch"] = true, ["typeof"] = true, ["function"] = true, ["="] = true, ["throw"] = true, ["for"] = true, ["if"] = true}
+local reserved = {["<="] = true, ["function"] = true, ["for"] = true, ["switch"] = true, ["continue"] = true, ["else"] = true, ["var"] = true, ["local"] = true, ["default"] = true, [">="] = true, ["void"] = true, ["="] = true, ["case"] = true, ["/"] = true, ["this"] = true, ["-"] = true, ["break"] = true, ["do"] = true, ["*"] = true, ["new"] = true, ["debugger"] = true, ["typeof"] = true, ["repeat"] = true, ["delete"] = true, ["throw"] = true, ["in"] = true, ["or"] = true, ["while"] = true, ["false"] = true, ["end"] = true, ["then"] = true, ["finally"] = true, ["not"] = true, ["until"] = true, ["elseif"] = true, ["nil"] = true, ["if"] = true, ["return"] = true, ["=="] = true, ["<"] = true, [">"] = true, ["try"] = true, ["%"] = true, ["with"] = true, ["instanceof"] = true, ["catch"] = true, ["true"] = true, ["+"] = true, ["and"] = true}
 function reserved63(x)
   return(reserved[x])
 end
@@ -408,40 +408,40 @@ function mapo(f, t)
 end
 local __x57 = {}
 local _x58 = {}
-_x58.lua = "not "
 _x58.js = "!"
+_x58.lua = "not "
 __x57["not"] = _x58
 local __x59 = {}
 __x59["%"] = true
-__x59["/"] = true
 __x59["*"] = true
+__x59["/"] = true
 local __x60 = {}
-__x60["-"] = true
 __x60["+"] = true
+__x60["-"] = true
 local __x61 = {}
 local _x62 = {}
-_x62.lua = ".."
 _x62.js = "+"
+_x62.lua = ".."
 __x61.cat = _x62
 local __x63 = {}
-__x63[">="] = true
 __x63["<="] = true
-__x63["<"] = true
 __x63[">"] = true
+__x63[">="] = true
+__x63["<"] = true
 local __x64 = {}
 local _x65 = {}
-_x65.lua = "=="
 _x65.js = "==="
+_x65.lua = "=="
 __x64["="] = _x65
 local __x66 = {}
 local _x67 = {}
-_x67.lua = "and"
 _x67.js = "&&"
+_x67.lua = "and"
 __x66["and"] = _x67
 local __x68 = {}
 local _x69 = {}
-_x69.lua = "or"
 _x69.js = "||"
+_x69.lua = "or"
 __x68["or"] = _x69
 local infix = {__x57, __x59, __x60, __x61, __x63, __x64, __x66, __x68}
 local function unary63(form)
@@ -592,8 +592,8 @@ local function compile_special(form, stmt63)
   local args = cut(_id5, 1)
   local _id6 = getenv(x)
   local self_tr63 = _id6.tr
-  local stmt = _id6.stmt
   local special = _id6.special
+  local stmt = _id6.stmt
   local tr = terminator(stmt63 and not self_tr63)
   return(apply(special, args) .. tr)
 end
@@ -982,7 +982,7 @@ end
 function load_string(str)
   return(run(compile_string(str)))
 end
-setenv("do", {_stash = true, tr = true, stmt = true, special = function (...)
+setenv("do", {_stash = true, tr = true, special = function (...)
   local forms = unstash({...})
   local s = ""
   local _x112 = forms
@@ -994,8 +994,8 @@ setenv("do", {_stash = true, tr = true, stmt = true, special = function (...)
     _i12 = _i12 + 1
   end
   return(s)
-end})
-setenv("%if", {_stash = true, tr = true, stmt = true, special = function (cond, cons, alt)
+end, stmt = true})
+setenv("%if", {_stash = true, tr = true, special = function (cond, cons, alt)
   local _cond1 = compile(cond)
   indent_level = indent_level + 1
   local _x115 = compile(cons, {_stash = true, stmt = true})
@@ -1028,8 +1028,8 @@ setenv("%if", {_stash = true, tr = true, stmt = true, special = function (cond, 
   else
     return(s .. "\n")
   end
-end})
-setenv("while", {_stash = true, tr = true, stmt = true, special = function (cond, form)
+end, stmt = true})
+setenv("while", {_stash = true, tr = true, special = function (cond, form)
   local _cond3 = compile(cond)
   indent_level = indent_level + 1
   local _x118 = compile(form, {_stash = true, stmt = true})
@@ -1041,8 +1041,8 @@ setenv("while", {_stash = true, tr = true, stmt = true, special = function (cond
   else
     return(ind .. "while " .. _cond3 .. " do\n" .. body .. ind .. "end\n")
   end
-end})
-setenv("%for", {_stash = true, tr = true, stmt = true, special = function (t, k, form)
+end, stmt = true})
+setenv("%for", {_stash = true, tr = true, special = function (t, k, form)
   local _t1 = compile(t)
   local ind = indentation()
   indent_level = indent_level + 1
@@ -1054,8 +1054,8 @@ setenv("%for", {_stash = true, tr = true, stmt = true, special = function (t, k,
   else
     return(ind .. "for (" .. k .. " in " .. _t1 .. ") {\n" .. body .. ind .. "}\n")
   end
-end})
-setenv("%try", {_stash = true, tr = true, stmt = true, special = function (form)
+end, stmt = true})
+setenv("%try", {_stash = true, tr = true, special = function (form)
   local e = unique("e")
   local ind = indentation()
   indent_level = indent_level + 1
@@ -1068,7 +1068,7 @@ setenv("%try", {_stash = true, tr = true, stmt = true, special = function (form)
   indent_level = indent_level - 1
   local h = _x130
   return(ind .. "try {\n" .. body .. ind .. "}\n" .. ind .. "catch (" .. e .. ") {\n" .. h .. ind .. "}\n")
-end})
+end, stmt = true})
 setenv("%delete", {_stash = true, special = function (place)
   return(indentation() .. "delete " .. compile(place))
 end, stmt = true})
@@ -1078,22 +1078,22 @@ end, stmt = true})
 setenv("%function", {_stash = true, special = function (args, body)
   return(compile_function(args, body))
 end})
-setenv("%global-function", {_stash = true, tr = true, stmt = true, special = function (name, args, body)
+setenv("%global-function", {_stash = true, tr = true, special = function (name, args, body)
   if target == "lua" then
     local x = compile_function(args, body, {_stash = true, name = name})
     return(indentation() .. x)
   else
     return(compile({"set", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
-end})
-setenv("%local-function", {_stash = true, tr = true, stmt = true, special = function (name, args, body)
+end, stmt = true})
+setenv("%local-function", {_stash = true, tr = true, special = function (name, args, body)
   if target == "lua" then
     local x = compile_function(args, body, {_stash = true, name = name, prefix = "local"})
     return(indentation() .. x)
   else
     return(compile({"%local", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
-end})
+end, stmt = true})
 setenv("return", {_stash = true, special = function (x)
   local _e27
   if nil63(x) then
@@ -1217,4 +1217,4 @@ setenv("%object", {_stash = true, special = function (...)
   end
   return(s .. "}")
 end})
-return({["compile-string"] = compile_string, expand = expand, ["expand-string"] = expand_string, eval = eval, ["compile-file"] = compile_file, ["load-string"] = load_string, load = load, compile = compile, run = run, ["run-file"] = run_file})
+return({eval = eval, run = run, ["compile-string"] = compile_string, ["compile-file"] = compile_file, compile = compile, ["run-file"] = run_file, load = load, expand = expand, ["expand-string"] = expand_string, ["load-string"] = load_string})

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -359,7 +359,7 @@ function indentation()
   end
   return(s)
 end
-local reserved = {["with"] = true, ["elseif"] = true, ["do"] = true, ["=="] = true, ["local"] = true, ["for"] = true, ["function"] = true, ["this"] = true, ["/"] = true, ["debugger"] = true, ["else"] = true, [">"] = true, ["delete"] = true, ["throw"] = true, ["switch"] = true, ["until"] = true, ["not"] = true, ["<"] = true, ["*"] = true, ["%"] = true, ["instanceof"] = true, ["end"] = true, [">="] = true, ["and"] = true, ["<="] = true, ["false"] = true, ["finally"] = true, ["default"] = true, ["return"] = true, ["in"] = true, ["break"] = true, ["or"] = true, ["var"] = true, ["repeat"] = true, ["try"] = true, ["true"] = true, ["case"] = true, ["void"] = true, ["nil"] = true, ["while"] = true, ["typeof"] = true, ["new"] = true, ["catch"] = true, ["then"] = true, ["="] = true, ["if"] = true, ["+"] = true, ["continue"] = true, ["-"] = true}
+local reserved = {["%"] = true, ["continue"] = true, ["true"] = true, ["do"] = true, ["return"] = true, ["break"] = true, ["+"] = true, [">"] = true, ["in"] = true, ["<"] = true, ["/"] = true, ["and"] = true, ["-"] = true, ["=="] = true, ["end"] = true, ["debugger"] = true, ["else"] = true, ["try"] = true, ["until"] = true, ["finally"] = true, ["instanceof"] = true, ["*"] = true, ["catch"] = true, ["elseif"] = true, ["this"] = true, ["or"] = true, ["while"] = true, ["not"] = true, ["default"] = true, ["void"] = true, ["new"] = true, ["case"] = true, ["then"] = true, ["nil"] = true, ["local"] = true, [">="] = true, ["false"] = true, ["delete"] = true, ["<="] = true, ["with"] = true, ["repeat"] = true, ["var"] = true, ["switch"] = true, ["typeof"] = true, ["function"] = true, ["="] = true, ["throw"] = true, ["for"] = true, ["if"] = true}
 function reserved63(x)
   return(reserved[x])
 end
@@ -408,40 +408,40 @@ function mapo(f, t)
 end
 local __x57 = {}
 local _x58 = {}
-_x58.js = "!"
 _x58.lua = "not "
+_x58.js = "!"
 __x57["not"] = _x58
 local __x59 = {}
-__x59["/"] = true
 __x59["%"] = true
+__x59["/"] = true
 __x59["*"] = true
 local __x60 = {}
-__x60["+"] = true
 __x60["-"] = true
+__x60["+"] = true
 local __x61 = {}
 local _x62 = {}
-_x62.js = "+"
 _x62.lua = ".."
+_x62.js = "+"
 __x61.cat = _x62
 local __x63 = {}
 __x63[">="] = true
-__x63["<"] = true
 __x63["<="] = true
+__x63["<"] = true
 __x63[">"] = true
 local __x64 = {}
 local _x65 = {}
-_x65.js = "==="
 _x65.lua = "=="
+_x65.js = "==="
 __x64["="] = _x65
 local __x66 = {}
 local _x67 = {}
-_x67.js = "&&"
 _x67.lua = "and"
+_x67.js = "&&"
 __x66["and"] = _x67
 local __x68 = {}
 local _x69 = {}
-_x69.js = "||"
 _x69.lua = "or"
+_x69.js = "||"
 __x68["or"] = _x69
 local infix = {__x57, __x59, __x60, __x61, __x63, __x64, __x66, __x68}
 local function unary63(form)
@@ -650,8 +650,8 @@ end
 function compile_function(args, body, ...)
   local _r58 = unstash({...})
   local _id12 = _r58
-  local prefix = _id12.prefix
   local name = _id12.name
+  local prefix = _id12.prefix
   local _e17
   if name then
     _e17 = compile(name)
@@ -982,7 +982,7 @@ end
 function load_string(str)
   return(run(compile_string(str)))
 end
-setenv("do", {_stash = true, special = function (...)
+setenv("do", {_stash = true, tr = true, stmt = true, special = function (...)
   local forms = unstash({...})
   local s = ""
   local _x112 = forms
@@ -994,8 +994,8 @@ setenv("do", {_stash = true, special = function (...)
     _i12 = _i12 + 1
   end
   return(s)
-end, tr = true, stmt = true})
-setenv("%if", {_stash = true, special = function (cond, cons, alt)
+end})
+setenv("%if", {_stash = true, tr = true, stmt = true, special = function (cond, cons, alt)
   local _cond1 = compile(cond)
   indent_level = indent_level + 1
   local _x115 = compile(cons, {_stash = true, stmt = true})
@@ -1028,8 +1028,8 @@ setenv("%if", {_stash = true, special = function (cond, cons, alt)
   else
     return(s .. "\n")
   end
-end, tr = true, stmt = true})
-setenv("while", {_stash = true, special = function (cond, form)
+end})
+setenv("while", {_stash = true, tr = true, stmt = true, special = function (cond, form)
   local _cond3 = compile(cond)
   indent_level = indent_level + 1
   local _x118 = compile(form, {_stash = true, stmt = true})
@@ -1041,8 +1041,8 @@ setenv("while", {_stash = true, special = function (cond, form)
   else
     return(ind .. "while " .. _cond3 .. " do\n" .. body .. ind .. "end\n")
   end
-end, tr = true, stmt = true})
-setenv("%for", {_stash = true, special = function (t, k, form)
+end})
+setenv("%for", {_stash = true, tr = true, stmt = true, special = function (t, k, form)
   local _t1 = compile(t)
   local ind = indentation()
   indent_level = indent_level + 1
@@ -1054,8 +1054,8 @@ setenv("%for", {_stash = true, special = function (t, k, form)
   else
     return(ind .. "for (" .. k .. " in " .. _t1 .. ") {\n" .. body .. ind .. "}\n")
   end
-end, tr = true, stmt = true})
-setenv("%try", {_stash = true, special = function (form)
+end})
+setenv("%try", {_stash = true, tr = true, stmt = true, special = function (form)
   local e = unique("e")
   local ind = indentation()
   indent_level = indent_level + 1
@@ -1068,7 +1068,7 @@ setenv("%try", {_stash = true, special = function (form)
   indent_level = indent_level - 1
   local h = _x130
   return(ind .. "try {\n" .. body .. ind .. "}\n" .. ind .. "catch (" .. e .. ") {\n" .. h .. ind .. "}\n")
-end, tr = true, stmt = true})
+end})
 setenv("%delete", {_stash = true, special = function (place)
   return(indentation() .. "delete " .. compile(place))
 end, stmt = true})
@@ -1078,22 +1078,22 @@ end, stmt = true})
 setenv("%function", {_stash = true, special = function (args, body)
   return(compile_function(args, body))
 end})
-setenv("%global-function", {_stash = true, special = function (name, args, body)
+setenv("%global-function", {_stash = true, tr = true, stmt = true, special = function (name, args, body)
   if target == "lua" then
     local x = compile_function(args, body, {_stash = true, name = name})
     return(indentation() .. x)
   else
     return(compile({"set", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
-end, tr = true, stmt = true})
-setenv("%local-function", {_stash = true, special = function (name, args, body)
+end})
+setenv("%local-function", {_stash = true, tr = true, stmt = true, special = function (name, args, body)
   if target == "lua" then
-    local x = compile_function(args, body, {_stash = true, prefix = "local", name = name})
+    local x = compile_function(args, body, {_stash = true, name = name, prefix = "local"})
     return(indentation() .. x)
   else
     return(compile({"%local", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
-end, tr = true, stmt = true})
+end})
 setenv("return", {_stash = true, special = function (x)
   local _e27
   if nil63(x) then
@@ -1217,4 +1217,4 @@ setenv("%object", {_stash = true, special = function (...)
   end
   return(s .. "}")
 end})
-return({["compile-string"] = compile_string, ["expand-string"] = expand_string, ["compile-file"] = compile_file, run = run, expand = expand, load = load, ["run-file"] = run_file, compile = compile, eval = eval, ["load-string"] = load_string})
+return({["compile-string"] = compile_string, expand = expand, ["expand-string"] = expand_string, eval = eval, ["compile-file"] = compile_file, ["load-string"] = load_string, load = load, compile = compile, run = run, ["run-file"] = run_file})

--- a/bin/lumen
+++ b/bin/lumen
@@ -25,10 +25,10 @@ fi
 case $HOST in
     node*)
         CODE=lumen.js
-        export NODE_PATH="$HOME:$DIR/lib";;
+        export NODE_PATH="$NODE_PATH:$HOME:$DIR/lib";;
     *)
         CODE=lumen.lua
-        export LUA_PATH="$HOME/?.lua;$DIR/lib/?.lua;;";;
+        export LUA_PATH="$LUA_PATH;$HOME/?.lua;$DIR/lib/?.lua;;";;
 esac
 
 export USER_HOME="$USR"

--- a/bin/lumen
+++ b/bin/lumen
@@ -2,6 +2,7 @@
 
 DIR="`pwd`"
 cd "`dirname "$0"`"
+USR="$HOME"
 HOME="`pwd`"
 cd "$DIR"
 
@@ -29,5 +30,11 @@ case $HOST in
         CODE=lumen.lua
         export LUA_PATH="$HOME/?.lua;$DIR/lib/?.lua;;";;
 esac
+
+export USER_HOME="$USR"
+export LUMEN_DIR="$DIR"
+cd "$HOME/.."
+export LUMEN_HOME="`pwd`"
+cd "$DIR"
 
 exec $HOST "$HOME/$CODE" "$@"

--- a/bin/lumen
+++ b/bin/lumen
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-DIR=`pwd`
-cd "`dirname $0`"
-HOME=`pwd`
-cd $DIR
+DIR="`pwd`"
+cd "`dirname "$0"`"
+HOME="`pwd`"
+cd "$DIR"
 
 if [ ! -z $LUMEN_HOST ]
 then
@@ -24,10 +24,10 @@ fi
 case $HOST in
     node*)
         CODE=lumen.js
-        export NODE_PATH=$HOME:$DIR/lib;;
+        export NODE_PATH="$HOME:$DIR/lib";;
     *)
         CODE=lumen.lua
         export LUA_PATH="$HOME/?.lua;$DIR/lib/?.lua;;";;
 esac
 
-exec $HOST $HOME/$CODE "$@"
+exec $HOST "$HOME/$CODE" "$@"

--- a/bin/lumen
+++ b/bin/lumen
@@ -4,6 +4,7 @@ DIR="`pwd`"
 cd "`dirname "$0"`"
 USR="$HOME"
 HOME="`pwd`"
+PLATFORM="`python -c 'import sys; sys.stdout.write(sys.platform)'`"
 cd "$DIR"
 
 if [ ! -z $LUMEN_HOST ]
@@ -25,10 +26,10 @@ fi
 case $HOST in
     node*)
         CODE=lumen.js
-        export NODE_PATH="$NODE_PATH:$HOME:$DIR/lib";;
+        export NODE_PATH="$NODE_PATH:$HOME:$DIR/lib:$DIR/lib/$PLATFORM";;
     *)
         CODE=lumen.lua
-        export LUA_PATH="$LUA_PATH;$HOME/?.lua;$DIR/lib/?.lua;;";;
+        export LUA_PATH="$LUA_PATH;$HOME/?.lua;$DIR/lib/?.lua;$DIR/lib/$PLATFORM/?.lua;;";;
 esac
 
 export USER_HOME="$USR"

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -664,6 +664,7 @@ file_exists63 = function (path) {
   return(fs.existsSync(path, "utf8"));
 };
 path_sep = require("path").sep;
+windows63 = path_sep === "\\";
 print = function (x) {
   return(console.log(x));
 };

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -663,6 +663,9 @@ write_file = function (path, data) {
 file_exists63 = function (path) {
   return(fs.existsSync(path, "utf8"));
 };
+read_env = function (varname) {
+  return(process.env[varname]);
+};
 path_sep = require("path").sep;
 windows63 = path_sep === "\\";
 print = function (x) {

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -668,6 +668,22 @@ read_env = function (varname) {
 };
 path_sep = require("path").sep;
 windows63 = path_sep === "\\";
+user_path = function (path) {
+  var base = read_env("USER_HOME");
+  if (is63(path)) {
+    return(base + path_sep + path);
+  } else {
+    return(base);
+  }
+};
+lumen_path = function (path) {
+  var base = read_env("LUMEN_HOME");
+  if (is63(path)) {
+    return(base + path_sep + path);
+  } else {
+    return(base);
+  }
+};
 print = function (x) {
   return(console.log(x));
 };
@@ -881,7 +897,7 @@ setenv("define-global", {_stash: true, macro: function (name, x) {
   var _r35 = unstash(Array.prototype.slice.call(arguments, 2));
   var _id29 = _r35;
   var body = cut(_id29, 0);
-  setenv(name, {_stash: true, toplevel: true, variable: true});
+  setenv(name, {_stash: true, variable: true, toplevel: true});
   if (some63(body)) {
     return(join(["%global-function", name], bind42(x, body)));
   } else {

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -660,6 +660,9 @@ read_file = function (path) {
 write_file = function (path, data) {
   return(fs.writeFileSync(path, data, "utf8"));
 };
+file_exists63 = function (path) {
+  return(fs.existsSync(path, "utf8"));
+};
 print = function (x) {
   return(console.log(x));
 };
@@ -873,7 +876,7 @@ setenv("define-global", {_stash: true, macro: function (name, x) {
   var _r35 = unstash(Array.prototype.slice.call(arguments, 2));
   var _id29 = _r35;
   var body = cut(_id29, 0);
-  setenv(name, {_stash: true, toplevel: true, variable: true});
+  setenv(name, {_stash: true, variable: true, toplevel: true});
   if (some63(body)) {
     return(join(["%global-function", name], bind42(x, body)));
   } else {

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -897,7 +897,7 @@ setenv("define-global", {_stash: true, macro: function (name, x) {
   var _r35 = unstash(Array.prototype.slice.call(arguments, 2));
   var _id29 = _r35;
   var body = cut(_id29, 0);
-  setenv(name, {_stash: true, variable: true, toplevel: true});
+  setenv(name, {_stash: true, toplevel: true, variable: true});
   if (some63(body)) {
     return(join(["%global-function", name], bind42(x, body)));
   } else {

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -663,6 +663,7 @@ write_file = function (path, data) {
 file_exists63 = function (path) {
   return(fs.existsSync(path, "utf8"));
 };
+path_sep = require("path").sep;
 print = function (x) {
   return(console.log(x));
 };
@@ -876,7 +877,7 @@ setenv("define-global", {_stash: true, macro: function (name, x) {
   var _r35 = unstash(Array.prototype.slice.call(arguments, 2));
   var _id29 = _r35;
   var body = cut(_id29, 0);
-  setenv(name, {_stash: true, variable: true, toplevel: true});
+  setenv(name, {_stash: true, toplevel: true, variable: true});
   if (some63(body)) {
     return(join(["%global-function", name], bind42(x, body)));
   } else {

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -590,6 +590,7 @@ function file_exists63(path)
   end))
 end
 path_sep = char(_G.package.config, 0)
+windows63 = path_sep == "\\"
 function write(x)
   return(io.write(x))
 end
@@ -792,7 +793,7 @@ setenv("define-global", {_stash = true, macro = function (name, x, ...)
   local _r35 = unstash({...})
   local _id29 = _r35
   local body = cut(_id29, 0)
-  setenv(name, {_stash = true, toplevel = true, variable = true})
+  setenv(name, {_stash = true, variable = true, toplevel = true})
   if some63(body) then
     return(join({"%global-function", name}, bind42(x, body)))
   else

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -558,26 +558,35 @@ function setenv(k, ...)
     return(frame[k])
   end
 end
-local function call_with_file(file, f)
-  if is63(file) then
-    local _e,_x12 = xpcall(function ()
-      return(f(file))
-    end, _37message_handler)
-    local _id2 = {_e, _x12}
-    local ok = _id2[1]
-    local s = _id2[2]
-    file.close(file)
-    return(s)
+local function call_with_file(f, call)
+  local _e,_x12 = xpcall(function ()
+    return(call(f))
+  end, _37message_handler)
+  local _id2 = {_e, _x12}
+  local ok = _id2[1]
+  local s = _id2[2]
+  if is63(f) then
+    f.close(f)
   end
+  return(s)
 end
 function read_file(path)
   return(call_with_file(io.open(path), function (f)
-    return(f.read(f, "*a"))
+    if is63(f) then
+      return(f.read(f, "*a"))
+    end
   end))
 end
 function write_file(path, data)
   return(call_with_file(io.open(path, "w"), function (f)
-    return(f.write(f, data))
+    if is63(f) then
+      return(f.write(f, data))
+    end
+  end))
+end
+function file_exists63(path)
+  return(call_with_file(io.open(path), function (f)
+    return(is63(f))
   end))
 end
 function write(x)
@@ -782,7 +791,7 @@ setenv("define-global", {_stash = true, macro = function (name, x, ...)
   local _r35 = unstash({...})
   local _id29 = _r35
   local body = cut(_id29, 0)
-  setenv(name, {_stash = true, variable = true, toplevel = true})
+  setenv(name, {_stash = true, toplevel = true, variable = true})
   if some63(body) then
     return(join({"%global-function", name}, bind42(x, body)))
   else

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -61,21 +61,21 @@ end
 function cut(x, from, upto)
   local l = {}
   local j = 0
-  local _e
-  if nil63(from) or from < 0 then
-    _e = 0
-  else
-    _e = from
-  end
-  local i = _e
-  local n = _35(x)
   local _e1
-  if nil63(upto) or upto > n then
-    _e1 = n
+  if nil63(from) or from < 0 then
+    _e1 = 0
   else
-    _e1 = upto
+    _e1 = from
   end
-  local _upto = _e1
+  local i = _e1
+  local n = _35(x)
+  local _e2
+  if nil63(upto) or upto > n then
+    _e2 = n
+  else
+    _e2 = upto
+  end
+  local _upto = _e2
   while i < _upto do
     l[j + 1] = x[i + 1]
     i = i + 1
@@ -116,11 +116,11 @@ function char(s, n)
   return(clip(s, n, n + 1))
 end
 function code(s, n)
-  local _e2
+  local _e3
   if n then
-    _e2 = n + 1
+    _e3 = n + 1
   end
-  return(sbyte(s, _e2))
+  return(sbyte(s, _e3))
 end
 function string_literal63(x)
   return(string63(x) and char(x, 0) == "\"")
@@ -326,11 +326,11 @@ function unstash(args)
   end
 end
 function search(s, pattern, start)
-  local _e3
+  local _e4
   if start then
-    _e3 = start + 1
+    _e4 = start + 1
   end
-  local _start = _e3
+  local _start = _e4
   local i = sfind(s, pattern, _start, true)
   return(i and i - 1)
 end
@@ -430,25 +430,25 @@ function escape(s)
   local i = 0
   while i < _35(s) do
     local c = char(s, i)
-    local _e4
+    local _e5
     if c == "\n" then
-      _e4 = "\\n"
+      _e5 = "\\n"
     else
-      local _e5
+      local _e6
       if c == "\"" then
-        _e5 = "\\\""
+        _e6 = "\\\""
       else
-        local _e6
+        local _e7
         if c == "\\" then
-          _e6 = "\\\\"
+          _e7 = "\\\\"
         else
-          _e6 = c
+          _e7 = c
         end
-        _e5 = _e6
+        _e6 = _e7
       end
-      _e4 = _e5
+      _e5 = _e6
     end
-    local c1 = _e4
+    local c1 = _e5
     s1 = s1 .. c1
     i = i + 1
   end
@@ -540,13 +540,13 @@ function setenv(k, ...)
   local _id1 = _r66
   local _keys = cut(_id1, 0)
   if string63(k) then
-    local _e7
+    local _e8
     if _keys.toplevel then
-      _e7 = hd(environment)
+      _e8 = hd(environment)
     else
-      _e7 = last(environment)
+      _e8 = last(environment)
     end
-    local frame = _e7
+    local frame = _e8
     local entry = frame[k] or {}
     local _o12 = _keys
     local _k = nil
@@ -558,13 +558,27 @@ function setenv(k, ...)
     return(frame[k])
   end
 end
+local function call_with_file(file, f)
+  if is63(file) then
+    local _e,_x12 = xpcall(function ()
+      return(f(file))
+    end, _37message_handler)
+    local _id2 = {_e, _x12}
+    local ok = _id2[1]
+    local s = _id2[2]
+    file.close(file)
+    return(s)
+  end
+end
 function read_file(path)
-  local f = io.open(path)
-  return(f.read(f, "*a"))
+  return(call_with_file(io.open(path), function (f)
+    return(f.read(f, "*a"))
+  end))
 end
 function write_file(path, data)
-  local f = io.open(path, "w")
-  return(f.write(f, data))
+  return(call_with_file(io.open(path, "w"), function (f)
+    return(f.write(f, data))
+  end))
 end
 function write(x)
   return(io.write(x))
@@ -768,7 +782,7 @@ setenv("define-global", {_stash = true, macro = function (name, x, ...)
   local _r35 = unstash({...})
   local _id29 = _r35
   local body = cut(_id29, 0)
-  setenv(name, {_stash = true, toplevel = true, variable = true})
+  setenv(name, {_stash = true, variable = true, toplevel = true})
   if some63(body) then
     return(join({"%global-function", name}, bind42(x, body)))
   else

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -589,6 +589,7 @@ function file_exists63(path)
     return(is63(f))
   end))
 end
+path_sep = char(_G.package.config, 0)
 function write(x)
   return(io.write(x))
 end

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -594,6 +594,22 @@ function read_env(varname)
 end
 path_sep = char(_G.package.config, 0)
 windows63 = path_sep == "\\"
+function user_path(path)
+  local base = read_env("USER_HOME")
+  if is63(path) then
+    return(base .. path_sep .. path)
+  else
+    return(base)
+  end
+end
+function lumen_path(path)
+  local base = read_env("LUMEN_HOME")
+  if is63(path) then
+    return(base .. path_sep .. path)
+  else
+    return(base)
+  end
+end
 function write(x)
   return(io.write(x))
 end
@@ -796,7 +812,7 @@ setenv("define-global", {_stash = true, macro = function (name, x, ...)
   local _r35 = unstash({...})
   local _id29 = _r35
   local body = cut(_id29, 0)
-  setenv(name, {_stash = true, toplevel = true, variable = true})
+  setenv(name, {_stash = true, variable = true, toplevel = true})
   if some63(body) then
     return(join({"%global-function", name}, bind42(x, body)))
   else

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -589,6 +589,9 @@ function file_exists63(path)
     return(is63(f))
   end))
 end
+function read_env(varname)
+  return(os.getenv(varname))
+end
 path_sep = char(_G.package.config, 0)
 windows63 = path_sep == "\\"
 function write(x)
@@ -793,7 +796,7 @@ setenv("define-global", {_stash = true, macro = function (name, x, ...)
   local _r35 = unstash({...})
   local _id29 = _r35
   local body = cut(_id29, 0)
-  setenv(name, {_stash = true, variable = true, toplevel = true})
+  setenv(name, {_stash = true, toplevel = true, variable = true})
   if some63(body) then
     return(join({"%global-function", name}, bind42(x, body)))
   else

--- a/bin/reader.js
+++ b/bin/reader.js
@@ -1,13 +1,13 @@
-var delimiters = {"\n": true, ";": true, ")": true, "(": true};
-var whitespace = {"\n": true, " ": true, "\t": true};
+var delimiters = {"(": true, ";": true, ")": true, "\n": true};
+var whitespace = {" ": true, "\t": true, "\n": true};
 var stream = function (str, more) {
-  return({more: more, string: str, pos: 0, len: _35(str)});
+  return({pos: 0, more: more, len: _35(str), string: str});
 };
 var peek_char = function (s) {
   var _id = s;
-  var string = _id.string;
-  var len = _id.len;
   var pos = _id.pos;
+  var len = _id.len;
+  var string = _id.string;
   if (pos < len) {
     return(char(string, pos));
   }
@@ -76,8 +76,8 @@ var flag63 = function (atom) {
 };
 var expected = function (s, c) {
   var _id1 = s;
-  var more = _id1.more;
   var pos = _id1.pos;
+  var more = _id1.more;
   var _id2 = more;
   var _e;
   if (_id2) {

--- a/bin/reader.js
+++ b/bin/reader.js
@@ -1,12 +1,12 @@
-var delimiters = {"\n": true, "(": true, ";": true, ")": true};
-var whitespace = {" ": true, "\t": true, "\n": true};
+var delimiters = {"(": true, "\n": true, ";": true, ")": true};
+var whitespace = {"\n": true, " ": true, "\t": true};
 var stream = function (str, more) {
-  return({len: _35(str), pos: 0, string: str, more: more});
+  return({pos: 0, more: more, len: _35(str), string: str});
 };
 var peek_char = function (s) {
   var _id = s;
-  var len = _id.len;
   var pos = _id.pos;
+  var len = _id.len;
   var string = _id.string;
   if (pos < len) {
     return(char(string, pos));

--- a/bin/reader.js
+++ b/bin/reader.js
@@ -1,13 +1,13 @@
-var delimiters = {"(": true, ";": true, ")": true, "\n": true};
-var whitespace = {" ": true, "\t": true, "\n": true};
+var delimiters = {")": true, "(": true, "\n": true, ";": true};
+var whitespace = {"\t": true, " ": true, "\n": true};
 var stream = function (str, more) {
-  return({pos: 0, more: more, len: _35(str), string: str});
+  return({string: str, pos: 0, more: more, len: _35(str)});
 };
 var peek_char = function (s) {
   var _id = s;
-  var pos = _id.pos;
-  var len = _id.len;
   var string = _id.string;
+  var len = _id.len;
+  var pos = _id.pos;
   if (pos < len) {
     return(char(string, pos));
   }
@@ -76,8 +76,8 @@ var flag63 = function (atom) {
 };
 var expected = function (s, c) {
   var _id1 = s;
-  var pos = _id1.pos;
   var more = _id1.more;
+  var pos = _id1.pos;
   var _id2 = more;
   var _e;
   if (_id2) {

--- a/bin/reader.js
+++ b/bin/reader.js
@@ -1,13 +1,13 @@
-var delimiters = {"\n": true, "(": true, ")": true, ";": true};
-var whitespace = {"\n": true, "\t": true, " ": true};
+var delimiters = {"\n": true, "(": true, ";": true, ")": true};
+var whitespace = {" ": true, "\t": true, "\n": true};
 var stream = function (str, more) {
-  return({more: more, string: str, pos: 0, len: _35(str)});
+  return({len: _35(str), pos: 0, string: str, more: more});
 };
 var peek_char = function (s) {
   var _id = s;
   var len = _id.len;
-  var string = _id.string;
   var pos = _id.pos;
+  var string = _id.string;
   if (pos < len) {
     return(char(string, pos));
   }
@@ -76,8 +76,8 @@ var flag63 = function (atom) {
 };
 var expected = function (s, c) {
   var _id1 = s;
-  var more = _id1.more;
   var pos = _id1.pos;
+  var more = _id1.more;
   var _id2 = more;
   var _e;
   if (_id2) {

--- a/bin/reader.js
+++ b/bin/reader.js
@@ -1,7 +1,7 @@
-var delimiters = {"\n": true, ")": true, "(": true, ";": true};
+var delimiters = {"\n": true, "(": true, ")": true, ";": true};
 var whitespace = {"\n": true, "\t": true, " ": true};
 var stream = function (str, more) {
-  return({pos: 0, more: more, string: str, len: _35(str)});
+  return({more: more, string: str, pos: 0, len: _35(str)});
 };
 var peek_char = function (s) {
   var _id = s;
@@ -76,8 +76,8 @@ var flag63 = function (atom) {
 };
 var expected = function (s, c) {
   var _id1 = s;
-  var pos = _id1.pos;
   var more = _id1.more;
+  var pos = _id1.pos;
   var _id2 = more;
   var _e;
   if (_id2) {

--- a/bin/reader.js
+++ b/bin/reader.js
@@ -1,5 +1,5 @@
-var delimiters = {"(": true, "\n": true, ";": true, ")": true};
-var whitespace = {"\n": true, " ": true, "\t": true};
+var delimiters = {")": true, "\n": true, ";": true, "(": true};
+var whitespace = {"\n": true, "\t": true, " ": true};
 var stream = function (str, more) {
   return({pos: 0, more: more, len: _35(str), string: str});
 };

--- a/bin/reader.js
+++ b/bin/reader.js
@@ -1,12 +1,12 @@
-var delimiters = {")": true, "(": true, "\n": true, ";": true};
-var whitespace = {"\t": true, " ": true, "\n": true};
+var delimiters = {"(": true, ")": true, ";": true, "\n": true};
+var whitespace = {"\n": true, " ": true, "\t": true};
 var stream = function (str, more) {
-  return({string: str, pos: 0, more: more, len: _35(str)});
+  return({more: more, len: _35(str), string: str, pos: 0});
 };
 var peek_char = function (s) {
   var _id = s;
-  var string = _id.string;
   var len = _id.len;
+  var string = _id.string;
   var pos = _id.pos;
   if (pos < len) {
     return(char(string, pos));
@@ -76,8 +76,8 @@ var flag63 = function (atom) {
 };
 var expected = function (s, c) {
   var _id1 = s;
-  var more = _id1.more;
   var pos = _id1.pos;
+  var more = _id1.more;
   var _id2 = more;
   var _e;
   if (_id2) {

--- a/bin/reader.js
+++ b/bin/reader.js
@@ -1,7 +1,7 @@
-var delimiters = {"(": true, ")": true, ";": true, "\n": true};
-var whitespace = {"\n": true, " ": true, "\t": true};
+var delimiters = {"\n": true, ")": true, "(": true, ";": true};
+var whitespace = {"\n": true, "\t": true, " ": true};
 var stream = function (str, more) {
-  return({more: more, len: _35(str), string: str, pos: 0});
+  return({pos: 0, more: more, string: str, len: _35(str)});
 };
 var peek_char = function (s) {
   var _id = s;

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -1,12 +1,12 @@
-local delimiters = {["\n"] = true, [";"] = true, ["("] = true, [")"] = true}
-local whitespace = {["\n"] = true, ["\t"] = true, [" "] = true}
+local delimiters = {["\n"] = true, [")"] = true, ["("] = true, [";"] = true}
+local whitespace = {[" "] = true, ["\n"] = true, ["\t"] = true}
 local function stream(str, more)
-  return({more = more, string = str, pos = 0, len = _35(str)})
+  return({len = _35(str), pos = 0, string = str, more = more})
 end
 local function peek_char(s)
   local _id = s
-  local string = _id.string
   local pos = _id.pos
+  local string = _id.string
   local len = _id.len
   if pos < len then
     return(char(string, pos))
@@ -76,8 +76,8 @@ local function flag63(atom)
 end
 local function expected(s, c)
   local _id1 = s
-  local more = _id1.more
   local pos = _id1.pos
+  local more = _id1.more
   local _id2 = more
   local _e
   if _id2 then
@@ -211,4 +211,4 @@ read_table[","] = function (s)
     return(wrap(s, "unquote"))
   end
 end
-return({["read-string"] = read_string, ["read-all"] = read_all, stream = stream, read = read})
+return({stream = stream, ["read-all"] = read_all, ["read-string"] = read_string, read = read})

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -1,12 +1,12 @@
-local delimiters = {[";"] = true, ["\n"] = true, [")"] = true, ["("] = true}
-local whitespace = {["\t"] = true, [" "] = true, ["\n"] = true}
+local delimiters = {[";"] = true, ["\n"] = true, ["("] = true, [")"] = true}
+local whitespace = {["\n"] = true, [" "] = true, ["\t"] = true}
 local function stream(str, more)
-  return({string = str, len = _35(str), more = more, pos = 0})
+  return({len = _35(str), more = more, string = str, pos = 0})
 end
 local function peek_char(s)
   local _id = s
-  local string = _id.string
   local len = _id.len
+  local string = _id.string
   local pos = _id.pos
   if pos < len then
     return(char(string, pos))
@@ -76,8 +76,8 @@ local function flag63(atom)
 end
 local function expected(s, c)
   local _id1 = s
-  local pos = _id1.pos
   local more = _id1.more
+  local pos = _id1.pos
   local _id2 = more
   local _e
   if _id2 then
@@ -211,4 +211,4 @@ read_table[","] = function (s)
     return(wrap(s, "unquote"))
   end
 end
-return({["read-all"] = read_all, read = read, stream = stream, ["read-string"] = read_string})
+return({["read-string"] = read_string, read = read, ["read-all"] = read_all, stream = stream})

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -1,13 +1,13 @@
-local delimiters = {[";"] = true, ["\n"] = true, [")"] = true, ["("] = true}
-local whitespace = {[" "] = true, ["\n"] = true, ["\t"] = true}
+local delimiters = {[";"] = true, ["("] = true, ["\n"] = true, [")"] = true}
+local whitespace = {["\n"] = true, ["\t"] = true, [" "] = true}
 local function stream(str, more)
-  return({string = str, pos = 0, len = _35(str), more = more})
+  return({pos = 0, len = _35(str), string = str, more = more})
 end
 local function peek_char(s)
   local _id = s
   local pos = _id.pos
-  local len = _id.len
   local string = _id.string
+  local len = _id.len
   if pos < len then
     return(char(string, pos))
   end
@@ -211,4 +211,4 @@ read_table[","] = function (s)
     return(wrap(s, "unquote"))
   end
 end
-return({["read-all"] = read_all, ["read-string"] = read_string, read = read, stream = stream})
+return({["read-all"] = read_all, ["read-string"] = read_string, stream = stream, read = read})

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -1,13 +1,13 @@
-local delimiters = {[";"] = true, ["\n"] = true, ["("] = true, [")"] = true}
-local whitespace = {["\n"] = true, [" "] = true, ["\t"] = true}
+local delimiters = {[";"] = true, ["("] = true, [")"] = true, ["\n"] = true}
+local whitespace = {[" "] = true, ["\t"] = true, ["\n"] = true}
 local function stream(str, more)
-  return({len = _35(str), more = more, string = str, pos = 0})
+  return({pos = 0, string = str, len = _35(str), more = more})
 end
 local function peek_char(s)
   local _id = s
+  local pos = _id.pos
   local len = _id.len
   local string = _id.string
-  local pos = _id.pos
   if pos < len then
     return(char(string, pos))
   end
@@ -76,8 +76,8 @@ local function flag63(atom)
 end
 local function expected(s, c)
   local _id1 = s
-  local more = _id1.more
   local pos = _id1.pos
+  local more = _id1.more
   local _id2 = more
   local _e
   if _id2 then
@@ -211,4 +211,4 @@ read_table[","] = function (s)
     return(wrap(s, "unquote"))
   end
 end
-return({["read-string"] = read_string, read = read, ["read-all"] = read_all, stream = stream})
+return({["read-all"] = read_all, read = read, stream = stream, ["read-string"] = read_string})

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -1,13 +1,13 @@
-local delimiters = {[")"] = true, ["\n"] = true, [";"] = true, ["("] = true}
-local whitespace = {[" "] = true, ["\n"] = true, ["\t"] = true}
+local delimiters = {[";"] = true, ["\n"] = true, ["("] = true, [")"] = true}
+local whitespace = {["\n"] = true, [" "] = true, ["\t"] = true}
 local function stream(str, more)
-  return({more = more, pos = 0, string = str, len = _35(str)})
+  return({len = _35(str), pos = 0, more = more, string = str})
 end
 local function peek_char(s)
   local _id = s
   local pos = _id.pos
-  local string = _id.string
   local len = _id.len
+  local string = _id.string
   if pos < len then
     return(char(string, pos))
   end
@@ -211,4 +211,4 @@ read_table[","] = function (s)
     return(wrap(s, "unquote"))
   end
 end
-return({read = read, stream = stream, ["read-all"] = read_all, ["read-string"] = read_string})
+return({stream = stream, ["read-string"] = read_string, ["read-all"] = read_all, read = read})

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -1,12 +1,12 @@
-local delimiters = {[";"] = true, ["("] = true, ["\n"] = true, [")"] = true}
+local delimiters = {["\n"] = true, [";"] = true, ["("] = true, [")"] = true}
 local whitespace = {["\n"] = true, ["\t"] = true, [" "] = true}
 local function stream(str, more)
-  return({pos = 0, len = _35(str), string = str, more = more})
+  return({more = more, string = str, pos = 0, len = _35(str)})
 end
 local function peek_char(s)
   local _id = s
-  local pos = _id.pos
   local string = _id.string
+  local pos = _id.pos
   local len = _id.len
   if pos < len then
     return(char(string, pos))
@@ -76,8 +76,8 @@ local function flag63(atom)
 end
 local function expected(s, c)
   local _id1 = s
-  local pos = _id1.pos
   local more = _id1.more
+  local pos = _id1.pos
   local _id2 = more
   local _e
   if _id2 then
@@ -211,4 +211,4 @@ read_table[","] = function (s)
     return(wrap(s, "unquote"))
   end
 end
-return({["read-all"] = read_all, ["read-string"] = read_string, stream = stream, read = read})
+return({["read-string"] = read_string, ["read-all"] = read_all, stream = stream, read = read})

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -1,13 +1,13 @@
-local delimiters = {[";"] = true, ["("] = true, [")"] = true, ["\n"] = true}
-local whitespace = {[" "] = true, ["\t"] = true, ["\n"] = true}
+local delimiters = {[")"] = true, ["\n"] = true, [";"] = true, ["("] = true}
+local whitespace = {[" "] = true, ["\n"] = true, ["\t"] = true}
 local function stream(str, more)
-  return({pos = 0, string = str, len = _35(str), more = more})
+  return({more = more, pos = 0, string = str, len = _35(str)})
 end
 local function peek_char(s)
   local _id = s
   local pos = _id.pos
-  local len = _id.len
   local string = _id.string
+  local len = _id.len
   if pos < len then
     return(char(string, pos))
   end
@@ -76,8 +76,8 @@ local function flag63(atom)
 end
 local function expected(s, c)
   local _id1 = s
-  local pos = _id1.pos
   local more = _id1.more
+  local pos = _id1.pos
   local _id2 = more
   local _e
   if _id2 then
@@ -211,4 +211,4 @@ read_table[","] = function (s)
     return(wrap(s, "unquote"))
   end
 end
-return({["read-all"] = read_all, read = read, stream = stream, ["read-string"] = read_string})
+return({read = read, stream = stream, ["read-all"] = read_all, ["read-string"] = read_string})

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -1,13 +1,13 @@
-local delimiters = {["\n"] = true, [")"] = true, ["("] = true, [";"] = true}
-local whitespace = {[" "] = true, ["\n"] = true, ["\t"] = true}
+local delimiters = {[";"] = true, ["\n"] = true, [")"] = true, ["("] = true}
+local whitespace = {["\t"] = true, [" "] = true, ["\n"] = true}
 local function stream(str, more)
-  return({len = _35(str), pos = 0, string = str, more = more})
+  return({string = str, len = _35(str), more = more, pos = 0})
 end
 local function peek_char(s)
   local _id = s
-  local pos = _id.pos
   local string = _id.string
   local len = _id.len
+  local pos = _id.pos
   if pos < len then
     return(char(string, pos))
   end
@@ -211,4 +211,4 @@ read_table[","] = function (s)
     return(wrap(s, "unquote"))
   end
 end
-return({stream = stream, ["read-all"] = read_all, ["read-string"] = read_string, read = read})
+return({["read-all"] = read_all, read = read, stream = stream, ["read-string"] = read_string})

--- a/compiler.l
+++ b/compiler.l
@@ -233,6 +233,7 @@
   (or (number-code? n)         ; 0-9
       (and (> n 64) (< n 91))  ; A-Z
       (and (> n 96) (< n 123)) ; a-z
+      (= n 46)                 ; .
       (= n 95)))               ; _
 
 (define-global valid-id? (id)

--- a/compiler.l
+++ b/compiler.l
@@ -548,14 +548,23 @@
 (define run-file (path)
   (run (read-file path)))
 
-(define compile-file (path)
-  (let (s ((get reader 'stream) (read-file path))
-        body ((get reader 'read-all) s)
-        form (expand `(do ,@body)))
+(define expand-string (str)
+  (let (s ((get reader 'stream) str)
+        body ((get reader 'read-all) s))
+    (expand `(do ,@body))))
+
+(define compile-string (str)
+  (let form (expand-string str)
     (compile form :stmt)))
+
+(define compile-file (path)
+  (compile-string (read-file path)))
 
 (define-global load (path)
   (run (compile-file path)))
+
+(define-global load-string (str)
+  (run (compile-string str)))
 
 (define-special do forms :stmt :tr
   (with s ""
@@ -686,8 +695,12 @@
     (cat s "}")))
 
 (export eval
+        run
         run-file
+        expand-string
+        compile-string
         compile-file
         load
+        load-string
         expand
         compile)

--- a/runtime.l
+++ b/runtime.l
@@ -361,6 +361,8 @@
     js: (get (require 'path) 'sep)
     lua: (char (get (get _G 'package) 'config) 0)))
 
+(define-global windows? (= path-sep "\\"))
+
 (target js: (define-global print (x) ((get console 'log) x)))
 
 (define-global write (x)

--- a/runtime.l
+++ b/runtime.l
@@ -332,23 +332,29 @@
 (target js: (define fs (require 'fs)))
 
 (target lua:
-  (define call-with-file (file f)
-    (when (is? file)
-      (let ((ok s) (guard (f file)))
-        ((get file 'close) file)
-        s))))
+  (define call-with-file (f call)
+    (let ((ok s) (guard (call f)))
+      (when (is? f)
+        ((get f 'close) f))
+      s)))
 
 (define-global read-file (path)
   (target
     js: ((get fs 'readFileSync) path 'utf8)
     lua: (call-with-file ((get io 'open) path) (fn (f)
-           ((get f 'read) f '*a)))))
+           (when (is? f) ((get f 'read) f '*a))))))
 
 (define-global write-file (path data)
   (target
     js: ((get fs 'writeFileSync) path data 'utf8)
     lua: (call-with-file ((get io 'open) path 'w) (fn (f)
-           ((get f 'write) f data)))))
+           (when (is? f) ((get f 'write) f data))))))
+
+(define-global file-exists? (path)
+  (target
+    js: ((get fs 'existsSync) path 'utf8)
+    lua: (call-with-file ((get io 'open) path) (fn (f)
+           (is? f)))))
 
 (target js: (define-global print (x) ((get console 'log) x)))
 

--- a/runtime.l
+++ b/runtime.l
@@ -368,6 +368,14 @@
 
 (define-global windows? (= path-sep "\\"))
 
+(define-global user-path (path)
+  (let base (read-env "USER_HOME")
+    (if (is? path) (cat base path-sep path) base)))
+
+(define-global lumen-path (path)
+  (let base (read-env "LUMEN_HOME")
+    (if (is? path) (cat base path-sep path) base)))
+
 (target js: (define-global print (x) ((get console 'log) x)))
 
 (define-global write (x)

--- a/runtime.l
+++ b/runtime.l
@@ -356,6 +356,11 @@
     lua: (call-with-file ((get io 'open) path) (fn (f)
            (is? f)))))
 
+(define-global path-sep 
+  (target
+    js: (get (require 'path) 'sep)
+    lua: (char (get (get _G 'package) 'config) 0)))
+
 (target js: (define-global print (x) ((get console 'log) x)))
 
 (define-global write (x)

--- a/runtime.l
+++ b/runtime.l
@@ -331,17 +331,24 @@
 
 (target js: (define fs (require 'fs)))
 
+(target lua:
+  (define call-with-file (file f)
+    (when (is? file)
+      (let ((ok s) (guard (f file)))
+        ((get file 'close) file)
+        s))))
+
 (define-global read-file (path)
   (target
     js: ((get fs 'readFileSync) path 'utf8)
-    lua: (let f ((get io 'open) path)
-	   ((get f 'read) f '*a))))
+    lua: (call-with-file ((get io 'open) path) (fn (f)
+           ((get f 'read) f '*a)))))
 
 (define-global write-file (path data)
   (target
     js: ((get fs 'writeFileSync) path data 'utf8)
-    lua: (let f ((get io 'open) path 'w)
-           ((get f 'write) f data))))
+    lua: (call-with-file ((get io 'open) path 'w) (fn (f)
+           ((get f 'write) f data)))))
 
 (target js: (define-global print (x) ((get console 'log) x)))
 

--- a/runtime.l
+++ b/runtime.l
@@ -356,6 +356,11 @@
     lua: (call-with-file ((get io 'open) path) (fn (f)
            (is? f)))))
 
+(define-global read-env (varname)
+  (target
+    js: (get (get process 'env) varname)
+    lua: ((get os 'getenv) varname)))
+
 (define-global path-sep 
   (target
     js: (get (require 'path) 'sep)


### PR DESCRIPTION
Here are some fixes and new additions to Lumen.  Let me know if you don't want some of these or want me to rework anything.

Fixes:
- `bin/lumen` correctly handles spaces in `pwd`
- For Lua hosts, fixed `read-file` and `write-file` to explicitly close the file before returning a result
- Added `(code ".")` to `valid-code?` in `compiler.l`, which fixes compiling `foo.bar` expressions
  - (E.g. `ffi.load` was incorrectly compiling to `ffi63load` rather than `foo.load`, which was causing errors when loading the `motor` lib)

Additions to `bin/lumen`:
- Users can prepend to LUA_PATH and NODE_PATH when invoking lumen
  - (E.g. `LUA_PATH="$(pwd)/some/path/to/?.lua" lumen`)
- Automatically add `$DIR/lib/$PLATFORM` to `NODE_PATH` and `$DIR/lib/$PLATFORM/?.lua` to `LUA_PATH`
  - (E.g. No longer need to run `lumen` like `LUA_PATH="$(pwd)/lib/darwin/?.lua" lumen` when loading the `motor` lib)

Additions to `compiler.l`:
- New fns: `compile-string`, `expand-string`, `load-string`
- New exports: `run`, `compile-string`, `expand-string`, `load-string`

Additions to `runtime.l`:
- `(file-exists? filename)` returns `true` if the filename is a valid file, else `false`
- `(read-env varname)` returns the value of the environment variable `varname`
  - `read-env` isn't a good name for this
- `(user-path path)` returns the absolute path to the user's home dir, joined with `path` (if non-`nil`)
- `(lumen-path path)` returns the absolute path to lumen's dir, joined with `path` (if non-`nil`)
- The `path-sep` global is `"\\"` on Windows, else `"/"`
- The `windows?` global is `true` on Windows, else `false`

