### PR TITLE
`inf -inf nan -nan Inf -Inf NaN -NaN` work as expected on all hosts

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -79,13 +79,13 @@ var stash42 = function (args) {
     var k = undefined;
     for (k in _o) {
       var v = _o[k];
-      var _e11;
+      var _e9;
       if (numeric63(k)) {
-        _e11 = parseInt(k);
+        _e9 = parseInt(k);
       } else {
-        _e11 = k;
+        _e9 = k;
       }
-      var _k = _e11;
+      var _k = _e9;
       if (!number63(_k)) {
         add(l, literal(_k));
         add(l, v);
@@ -116,28 +116,28 @@ bind = function (lh, rh) {
     var k = undefined;
     for (k in _o1) {
       var v = _o1[k];
-      var _e12;
+      var _e10;
       if (numeric63(k)) {
-        _e12 = parseInt(k);
+        _e10 = parseInt(k);
       } else {
-        _e12 = k;
+        _e10 = k;
       }
-      var _k1 = _e12;
-      var _e13;
+      var _k1 = _e10;
+      var _e11;
       if (_k1 === "rest") {
-        _e13 = ["cut", id, _35(lh)];
+        _e11 = ["cut", id, _35(lh)];
       } else {
-        _e13 = ["get", id, ["quote", bias(_k1)]];
+        _e11 = ["get", id, ["quote", bias(_k1)]];
       }
-      var x = _e13;
+      var x = _e11;
       if (is63(_k1)) {
-        var _e14;
+        var _e12;
         if (v === true) {
-          _e14 = _k1;
+          _e12 = _k1;
         } else {
-          _e14 = v;
+          _e12 = v;
         }
-        var _k2 = _e14;
+        var _k2 = _e12;
         bs = join(bs, bind(_k2, x));
       }
     }
@@ -166,13 +166,13 @@ bind42 = function (args, body) {
     var k = undefined;
     for (k in _o2) {
       var v = _o2[k];
-      var _e15;
+      var _e13;
       if (numeric63(k)) {
-        _e15 = parseInt(k);
+        _e13 = parseInt(k);
       } else {
-        _e15 = k;
+        _e13 = k;
       }
-      var _k3 = _e15;
+      var _k3 = _e13;
       if (number63(_k3)) {
         if (atom63(v)) {
           add(args1, v);
@@ -219,13 +219,13 @@ var expand_function = function (_x36) {
   var _i3 = undefined;
   for (_i3 in _o3) {
     var _x37 = _o3[_i3];
-    var _e16;
+    var _e14;
     if (numeric63(_i3)) {
-      _e16 = parseInt(_i3);
+      _e14 = parseInt(_i3);
     } else {
-      _e16 = _i3;
+      _e14 = _i3;
     }
-    var __i3 = _e16;
+    var __i3 = _e14;
     setenv(_x37, {_stash: true, variable: true});
   }
   var _x38 = join(["%function", args], macroexpand(body));
@@ -243,13 +243,13 @@ var expand_definition = function (_x40) {
   var _i4 = undefined;
   for (_i4 in _o4) {
     var _x41 = _o4[_i4];
-    var _e17;
+    var _e15;
     if (numeric63(_i4)) {
-      _e17 = parseInt(_i4);
+      _e15 = parseInt(_i4);
     } else {
-      _e17 = _i4;
+      _e15 = _i4;
     }
-    var __i4 = _e17;
+    var __i4 = _e15;
     setenv(_x41, {_stash: true, variable: true});
   }
   var _x42 = join([x, name, args], macroexpand(body));
@@ -300,21 +300,21 @@ var quasiquote_list = function (form, depth) {
   var k = undefined;
   for (k in _o5) {
     var v = _o5[k];
-    var _e18;
+    var _e16;
     if (numeric63(k)) {
-      _e18 = parseInt(k);
+      _e16 = parseInt(k);
     } else {
-      _e18 = k;
+      _e16 = k;
     }
-    var _k4 = _e18;
+    var _k4 = _e16;
     if (!number63(_k4)) {
-      var _e19;
+      var _e17;
       if (quasisplice63(v, depth)) {
-        _e19 = quasiexpand(v[1]);
+        _e17 = quasiexpand(v[1]);
       } else {
-        _e19 = quasiexpand(v, depth);
+        _e17 = quasiexpand(v, depth);
       }
-      var _v = _e19;
+      var _v = _e17;
       last(xs)[_k4] = _v;
     }
   }
@@ -401,7 +401,7 @@ indentation = function () {
   }
   return(s);
 };
-var reserved = {"=": true, "==": true, "+": true, "-": true, "%": true, "*": true, "/": true, "<": true, ">": true, "<=": true, ">=": true, "break": true, "case": true, "catch": true, "continue": true, "debugger": true, "default": true, "delete": true, "do": true, "else": true, "finally": true, "for": true, "function": true, "if": true, "in": true, "instanceof": true, "new": true, "return": true, "switch": true, "this": true, "throw": true, "try": true, "typeof": true, "var": true, "void": true, "with": true, "and": true, "end": true, "repeat": true, "while": true, "false": true, "local": true, "nil": true, "then": true, "not": true, "true": true, "elseif": true, "or": true, "until": true};
+var reserved = {"nil": true, "continue": true, "for": true, "then": true, "case": true, "delete": true, "instanceof": true, "local": true, "=": true, "debugger": true, "+": true, "==": true, "-": true, "this": true, "and": true, "while": true, "try": true, "var": true, "do": true, "true": true, "/": true, "switch": true, "%": true, "false": true, "or": true, "function": true, "typeof": true, "until": true, "not": true, "void": true, "repeat": true, "default": true, "<=": true, "in": true, "*": true, "new": true, "<": true, ">": true, "else": true, ">=": true, "elseif": true, "if": true, "catch": true, "return": true, "finally": true, "throw": true, "break": true, "end": true, "with": true};
 reserved63 = function (x) {
   return(reserved[x]);
 };
@@ -440,13 +440,13 @@ mapo = function (f, t) {
   var k = undefined;
   for (k in _o6) {
     var v = _o6[k];
-    var _e20;
+    var _e18;
     if (numeric63(k)) {
-      _e20 = parseInt(k);
+      _e18 = parseInt(k);
     } else {
-      _e20 = k;
+      _e18 = k;
     }
-    var _k5 = _e20;
+    var _k5 = _e18;
     var x = f(v);
     if (is63(x)) {
       add(o, literal(_k5));
@@ -457,40 +457,40 @@ mapo = function (f, t) {
 };
 var __x57 = [];
 var _x58 = [];
-_x58.js = "!";
 _x58.lua = "not ";
+_x58.js = "!";
 __x57["not"] = _x58;
 var __x59 = [];
-__x59["*"] = true;
 __x59["/"] = true;
 __x59["%"] = true;
+__x59["*"] = true;
 var __x60 = [];
 __x60["+"] = true;
 __x60["-"] = true;
 var __x61 = [];
 var _x62 = [];
-_x62.js = "+";
 _x62.lua = "..";
+_x62.js = "+";
 __x61.cat = _x62;
 var __x63 = [];
-__x63["<"] = true;
-__x63[">"] = true;
-__x63["<="] = true;
 __x63[">="] = true;
+__x63["<"] = true;
+__x63["<="] = true;
+__x63[">"] = true;
 var __x64 = [];
 var _x65 = [];
-_x65.js = "===";
 _x65.lua = "==";
+_x65.js = "===";
 __x64["="] = _x65;
 var __x66 = [];
 var _x67 = [];
-_x67.js = "&&";
 _x67.lua = "and";
+_x67.js = "&&";
 __x66["and"] = _x67;
 var __x68 = [];
 var _x69 = [];
-_x69.js = "||";
 _x69.lua = "or";
+_x69.js = "||";
 __x68["or"] = _x69;
 var infix = [__x57, __x59, __x60, __x61, __x63, __x64, __x66, __x68];
 var unary63 = function (form) {
@@ -505,13 +505,13 @@ var precedence = function (form) {
     var k = undefined;
     for (k in _o7) {
       var v = _o7[k];
-      var _e21;
+      var _e19;
       if (numeric63(k)) {
-        _e21 = parseInt(k);
+        _e19 = parseInt(k);
       } else {
-        _e21 = k;
+        _e19 = k;
       }
-      var _k6 = _e21;
+      var _k6 = _e19;
       if (v[hd(form)]) {
         return(index(_k6));
       }
@@ -553,13 +553,13 @@ var escape_newlines = function (s) {
   var i = 0;
   while (i < _35(s)) {
     var c = char(s, i);
-    var _e22;
+    var _e20;
     if (c === "\n") {
-      _e22 = "\\n";
+      _e20 = "\\n";
     } else {
-      _e22 = c;
+      _e20 = c;
     }
-    s1 = s1 + _e22;
+    s1 = s1 + _e20;
     i = i + 1;
   }
   return(s1);
@@ -570,25 +570,25 @@ var id = function (id) {
   while (i < _35(id)) {
     var c = char(id, i);
     var n = code(c);
-    var _e23;
+    var _e21;
     if (c === "-") {
-      _e23 = "_";
+      _e21 = "_";
     } else {
-      var _e24;
+      var _e22;
       if (valid_code63(n)) {
-        _e24 = c;
+        _e22 = c;
       } else {
-        var _e25;
+        var _e23;
         if (i === 0) {
-          _e25 = "_" + n;
+          _e23 = "_" + n;
         } else {
-          _e25 = n;
+          _e23 = n;
         }
-        _e24 = _e25;
+        _e22 = _e23;
       }
-      _e23 = _e24;
+      _e21 = _e22;
     }
-    var c1 = _e23;
+    var c1 = _e21;
     id1 = id1 + c1;
     i = i + 1;
   }
@@ -645,8 +645,8 @@ var compile_special = function (form, stmt63) {
   var x = _id5[0];
   var args = cut(_id5, 1);
   var _id6 = getenv(x);
-  var special = _id6.special;
   var stmt = _id6.stmt;
+  var special = _id6.special;
   var self_tr63 = _id6.tr;
   var tr = terminator(stmt63 && !self_tr63);
   return(apply(special, args) + tr);
@@ -668,13 +668,13 @@ var op_delims = function (parent, child) {
   var _r56 = unstash(Array.prototype.slice.call(arguments, 2));
   var _id7 = _r56;
   var right = _id7.right;
-  var _e26;
+  var _e24;
   if (right) {
-    _e26 = _6261;
+    _e24 = _6261;
   } else {
-    _e26 = _62;
+    _e24 = _62;
   }
-  if (_e26(precedence(child), precedence(parent))) {
+  if (_e24(precedence(child), precedence(parent))) {
     return(["(", ")"]);
   } else {
     return(["", ""]);
@@ -704,35 +704,35 @@ var compile_infix = function (form) {
 compile_function = function (args, body) {
   var _r58 = unstash(Array.prototype.slice.call(arguments, 2));
   var _id12 = _r58;
-  var name = _id12.name;
   var prefix = _id12.prefix;
-  var _e27;
+  var name = _id12.name;
+  var _e25;
   if (name) {
-    _e27 = compile(name);
+    _e25 = compile(name);
   } else {
-    _e27 = "";
+    _e25 = "";
   }
-  var _id13 = _e27;
+  var _id13 = _e25;
   var _args = compile_args(args);
   indent_level = indent_level + 1;
   var _x74 = compile(body, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
   var _body = _x74;
   var ind = indentation();
-  var _e28;
+  var _e26;
   if (prefix) {
-    _e28 = prefix + " ";
+    _e26 = prefix + " ";
   } else {
-    _e28 = "";
+    _e26 = "";
   }
-  var p = _e28;
-  var _e29;
+  var p = _e26;
+  var _e27;
   if (target === "js") {
-    _e29 = "";
+    _e27 = "";
   } else {
-    _e29 = "end";
+    _e27 = "end";
   }
-  var tr = _e29;
+  var tr = _e27;
   if (name) {
     tr = tr + "\n";
   }
@@ -756,26 +756,26 @@ compile = function (form) {
       return(compile_special(form, stmt));
     } else {
       var tr = terminator(stmt);
-      var _e30;
+      var _e28;
       if (stmt) {
-        _e30 = indentation();
+        _e28 = indentation();
       } else {
-        _e30 = "";
+        _e28 = "";
       }
-      var ind = _e30;
-      var _e31;
+      var ind = _e28;
+      var _e29;
       if (atom63(form)) {
-        _e31 = compile_atom(form);
+        _e29 = compile_atom(form);
       } else {
-        var _e32;
+        var _e30;
         if (infix63(hd(form))) {
-          _e32 = compile_infix(form);
+          _e30 = compile_infix(form);
         } else {
-          _e32 = compile_call(form);
+          _e30 = compile_call(form);
         }
-        _e31 = _e32;
+        _e29 = _e30;
       }
-      var _form = _e31;
+      var _form = _e29;
       return(ind + _form + tr);
     }
   }
@@ -843,19 +843,19 @@ var lower_if = function (args, hoist, stmt63, tail63) {
   var _then = _id16[1];
   var _else = _id16[2];
   if (stmt63 || tail63) {
-    var _e34;
+    var _e32;
     if (_else) {
-      _e34 = [lower_body([_else], tail63)];
+      _e32 = [lower_body([_else], tail63)];
     }
-    return(add(hoist, join(["%if", lower(cond, hoist), lower_body([_then], tail63)], _e34)));
+    return(add(hoist, join(["%if", lower(cond, hoist), lower_body([_then], tail63)], _e32)));
   } else {
     var e = unique("e");
     add(hoist, ["%local", e]);
-    var _e33;
+    var _e31;
     if (_else) {
-      _e33 = [lower(["set", e, _else])];
+      _e31 = [lower(["set", e, _else])];
     }
-    add(hoist, join(["%if", lower(cond, hoist), lower(["set", e, _then])], _e33));
+    add(hoist, join(["%if", lower(cond, hoist), lower(["set", e, _then])], _e31));
     return(e);
   }
 };
@@ -867,13 +867,13 @@ var lower_short = function (x, args, hoist) {
   var b1 = lower(b, hoist1);
   if (some63(hoist1)) {
     var _id18 = unique("id");
-    var _e35;
+    var _e33;
     if (x === "and") {
-      _e35 = ["%if", _id18, b, _id18];
+      _e33 = ["%if", _id18, b, _id18];
     } else {
-      _e35 = ["%if", _id18, _id18, b];
+      _e33 = ["%if", _id18, _id18, b];
     }
-    return(lower(["do", ["%local", _id18, a], _e35], hoist));
+    return(lower(["do", ["%local", _id18, a], _e33], hoist));
   } else {
     return([x, lower(a, hoist), b1]);
   }
@@ -1020,33 +1020,33 @@ var compile_file = function (path) {
 load = function (path) {
   return(run(compile_file(path)));
 };
-setenv("do", {_stash: true, special: function () {
+setenv("do", {_stash: true, stmt: true, tr: true, special: function () {
   var forms = unstash(Array.prototype.slice.call(arguments, 0));
   var s = "";
-  var _x107 = forms;
-  var _n12 = _35(_x107);
+  var _x108 = forms;
+  var _n12 = _35(_x108);
   var _i12 = 0;
   while (_i12 < _n12) {
-    var x = _x107[_i12];
+    var x = _x108[_i12];
     s = s + compile(x, {_stash: true, stmt: true});
     _i12 = _i12 + 1;
   }
   return(s);
-}, stmt: true, tr: true});
-setenv("%if", {_stash: true, special: function (cond, cons, alt) {
+}});
+setenv("%if", {_stash: true, stmt: true, tr: true, special: function (cond, cons, alt) {
   var _cond1 = compile(cond);
   indent_level = indent_level + 1;
-  var _x110 = compile(cons, {_stash: true, stmt: true});
+  var _x111 = compile(cons, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var _cons1 = _x110;
-  var _e36;
+  var _cons1 = _x111;
+  var _e34;
   if (alt) {
     indent_level = indent_level + 1;
-    var _x111 = compile(alt, {_stash: true, stmt: true});
+    var _x112 = compile(alt, {_stash: true, stmt: true});
     indent_level = indent_level - 1;
-    _e36 = _x111;
+    _e34 = _x112;
   }
-  var _alt1 = _e36;
+  var _alt1 = _e34;
   var ind = indentation();
   var s = "";
   if (target === "js") {
@@ -1066,47 +1066,47 @@ setenv("%if", {_stash: true, special: function (cond, cons, alt) {
   } else {
     return(s + "\n");
   }
-}, stmt: true, tr: true});
-setenv("while", {_stash: true, special: function (cond, form) {
+}});
+setenv("while", {_stash: true, stmt: true, tr: true, special: function (cond, form) {
   var _cond3 = compile(cond);
   indent_level = indent_level + 1;
-  var _x113 = compile(form, {_stash: true, stmt: true});
+  var _x114 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var body = _x113;
+  var body = _x114;
   var ind = indentation();
   if (target === "js") {
     return(ind + "while (" + _cond3 + ") {\n" + body + ind + "}\n");
   } else {
     return(ind + "while " + _cond3 + " do\n" + body + ind + "end\n");
   }
-}, stmt: true, tr: true});
-setenv("%for", {_stash: true, special: function (t, k, form) {
+}});
+setenv("%for", {_stash: true, stmt: true, tr: true, special: function (t, k, form) {
   var _t1 = compile(t);
   var ind = indentation();
   indent_level = indent_level + 1;
-  var _x115 = compile(form, {_stash: true, stmt: true});
+  var _x116 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var body = _x115;
+  var body = _x116;
   if (target === "lua") {
     return(ind + "for " + k + " in next, " + _t1 + " do\n" + body + ind + "end\n");
   } else {
     return(ind + "for (" + k + " in " + _t1 + ") {\n" + body + ind + "}\n");
   }
-}, stmt: true, tr: true});
-setenv("%try", {_stash: true, special: function (form) {
+}});
+setenv("%try", {_stash: true, stmt: true, tr: true, special: function (form) {
   var e = unique("e");
   var ind = indentation();
   indent_level = indent_level + 1;
-  var _x121 = compile(form, {_stash: true, stmt: true});
+  var _x122 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var body = _x121;
+  var body = _x122;
   var hf = ["return", ["%array", false, ["get", e, "\"message\""]]];
   indent_level = indent_level + 1;
-  var _x125 = compile(hf, {_stash: true, stmt: true});
+  var _x126 = compile(hf, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var h = _x125;
+  var h = _x126;
   return(ind + "try {\n" + body + ind + "}\n" + ind + "catch (" + e + ") {\n" + h + ind + "}\n");
-}, stmt: true, tr: true});
+}});
 setenv("%delete", {_stash: true, special: function (place) {
   return(indentation() + "delete " + compile(place));
 }, stmt: true});
@@ -1116,74 +1116,74 @@ setenv("break", {_stash: true, special: function () {
 setenv("%function", {_stash: true, special: function (args, body) {
   return(compile_function(args, body));
 }});
-setenv("%global-function", {_stash: true, special: function (name, args, body) {
+setenv("%global-function", {_stash: true, stmt: true, tr: true, special: function (name, args, body) {
   if (target === "lua") {
     var x = compile_function(args, body, {_stash: true, name: name});
     return(indentation() + x);
   } else {
     return(compile(["set", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}, stmt: true, tr: true});
-setenv("%local-function", {_stash: true, special: function (name, args, body) {
+}});
+setenv("%local-function", {_stash: true, stmt: true, tr: true, special: function (name, args, body) {
   if (target === "lua") {
-    var x = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
+    var x = compile_function(args, body, {_stash: true, prefix: "local", name: name});
     return(indentation() + x);
   } else {
     return(compile(["%local", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}, stmt: true, tr: true});
+}});
 setenv("return", {_stash: true, special: function (x) {
-  var _e37;
+  var _e35;
   if (nil63(x)) {
-    _e37 = "return";
+    _e35 = "return";
   } else {
-    _e37 = "return(" + compile(x) + ")";
+    _e35 = "return(" + compile(x) + ")";
   }
-  var _x135 = _e37;
-  return(indentation() + _x135);
+  var _x136 = _e35;
+  return(indentation() + _x136);
 }, stmt: true});
 setenv("new", {_stash: true, special: function (x) {
   return("new " + compile(x));
 }});
 setenv("error", {_stash: true, special: function (x) {
-  var _e38;
+  var _e36;
   if (target === "js") {
-    _e38 = "throw " + compile(["new", ["Error", x]]);
+    _e36 = "throw " + compile(["new", ["Error", x]]);
   } else {
-    _e38 = "error(" + compile(x) + ")";
+    _e36 = "error(" + compile(x) + ")";
   }
-  var e = _e38;
+  var e = _e36;
   return(indentation() + e);
 }, stmt: true});
 setenv("%local", {_stash: true, special: function (name, value) {
   var _id26 = compile(name);
   var value1 = compile(value);
-  var _e39;
+  var _e37;
   if (is63(value)) {
-    _e39 = " = " + value1;
+    _e37 = " = " + value1;
   } else {
-    _e39 = "";
+    _e37 = "";
   }
-  var rh = _e39;
-  var _e40;
+  var rh = _e37;
+  var _e38;
   if (target === "js") {
-    _e40 = "var ";
+    _e38 = "var ";
   } else {
-    _e40 = "local ";
+    _e38 = "local ";
   }
-  var keyword = _e40;
+  var keyword = _e38;
   var ind = indentation();
   return(ind + keyword + _id26 + rh);
 }, stmt: true});
 setenv("set", {_stash: true, special: function (lh, rh) {
   var _lh1 = compile(lh);
-  var _e41;
+  var _e39;
   if (nil63(rh)) {
-    _e41 = "nil";
+    _e39 = "nil";
   } else {
-    _e41 = rh;
+    _e39 = rh;
   }
-  var _rh1 = compile(_e41);
+  var _rh1 = compile(_e39);
   return(indentation() + _lh1 + " = " + _rh1);
 }, stmt: true});
 setenv("get", {_stash: true, special: function (t, k) {
@@ -1200,34 +1200,34 @@ setenv("get", {_stash: true, special: function (t, k) {
 }});
 setenv("%array", {_stash: true, special: function () {
   var forms = unstash(Array.prototype.slice.call(arguments, 0));
-  var _e42;
+  var _e40;
   if (target === "lua") {
-    _e42 = "{";
+    _e40 = "{";
   } else {
-    _e42 = "[";
+    _e40 = "[";
   }
-  var open = _e42;
-  var _e43;
+  var open = _e40;
+  var _e41;
   if (target === "lua") {
-    _e43 = "}";
+    _e41 = "}";
   } else {
-    _e43 = "]";
+    _e41 = "]";
   }
-  var close = _e43;
+  var close = _e41;
   var s = "";
   var c = "";
   var _o9 = forms;
   var k = undefined;
   for (k in _o9) {
     var v = _o9[k];
-    var _e44;
+    var _e42;
     if (numeric63(k)) {
-      _e44 = parseInt(k);
+      _e42 = parseInt(k);
     } else {
-      _e44 = k;
+      _e42 = k;
     }
-    var _k8 = _e44;
-    if (number63(_k8)) {
+    var _k7 = _e42;
+    if (number63(_k7)) {
       s = s + c + compile(v);
       c = ", ";
     }
@@ -1238,32 +1238,32 @@ setenv("%object", {_stash: true, special: function () {
   var forms = unstash(Array.prototype.slice.call(arguments, 0));
   var s = "{";
   var c = "";
-  var _e45;
+  var _e43;
   if (target === "lua") {
-    _e45 = " = ";
+    _e43 = " = ";
   } else {
-    _e45 = ": ";
+    _e43 = ": ";
   }
-  var sep = _e45;
+  var sep = _e43;
   var _o11 = pair(forms);
   var k = undefined;
   for (k in _o11) {
     var v = _o11[k];
-    var _e46;
+    var _e44;
     if (numeric63(k)) {
-      _e46 = parseInt(k);
+      _e44 = parseInt(k);
     } else {
-      _e46 = k;
+      _e44 = k;
     }
-    var _k11 = _e46;
-    if (number63(_k11)) {
+    var _k9 = _e44;
+    if (number63(_k9)) {
       var _id28 = v;
-      var _k12 = _id28[0];
+      var _k10 = _id28[0];
       var _v2 = _id28[1];
-      if (!string63(_k12)) {
-        throw new Error("Illegal key: " + string(_k12));
+      if (!string63(_k10)) {
+        throw new Error("Illegal key: " + string(_k10));
       }
-      s = s + c + key(_k12) + sep + compile(_v2);
+      s = s + c + key(_k10) + sep + compile(_v2);
       c = ", ";
     }
   }

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -109,21 +109,21 @@ function bind(lh, rh)
     local k = nil
     for k in next, _o1 do
       local v = _o1[k]
-      local _e11
+      local _e9
       if k == "rest" then
-        _e11 = {"cut", id, _35(lh)}
+        _e9 = {"cut", id, _35(lh)}
       else
-        _e11 = {"get", id, {"quote", bias(k)}}
+        _e9 = {"get", id, {"quote", bias(k)}}
       end
-      local x = _e11
+      local x = _e9
       if is63(k) then
-        local _e12
+        local _e10
         if v == true then
-          _e12 = k
+          _e10 = k
         else
-          _e12 = v
+          _e10 = v
         end
-        local _k = _e12
+        local _k = _e10
         bs = join(bs, bind(_k, x))
       end
     end
@@ -266,13 +266,13 @@ local function quasiquote_list(form, depth)
   for k in next, _o5 do
     local v = _o5[k]
     if not number63(k) then
-      local _e13
+      local _e11
       if quasisplice63(v, depth) then
-        _e13 = quasiexpand(v[2])
+        _e11 = quasiexpand(v[2])
       else
-        _e13 = quasiexpand(v, depth)
+        _e11 = quasiexpand(v, depth)
       end
-      local _v = _e13
+      local _v = _e11
       last(xs)[k] = _v
     end
   end
@@ -359,7 +359,7 @@ function indentation()
   end
   return(s)
 end
-local reserved = {["="] = true, ["=="] = true, ["+"] = true, ["-"] = true, ["%"] = true, ["*"] = true, ["/"] = true, ["<"] = true, [">"] = true, ["<="] = true, [">="] = true, ["break"] = true, ["case"] = true, ["catch"] = true, ["continue"] = true, ["debugger"] = true, ["default"] = true, ["delete"] = true, ["do"] = true, ["else"] = true, ["finally"] = true, ["for"] = true, ["function"] = true, ["if"] = true, ["in"] = true, ["instanceof"] = true, ["new"] = true, ["return"] = true, ["switch"] = true, ["this"] = true, ["throw"] = true, ["try"] = true, ["typeof"] = true, ["var"] = true, ["void"] = true, ["with"] = true, ["and"] = true, ["end"] = true, ["repeat"] = true, ["while"] = true, ["false"] = true, ["local"] = true, ["nil"] = true, ["then"] = true, ["not"] = true, ["true"] = true, ["elseif"] = true, ["or"] = true, ["until"] = true}
+local reserved = {["typeof"] = true, ["continue"] = true, ["nil"] = true, ["case"] = true, ["end"] = true, ["="] = true, [">="] = true, ["default"] = true, ["function"] = true, ["local"] = true, ["then"] = true, ["+"] = true, ["throw"] = true, ["do"] = true, ["else"] = true, ["return"] = true, ["var"] = true, ["false"] = true, ["true"] = true, ["until"] = true, ["not"] = true, ["with"] = true, ["or"] = true, [">"] = true, ["if"] = true, ["while"] = true, ["elseif"] = true, ["for"] = true, ["in"] = true, ["void"] = true, ["=="] = true, ["instanceof"] = true, ["<"] = true, ["finally"] = true, ["this"] = true, ["repeat"] = true, ["<="] = true, ["catch"] = true, ["try"] = true, ["and"] = true, ["switch"] = true, ["new"] = true, ["*"] = true, ["debugger"] = true, ["break"] = true, ["delete"] = true, ["/"] = true, ["%"] = true, ["-"] = true}
 function reserved63(x)
   return(reserved[x])
 end
@@ -416,17 +416,17 @@ __x59["*"] = true
 __x59["/"] = true
 __x59["%"] = true
 local __x60 = {}
-__x60["+"] = true
 __x60["-"] = true
+__x60["+"] = true
 local __x61 = {}
 local _x62 = {}
 _x62.js = "+"
 _x62.lua = ".."
 __x61.cat = _x62
 local __x63 = {}
-__x63["<"] = true
 __x63[">"] = true
 __x63["<="] = true
+__x63["<"] = true
 __x63[">="] = true
 local __x64 = {}
 local _x65 = {}
@@ -499,13 +499,13 @@ local function escape_newlines(s)
   local i = 0
   while i < _35(s) do
     local c = char(s, i)
-    local _e14
+    local _e12
     if c == "\n" then
-      _e14 = "\\n"
+      _e12 = "\\n"
     else
-      _e14 = c
+      _e12 = c
     end
-    s1 = s1 .. _e14
+    s1 = s1 .. _e12
     i = i + 1
   end
   return(s1)
@@ -516,25 +516,25 @@ local function id(id)
   while i < _35(id) do
     local c = char(id, i)
     local n = code(c)
-    local _e15
+    local _e13
     if c == "-" then
-      _e15 = "_"
+      _e13 = "_"
     else
-      local _e16
+      local _e14
       if valid_code63(n) then
-        _e16 = c
+        _e14 = c
       else
-        local _e17
+        local _e15
         if i == 0 then
-          _e17 = "_" .. n
+          _e15 = "_" .. n
         else
-          _e17 = n
+          _e15 = n
         end
-        _e16 = _e17
+        _e14 = _e15
       end
-      _e15 = _e16
+      _e13 = _e14
     end
-    local c1 = _e15
+    local c1 = _e13
     id1 = id1 .. c1
     i = i + 1
   end
@@ -591,9 +591,9 @@ local function compile_special(form, stmt63)
   local x = _id5[1]
   local args = cut(_id5, 1)
   local _id6 = getenv(x)
+  local self_tr63 = _id6.tr
   local special = _id6.special
   local stmt = _id6.stmt
-  local self_tr63 = _id6.tr
   local tr = terminator(stmt63 and not self_tr63)
   return(apply(special, args) .. tr)
 end
@@ -614,13 +614,13 @@ local function op_delims(parent, child, ...)
   local _r56 = unstash({...})
   local _id7 = _r56
   local right = _id7.right
-  local _e18
+  local _e16
   if right then
-    _e18 = _6261
+    _e16 = _6261
   else
-    _e18 = _62
+    _e16 = _62
   end
-  if _e18(precedence(child), precedence(parent)) then
+  if _e16(precedence(child), precedence(parent)) then
     return({"(", ")"})
   else
     return({"", ""})
@@ -652,33 +652,33 @@ function compile_function(args, body, ...)
   local _id12 = _r58
   local name = _id12.name
   local prefix = _id12.prefix
-  local _e19
+  local _e17
   if name then
-    _e19 = compile(name)
+    _e17 = compile(name)
   else
-    _e19 = ""
+    _e17 = ""
   end
-  local _id13 = _e19
+  local _id13 = _e17
   local _args = compile_args(args)
   indent_level = indent_level + 1
   local _x76 = compile(body, {_stash = true, stmt = true})
   indent_level = indent_level - 1
   local _body = _x76
   local ind = indentation()
-  local _e20
+  local _e18
   if prefix then
-    _e20 = prefix .. " "
+    _e18 = prefix .. " "
   else
-    _e20 = ""
+    _e18 = ""
   end
-  local p = _e20
-  local _e21
+  local p = _e18
+  local _e19
   if target == "js" then
-    _e21 = ""
+    _e19 = ""
   else
-    _e21 = "end"
+    _e19 = "end"
   end
-  local tr = _e21
+  local tr = _e19
   if name then
     tr = tr .. "\n"
   end
@@ -702,26 +702,26 @@ function compile(form, ...)
       return(compile_special(form, stmt))
     else
       local tr = terminator(stmt)
-      local _e22
+      local _e20
       if stmt then
-        _e22 = indentation()
+        _e20 = indentation()
       else
-        _e22 = ""
+        _e20 = ""
       end
-      local ind = _e22
-      local _e23
+      local ind = _e20
+      local _e21
       if atom63(form) then
-        _e23 = compile_atom(form)
+        _e21 = compile_atom(form)
       else
-        local _e24
+        local _e22
         if infix63(hd(form)) then
-          _e24 = compile_infix(form)
+          _e22 = compile_infix(form)
         else
-          _e24 = compile_call(form)
+          _e22 = compile_call(form)
         end
-        _e23 = _e24
+        _e21 = _e22
       end
-      local _form = _e23
+      local _form = _e21
       return(ind .. _form .. tr)
     end
   end
@@ -789,19 +789,19 @@ local function lower_if(args, hoist, stmt63, tail63)
   local _then = _id16[2]
   local _else = _id16[3]
   if stmt63 or tail63 then
-    local _e26
+    local _e24
     if _else then
-      _e26 = {lower_body({_else}, tail63)}
+      _e24 = {lower_body({_else}, tail63)}
     end
-    return(add(hoist, join({"%if", lower(cond, hoist), lower_body({_then}, tail63)}, _e26)))
+    return(add(hoist, join({"%if", lower(cond, hoist), lower_body({_then}, tail63)}, _e24)))
   else
     local e = unique("e")
     add(hoist, {"%local", e})
-    local _e25
+    local _e23
     if _else then
-      _e25 = {lower({"set", e, _else})}
+      _e23 = {lower({"set", e, _else})}
     end
-    add(hoist, join({"%if", lower(cond, hoist), lower({"set", e, _then})}, _e25))
+    add(hoist, join({"%if", lower(cond, hoist), lower({"set", e, _then})}, _e23))
     return(e)
   end
 end
@@ -813,13 +813,13 @@ local function lower_short(x, args, hoist)
   local b1 = lower(b, hoist1)
   if some63(hoist1) then
     local _id18 = unique("id")
-    local _e27
+    local _e25
     if x == "and" then
-      _e27 = {"%if", _id18, b, _id18}
+      _e25 = {"%if", _id18, b, _id18}
     else
-      _e27 = {"%if", _id18, _id18, b}
+      _e25 = {"%if", _id18, _id18, b}
     end
-    return(lower({"do", {"%local", _id18, a}, _e27}, hoist))
+    return(lower({"do", {"%local", _id18, a}, _e25}, hoist))
   else
     return({x, lower(a, hoist), b1})
   end
@@ -973,33 +973,33 @@ end
 function load(path)
   return(run(compile_file(path)))
 end
-setenv("do", {_stash = true, special = function (...)
+setenv("do", {_stash = true, tr = true, special = function (...)
   local forms = unstash({...})
   local s = ""
-  local _x111 = forms
-  local _n12 = _35(_x111)
+  local _x112 = forms
+  local _n12 = _35(_x112)
   local _i12 = 0
   while _i12 < _n12 do
-    local x = _x111[_i12 + 1]
+    local x = _x112[_i12 + 1]
     s = s .. compile(x, {_stash = true, stmt = true})
     _i12 = _i12 + 1
   end
   return(s)
-end, stmt = true, tr = true})
-setenv("%if", {_stash = true, special = function (cond, cons, alt)
+end, stmt = true})
+setenv("%if", {_stash = true, tr = true, special = function (cond, cons, alt)
   local _cond1 = compile(cond)
   indent_level = indent_level + 1
-  local _x114 = compile(cons, {_stash = true, stmt = true})
+  local _x115 = compile(cons, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local _cons1 = _x114
-  local _e28
+  local _cons1 = _x115
+  local _e26
   if alt then
     indent_level = indent_level + 1
-    local _x115 = compile(alt, {_stash = true, stmt = true})
+    local _x116 = compile(alt, {_stash = true, stmt = true})
     indent_level = indent_level - 1
-    _e28 = _x115
+    _e26 = _x116
   end
-  local _alt1 = _e28
+  local _alt1 = _e26
   local ind = indentation()
   local s = ""
   if target == "js" then
@@ -1019,47 +1019,47 @@ setenv("%if", {_stash = true, special = function (cond, cons, alt)
   else
     return(s .. "\n")
   end
-end, stmt = true, tr = true})
-setenv("while", {_stash = true, special = function (cond, form)
+end, stmt = true})
+setenv("while", {_stash = true, tr = true, special = function (cond, form)
   local _cond3 = compile(cond)
   indent_level = indent_level + 1
-  local _x117 = compile(form, {_stash = true, stmt = true})
+  local _x118 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local body = _x117
+  local body = _x118
   local ind = indentation()
   if target == "js" then
     return(ind .. "while (" .. _cond3 .. ") {\n" .. body .. ind .. "}\n")
   else
     return(ind .. "while " .. _cond3 .. " do\n" .. body .. ind .. "end\n")
   end
-end, stmt = true, tr = true})
-setenv("%for", {_stash = true, special = function (t, k, form)
+end, stmt = true})
+setenv("%for", {_stash = true, tr = true, special = function (t, k, form)
   local _t1 = compile(t)
   local ind = indentation()
   indent_level = indent_level + 1
-  local _x119 = compile(form, {_stash = true, stmt = true})
+  local _x120 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local body = _x119
+  local body = _x120
   if target == "lua" then
     return(ind .. "for " .. k .. " in next, " .. _t1 .. " do\n" .. body .. ind .. "end\n")
   else
     return(ind .. "for (" .. k .. " in " .. _t1 .. ") {\n" .. body .. ind .. "}\n")
   end
-end, stmt = true, tr = true})
-setenv("%try", {_stash = true, special = function (form)
+end, stmt = true})
+setenv("%try", {_stash = true, tr = true, special = function (form)
   local e = unique("e")
   local ind = indentation()
   indent_level = indent_level + 1
-  local _x125 = compile(form, {_stash = true, stmt = true})
+  local _x126 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local body = _x125
+  local body = _x126
   local hf = {"return", {"%array", false, {"get", e, "\"message\""}}}
   indent_level = indent_level + 1
-  local _x129 = compile(hf, {_stash = true, stmt = true})
+  local _x130 = compile(hf, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local h = _x129
+  local h = _x130
   return(ind .. "try {\n" .. body .. ind .. "}\n" .. ind .. "catch (" .. e .. ") {\n" .. h .. ind .. "}\n")
-end, stmt = true, tr = true})
+end, stmt = true})
 setenv("%delete", {_stash = true, special = function (place)
   return(indentation() .. "delete " .. compile(place))
 end, stmt = true})
@@ -1069,74 +1069,74 @@ end, stmt = true})
 setenv("%function", {_stash = true, special = function (args, body)
   return(compile_function(args, body))
 end})
-setenv("%global-function", {_stash = true, special = function (name, args, body)
+setenv("%global-function", {_stash = true, tr = true, special = function (name, args, body)
   if target == "lua" then
     local x = compile_function(args, body, {_stash = true, name = name})
     return(indentation() .. x)
   else
     return(compile({"set", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
-end, stmt = true, tr = true})
-setenv("%local-function", {_stash = true, special = function (name, args, body)
+end, stmt = true})
+setenv("%local-function", {_stash = true, tr = true, special = function (name, args, body)
   if target == "lua" then
     local x = compile_function(args, body, {_stash = true, name = name, prefix = "local"})
     return(indentation() .. x)
   else
     return(compile({"%local", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
-end, stmt = true, tr = true})
+end, stmt = true})
 setenv("return", {_stash = true, special = function (x)
-  local _e29
+  local _e27
   if nil63(x) then
-    _e29 = "return"
+    _e27 = "return"
   else
-    _e29 = "return(" .. compile(x) .. ")"
+    _e27 = "return(" .. compile(x) .. ")"
   end
-  local _x139 = _e29
-  return(indentation() .. _x139)
+  local _x140 = _e27
+  return(indentation() .. _x140)
 end, stmt = true})
 setenv("new", {_stash = true, special = function (x)
   return("new " .. compile(x))
 end})
 setenv("error", {_stash = true, special = function (x)
-  local _e30
+  local _e28
   if target == "js" then
-    _e30 = "throw " .. compile({"new", {"Error", x}})
+    _e28 = "throw " .. compile({"new", {"Error", x}})
   else
-    _e30 = "error(" .. compile(x) .. ")"
+    _e28 = "error(" .. compile(x) .. ")"
   end
-  local e = _e30
+  local e = _e28
   return(indentation() .. e)
 end, stmt = true})
 setenv("%local", {_stash = true, special = function (name, value)
   local _id26 = compile(name)
   local value1 = compile(value)
-  local _e31
+  local _e29
   if is63(value) then
-    _e31 = " = " .. value1
+    _e29 = " = " .. value1
   else
-    _e31 = ""
+    _e29 = ""
   end
-  local rh = _e31
-  local _e32
+  local rh = _e29
+  local _e30
   if target == "js" then
-    _e32 = "var "
+    _e30 = "var "
   else
-    _e32 = "local "
+    _e30 = "local "
   end
-  local keyword = _e32
+  local keyword = _e30
   local ind = indentation()
   return(ind .. keyword .. _id26 .. rh)
 end, stmt = true})
 setenv("set", {_stash = true, special = function (lh, rh)
   local _lh1 = compile(lh)
-  local _e33
+  local _e31
   if nil63(rh) then
-    _e33 = "nil"
+    _e31 = "nil"
   else
-    _e33 = rh
+    _e31 = rh
   end
-  local _rh1 = compile(_e33)
+  local _rh1 = compile(_e31)
   return(indentation() .. _lh1 .. " = " .. _rh1)
 end, stmt = true})
 setenv("get", {_stash = true, special = function (t, k)
@@ -1153,20 +1153,20 @@ setenv("get", {_stash = true, special = function (t, k)
 end})
 setenv("%array", {_stash = true, special = function (...)
   local forms = unstash({...})
-  local _e34
+  local _e32
   if target == "lua" then
-    _e34 = "{"
+    _e32 = "{"
   else
-    _e34 = "["
+    _e32 = "["
   end
-  local open = _e34
-  local _e35
+  local open = _e32
+  local _e33
   if target == "lua" then
-    _e35 = "}"
+    _e33 = "}"
   else
-    _e35 = "]"
+    _e33 = "]"
   end
-  local close = _e35
+  local close = _e33
   local s = ""
   local c = ""
   local _o9 = forms
@@ -1184,28 +1184,28 @@ setenv("%object", {_stash = true, special = function (...)
   local forms = unstash({...})
   local s = "{"
   local c = ""
-  local _e36
+  local _e34
   if target == "lua" then
-    _e36 = " = "
+    _e34 = " = "
   else
-    _e36 = ": "
+    _e34 = ": "
   end
-  local sep = _e36
+  local sep = _e34
   local _o11 = pair(forms)
   local k = nil
   for k in next, _o11 do
     local v = _o11[k]
     if number63(k) then
       local _id28 = v
-      local _k4 = _id28[1]
+      local _k2 = _id28[1]
       local _v2 = _id28[2]
-      if not string63(_k4) then
-        error("Illegal key: " .. string(_k4))
+      if not string63(_k2) then
+        error("Illegal key: " .. string(_k2))
       end
-      s = s .. c .. key(_k4) .. sep .. compile(_v2)
+      s = s .. c .. key(_k2) .. sep .. compile(_v2)
       c = ", "
     end
   end
   return(s .. "}")
 end})
-return({eval = eval, ["run-file"] = run_file, ["compile-file"] = compile_file, load = load, expand = expand, compile = compile})
+return({["run-file"] = run_file, expand = expand, compile = compile, eval = eval, ["compile-file"] = compile_file, load = load})

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -42,14 +42,11 @@ function63 = function (x) {
 atom63 = function (x) {
   return(nil63(x) || string63(x) || number63(x) || boolean63(x));
 };
-nan = 0 / 0;
-inf = 1 / 0;
-_inf = -(1 / 0);
 nan63 = function (n) {
   return(!(n === n));
 };
 inf63 = function (n) {
-  return(n === inf || n === _inf);
+  return(n === 1 / 0 || n === -1 / 0);
 };
 clip = function (s, from, upto) {
   return(s.substring(from, upto));
@@ -498,7 +495,7 @@ numeric63 = function (s) {
   return(true);
 };
 var tostring = function (x) {
-  return(x["toString"]());
+  return(x.toString());
 };
 escape = function (s) {
   var s1 = "\"";
@@ -536,72 +533,60 @@ string = function (x, depth) {
     if (nil63(x)) {
       return("nil");
     } else {
-      if (nan63(x)) {
-        return("nan");
-      } else {
-        if (x === inf) {
-          return("inf");
+      if (boolean63(x)) {
+        if (x) {
+          return("true");
         } else {
-          if (x === _inf) {
-            return("-inf");
+          return("false");
+        }
+      } else {
+        if (string63(x)) {
+          return(escape(x));
+        } else {
+          if (atom63(x)) {
+            return(tostring(x));
           } else {
-            if (boolean63(x)) {
-              if (x) {
-                return("true");
-              } else {
-                return("false");
-              }
+            if (function63(x)) {
+              return("function");
             } else {
-              if (string63(x)) {
-                return(escape(x));
-              } else {
-                if (atom63(x)) {
-                  return(tostring(x));
+              var s = "(";
+              var sp = "";
+              var xs = [];
+              var ks = [];
+              var d = (depth || 0) + 1;
+              var _o10 = x;
+              var k = undefined;
+              for (k in _o10) {
+                var v = _o10[k];
+                var _e16;
+                if (numeric63(k)) {
+                  _e16 = parseInt(k);
                 } else {
-                  if (function63(x)) {
-                    return("function");
-                  } else {
-                    var s = "(";
-                    var sp = "";
-                    var xs = [];
-                    var ks = [];
-                    var d = (depth || 0) + 1;
-                    var _o10 = x;
-                    var k = undefined;
-                    for (k in _o10) {
-                      var v = _o10[k];
-                      var _e16;
-                      if (numeric63(k)) {
-                        _e16 = parseInt(k);
-                      } else {
-                        _e16 = k;
-                      }
-                      var _k8 = _e16;
-                      if (number63(_k8)) {
-                        xs[_k8] = string(v, d);
-                      } else {
-                        add(ks, _k8 + ":");
-                        add(ks, string(v, d));
-                      }
-                    }
-                    var _o11 = join(xs, ks);
-                    var _i13 = undefined;
-                    for (_i13 in _o11) {
-                      var v = _o11[_i13];
-                      var _e17;
-                      if (numeric63(_i13)) {
-                        _e17 = parseInt(_i13);
-                      } else {
-                        _e17 = _i13;
-                      }
-                      var __i13 = _e17;
-                      s = s + sp + v;
-                      sp = " ";
-                    }
-                    return(s + ")");
-                  }
+                  _e16 = k;
+                }
+                var _k8 = _e16;
+                if (number63(_k8)) {
+                  xs[_k8] = string(v, d);
+                } else {
+                  add(ks, _k8 + ":");
+                  add(ks, string(v, d));
                 }
               }
+              var _o11 = join(xs, ks);
+              var _i13 = undefined;
+              for (_i13 in _o11) {
+                var v = _o11[_i13];
+                var _e17;
+                if (numeric63(_i13)) {
+                  _e17 = parseInt(_i13);
+                } else {
+                  _e17 = _i13;
+                }
+                var __i13 = _e17;
+                s = s + sp + v;
+                sp = " ";
+              }
+              return(s + ")");
             }
           }
         }
@@ -730,17 +715,17 @@ setenv("list", {_stash: true, macro: function () {
   var k = undefined;
   for (k in _o1) {
     var v = _o1[k];
-    var _e6;
+    var _e3;
     if (numeric63(k)) {
-      _e6 = parseInt(k);
+      _e3 = parseInt(k);
     } else {
-      _e6 = k;
+      _e3 = k;
     }
-    var _k1 = _e6;
-    if (number63(_k1)) {
-      l[_k1] = v;
+    var _k = _e3;
+    if (number63(_k)) {
+      l[_k] = v;
     } else {
-      add(forms, ["set", ["get", x, ["quote", _k1]], v]);
+      add(forms, ["set", ["get", x, ["quote", _k]], v]);
     }
   }
   if (some63(forms)) {
@@ -757,8 +742,8 @@ setenv("case", {_stash: true, macro: function (x) {
   var _r10 = unstash(Array.prototype.slice.call(arguments, 1));
   var _id2 = _r10;
   var clauses = cut(_id2, 0);
-  var bs = map(function (_x28) {
-    var _id3 = _x28;
+  var bs = map(function (_x31) {
+    var _id3 = _x31;
     var a = _id3[0];
     var b = _id3[1];
     if (nil63(b)) {
@@ -834,9 +819,9 @@ setenv("define-macro", {_stash: true, macro: function (name, args) {
   var _r25 = unstash(Array.prototype.slice.call(arguments, 2));
   var _id19 = _r25;
   var body = cut(_id19, 0);
-  var _x79 = ["setenv", ["quote", name]];
-  _x79.macro = join(["fn", args], body);
-  var form = _x79;
+  var _x89 = ["setenv", ["quote", name]];
+  _x89.macro = join(["fn", args], body);
+  var form = _x89;
   eval(form);
   return(form);
 }});
@@ -844,20 +829,20 @@ setenv("define-special", {_stash: true, macro: function (name, args) {
   var _r27 = unstash(Array.prototype.slice.call(arguments, 2));
   var _id21 = _r27;
   var body = cut(_id21, 0);
-  var _x85 = ["setenv", ["quote", name]];
-  _x85.special = join(["fn", args], body);
-  var form = join(_x85, keys(body));
+  var _x96 = ["setenv", ["quote", name]];
+  _x96.special = join(["fn", args], body);
+  var form = join(_x96, keys(body));
   eval(form);
   return(form);
 }});
 setenv("define-symbol", {_stash: true, macro: function (name, expansion) {
   setenv(name, {_stash: true, symbol: expansion});
-  var _x91 = ["setenv", ["quote", name]];
-  _x91.symbol = ["quote", expansion];
-  return(_x91);
+  var _x102 = ["setenv", ["quote", name]];
+  _x102.symbol = ["quote", expansion];
+  return(_x102);
 }});
-setenv("define-reader", {_stash: true, macro: function (_x99) {
-  var _id24 = _x99;
+setenv("define-reader", {_stash: true, macro: function (_x111) {
+  var _id24 = _x111;
   var char = _id24[0];
   var s = _id24[1];
   var _r31 = unstash(Array.prototype.slice.call(arguments, 1));
@@ -892,16 +877,16 @@ setenv("with-frame", {_stash: true, macro: function () {
   var x = unique("x");
   return(["do", ["add", "environment", ["obj"]], ["with", x, join(["do"], body), ["drop", "environment"]]]);
 }});
-setenv("with-bindings", {_stash: true, macro: function (_x128) {
-  var _id32 = _x128;
+setenv("with-bindings", {_stash: true, macro: function (_x144) {
+  var _id32 = _x144;
   var names = _id32[0];
   var _r37 = unstash(Array.prototype.slice.call(arguments, 1));
   var _id33 = _r37;
   var body = cut(_id33, 0);
   var x = unique("x");
-  var _x131 = ["setenv", x];
-  _x131.variable = true;
-  return(join(["with-frame", ["each", x, names, _x131]], body));
+  var _x147 = ["setenv", x];
+  _x147.variable = true;
+  return(join(["with-frame", ["each", x, names, _x147]], body));
 }});
 setenv("let-macro", {_stash: true, macro: function (definitions) {
   var _r40 = unstash(Array.prototype.slice.call(arguments, 1));
@@ -911,24 +896,24 @@ setenv("let-macro", {_stash: true, macro: function (definitions) {
   map(function (m) {
     return(macroexpand(join(["define-macro"], m)));
   }, definitions);
-  var _x135 = join(["do"], macroexpand(body));
+  var _x152 = join(["do"], macroexpand(body));
   drop(environment);
-  return(_x135);
+  return(_x152);
 }});
 setenv("let-symbol", {_stash: true, macro: function (expansions) {
   var _r44 = unstash(Array.prototype.slice.call(arguments, 1));
   var _id38 = _r44;
   var body = cut(_id38, 0);
   add(environment, {});
-  map(function (_x143) {
-    var _id39 = _x143;
+  map(function (_x161) {
+    var _id39 = _x161;
     var name = _id39[0];
     var exp = _id39[1];
     return(macroexpand(["define-symbol", name, exp]));
   }, pair(expansions));
-  var _x142 = join(["do"], macroexpand(body));
+  var _x160 = join(["do"], macroexpand(body));
   drop(environment);
-  return(_x142);
+  return(_x160);
 }});
 setenv("let-unique", {_stash: true, macro: function (names) {
   var _r48 = unstash(Array.prototype.slice.call(arguments, 1));
@@ -962,28 +947,28 @@ setenv("each", {_stash: true, macro: function (x, t) {
   var o = unique("o");
   var n = unique("n");
   var i = unique("i");
-  var _e7;
+  var _e4;
   if (atom63(x)) {
-    _e7 = [i, x];
+    _e4 = [i, x];
   } else {
-    var _e8;
+    var _e5;
     if (_35(x) > 1) {
-      _e8 = x;
+      _e5 = x;
     } else {
-      _e8 = [i, hd(x)];
+      _e5 = [i, hd(x)];
     }
-    _e7 = _e8;
+    _e4 = _e5;
   }
-  var _id47 = _e7;
+  var _id47 = _e4;
   var k = _id47[0];
   var v = _id47[1];
-  var _e9;
+  var _e6;
   if (target === "lua") {
-    _e9 = body;
+    _e6 = body;
   } else {
-    _e9 = [join(["let", k, ["if", ["numeric?", k], ["parseInt", k], k]], body)];
+    _e6 = [join(["let", k, ["if", ["numeric?", k], ["parseInt", k], k]], body)];
   }
-  return(["let", [o, t, k, "nil"], ["%for", o, k, join(["let", [v, ["get", o, k]]], _e9)]]);
+  return(["let", [o, t, k, "nil"], ["%for", o, k, join(["let", [v, ["get", o, k]]], _e6)]]);
 }});
 setenv("for", {_stash: true, macro: function (i, to) {
   var _r57 = unstash(Array.prototype.slice.call(arguments, 2));
@@ -1007,13 +992,13 @@ setenv("set-of", {_stash: true, macro: function () {
   var _i3 = undefined;
   for (_i3 in _o3) {
     var x = _o3[_i3];
-    var _e10;
+    var _e7;
     if (numeric63(_i3)) {
-      _e10 = parseInt(_i3);
+      _e7 = parseInt(_i3);
     } else {
-      _e10 = _i3;
+      _e7 = _i3;
     }
-    var __i3 = _e10;
+    var __i3 = _e7;
     l[x] = true;
   }
   return(join(["obj"], l));
@@ -1059,13 +1044,13 @@ setenv("export", {_stash: true, macro: function () {
     var _i5 = undefined;
     for (_i5 in _o5) {
       var k = _o5[_i5];
-      var _e11;
+      var _e8;
       if (numeric63(_i5)) {
-        _e11 = parseInt(_i5);
+        _e8 = parseInt(_i5);
       } else {
-        _e11 = _i5;
+        _e8 = _i5;
       }
-      var __i5 = _e11;
+      var __i5 = _e8;
       x[k] = k;
     }
     return(["return", join(["obj"], x)]);

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -46,14 +46,11 @@ end
 function atom63(x)
   return(nil63(x) or string63(x) or number63(x) or boolean63(x))
 end
-nan = 0 / 0
-inf = 1 / 0
-_inf = -(1 / 0)
 function nan63(n)
   return(not (n == n))
 end
 function inf63(n)
-  return(n == inf or n == _inf)
+  return(n == 1 / 0 or n == -1 / 0)
 end
 function clip(s, from, upto)
   return(ssub(s, from + 1, upto))
@@ -461,58 +458,46 @@ function string(x, depth)
     if nil63(x) then
       return("nil")
     else
-      if nan63(x) then
-        return("nan")
-      else
-        if x == inf then
-          return("inf")
+      if boolean63(x) then
+        if x then
+          return("true")
         else
-          if x == _inf then
-            return("-inf")
+          return("false")
+        end
+      else
+        if string63(x) then
+          return(escape(x))
+        else
+          if atom63(x) then
+            return(tostring(x))
           else
-            if boolean63(x) then
-              if x then
-                return("true")
-              else
-                return("false")
-              end
+            if function63(x) then
+              return("function")
             else
-              if string63(x) then
-                return(escape(x))
-              else
-                if atom63(x) then
-                  return(tostring(x))
+              local s = "("
+              local sp = ""
+              local xs = {}
+              local ks = {}
+              local d = (depth or 0) + 1
+              local _o10 = x
+              local k = nil
+              for k in next, _o10 do
+                local v = _o10[k]
+                if number63(k) then
+                  xs[k] = string(v, d)
                 else
-                  if function63(x) then
-                    return("function")
-                  else
-                    local s = "("
-                    local sp = ""
-                    local xs = {}
-                    local ks = {}
-                    local d = (depth or 0) + 1
-                    local _o10 = x
-                    local k = nil
-                    for k in next, _o10 do
-                      local v = _o10[k]
-                      if number63(k) then
-                        xs[k] = string(v, d)
-                      else
-                        add(ks, k .. ":")
-                        add(ks, string(v, d))
-                      end
-                    end
-                    local _o11 = join(xs, ks)
-                    local _i13 = nil
-                    for _i13 in next, _o11 do
-                      local v = _o11[_i13]
-                      s = s .. sp .. v
-                      sp = " "
-                    end
-                    return(s .. ")")
-                  end
+                  add(ks, k .. ":")
+                  add(ks, string(v, d))
                 end
               end
+              local _o11 = join(xs, ks)
+              local _i13 = nil
+              for _i13 in next, _o11 do
+                local v = _o11[_i13]
+                s = s .. sp .. v
+                sp = " "
+              end
+              return(s .. ")")
             end
           end
         end
@@ -666,8 +651,8 @@ setenv("case", {_stash = true, macro = function (x, ...)
   local _r10 = unstash({...})
   local _id2 = _r10
   local clauses = cut(_id2, 0)
-  local bs = map(function (_x31)
-    local _id3 = _x31
+  local bs = map(function (_x34)
+    local _id3 = _x34
     local a = _id3[1]
     local b = _id3[2]
     if nil63(b) then
@@ -743,9 +728,9 @@ setenv("define-macro", {_stash = true, macro = function (name, args, ...)
   local _r25 = unstash({...})
   local _id19 = _r25
   local body = cut(_id19, 0)
-  local _x89 = {"setenv", {"quote", name}}
-  _x89.macro = join({"fn", args}, body)
-  local form = _x89
+  local _x99 = {"setenv", {"quote", name}}
+  _x99.macro = join({"fn", args}, body)
+  local form = _x99
   eval(form)
   return(form)
 end})
@@ -753,20 +738,20 @@ setenv("define-special", {_stash = true, macro = function (name, args, ...)
   local _r27 = unstash({...})
   local _id21 = _r27
   local body = cut(_id21, 0)
-  local _x96 = {"setenv", {"quote", name}}
-  _x96.special = join({"fn", args}, body)
-  local form = join(_x96, keys(body))
+  local _x107 = {"setenv", {"quote", name}}
+  _x107.special = join({"fn", args}, body)
+  local form = join(_x107, keys(body))
   eval(form)
   return(form)
 end})
 setenv("define-symbol", {_stash = true, macro = function (name, expansion)
   setenv(name, {_stash = true, symbol = expansion})
-  local _x102 = {"setenv", {"quote", name}}
-  _x102.symbol = {"quote", expansion}
-  return(_x102)
+  local _x113 = {"setenv", {"quote", name}}
+  _x113.symbol = {"quote", expansion}
+  return(_x113)
 end})
-setenv("define-reader", {_stash = true, macro = function (_x110, ...)
-  local _id24 = _x110
+setenv("define-reader", {_stash = true, macro = function (_x122, ...)
+  local _id24 = _x122
   local char = _id24[1]
   local s = _id24[2]
   local _r31 = unstash({...})
@@ -789,7 +774,7 @@ setenv("define-global", {_stash = true, macro = function (name, x, ...)
   local _r35 = unstash({...})
   local _id29 = _r35
   local body = cut(_id29, 0)
-  setenv(name, {_stash = true, toplevel = true, variable = true})
+  setenv(name, {_stash = true, variable = true, toplevel = true})
   if some63(body) then
     return(join({"%global-function", name}, bind42(x, body)))
   else
@@ -801,16 +786,16 @@ setenv("with-frame", {_stash = true, macro = function (...)
   local x = unique("x")
   return({"do", {"add", "environment", {"obj"}}, {"with", x, join({"do"}, body), {"drop", "environment"}}})
 end})
-setenv("with-bindings", {_stash = true, macro = function (_x143, ...)
-  local _id32 = _x143
+setenv("with-bindings", {_stash = true, macro = function (_x159, ...)
+  local _id32 = _x159
   local names = _id32[1]
   local _r37 = unstash({...})
   local _id33 = _r37
   local body = cut(_id33, 0)
   local x = unique("x")
-  local _x147 = {"setenv", x}
-  _x147.variable = true
-  return(join({"with-frame", {"each", x, names, _x147}}, body))
+  local _x163 = {"setenv", x}
+  _x163.variable = true
+  return(join({"with-frame", {"each", x, names, _x163}}, body))
 end})
 setenv("let-macro", {_stash = true, macro = function (definitions, ...)
   local _r40 = unstash({...})
@@ -820,24 +805,24 @@ setenv("let-macro", {_stash = true, macro = function (definitions, ...)
   map(function (m)
     return(macroexpand(join({"define-macro"}, m)))
   end, definitions)
-  local _x152 = join({"do"}, macroexpand(body))
+  local _x169 = join({"do"}, macroexpand(body))
   drop(environment)
-  return(_x152)
+  return(_x169)
 end})
 setenv("let-symbol", {_stash = true, macro = function (expansions, ...)
   local _r44 = unstash({...})
   local _id38 = _r44
   local body = cut(_id38, 0)
   add(environment, {})
-  map(function (_x161)
-    local _id39 = _x161
+  map(function (_x179)
+    local _id39 = _x179
     local name = _id39[1]
     local exp = _id39[2]
     return(macroexpand({"define-symbol", name, exp}))
   end, pair(expansions))
-  local _x160 = join({"do"}, macroexpand(body))
+  local _x178 = join({"do"}, macroexpand(body))
   drop(environment)
-  return(_x160)
+  return(_x178)
 end})
 setenv("let-unique", {_stash = true, macro = function (names, ...)
   local _r48 = unstash({...})
@@ -871,28 +856,28 @@ setenv("each", {_stash = true, macro = function (x, t, ...)
   local o = unique("o")
   local n = unique("n")
   local i = unique("i")
-  local _e6
+  local _e3
   if atom63(x) then
-    _e6 = {i, x}
+    _e3 = {i, x}
   else
-    local _e7
+    local _e4
     if _35(x) > 1 then
-      _e7 = x
+      _e4 = x
     else
-      _e7 = {i, hd(x)}
+      _e4 = {i, hd(x)}
     end
-    _e6 = _e7
+    _e3 = _e4
   end
-  local _id47 = _e6
+  local _id47 = _e3
   local k = _id47[1]
   local v = _id47[2]
-  local _e8
+  local _e5
   if target == "lua" then
-    _e8 = body
+    _e5 = body
   else
-    _e8 = {join({"let", k, {"if", {"numeric?", k}, {"parseInt", k}, k}}, body)}
+    _e5 = {join({"let", k, {"if", {"numeric?", k}, {"parseInt", k}, k}}, body)}
   end
-  return({"let", {o, t, k, "nil"}, {"%for", o, k, join({"let", {v, {"get", o, k}}}, _e8)}})
+  return({"let", {o, t, k, "nil"}, {"%for", o, k, join({"let", {v, {"get", o, k}}}, _e5)}})
 end})
 setenv("for", {_stash = true, macro = function (i, to, ...)
   local _r57 = unstash({...})

--- a/bin/reader.js
+++ b/bin/reader.js
@@ -1,7 +1,7 @@
-var delimiters = {"(": true, ")": true, ";": true, "\n": true};
-var whitespace = {" ": true, "\t": true, "\n": true};
+var delimiters = {")": true, ";": true, "\n": true, "(": true};
+var whitespace = {"\t": true, " ": true, "\n": true};
 var stream = function (str, more) {
-  return({pos: 0, string: str, len: _35(str), more: more});
+  return({pos: 0, string: str, more: more, len: _35(str)});
 };
 var peek_char = function (s) {
   var _id = s;
@@ -96,6 +96,7 @@ var wrap = function (s, x) {
     return([x, y]);
   }
 };
+var literals = {"false": false, nan: ["/", 0, 0], "-nan": ["/", 0, 0], "-inf": ["/", -1, 0], inf: ["/", 1, 0], "true": true};
 read_table[""] = function (s) {
   var str = "";
   while (true) {
@@ -106,22 +107,15 @@ read_table[""] = function (s) {
       break;
     }
   }
-  if (str === "true") {
-    return(true);
+  var e = literals[str];
+  if (is63(e)) {
+    return(e);
   } else {
-    if (str === "false") {
-      return(false);
+    var n = number(str);
+    if (nil63(n) || nan63(n) || inf63(n)) {
+      return(str);
     } else {
-      if (str === "inf" || str === "-inf" || str === "nan" || str === "-nan") {
-        return(str);
-      } else {
-        var n = number(str);
-        if (is63(n)) {
-          return(n);
-        } else {
-          return(str);
-        }
-      }
+      return(n);
     }
   }
 };

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -1,5 +1,5 @@
-local delimiters = {["("] = true, [")"] = true, [";"] = true, ["\n"] = true}
-local whitespace = {[" "] = true, ["\t"] = true, ["\n"] = true}
+local delimiters = {["("] = true, ["\n"] = true, [")"] = true, [";"] = true}
+local whitespace = {["\n"] = true, ["\t"] = true, [" "] = true}
 local function stream(str, more)
   return({pos = 0, string = str, len = _35(str), more = more})
 end
@@ -76,8 +76,8 @@ local function flag63(atom)
 end
 local function expected(s, c)
   local _id1 = s
-  local more = _id1.more
   local pos = _id1.pos
+  local more = _id1.more
   local _id2 = more
   local _e
   if _id2 then
@@ -96,6 +96,7 @@ local function wrap(s, x)
     return({x, y})
   end
 end
+local literals = {["false"] = false, ["true"] = true, nan = {"/", 0, 0}, inf = {"/", 1, 0}, ["-nan"] = {"/", 0, 0}, ["-inf"] = {"/", -1, 0}}
 read_table[""] = function (s)
   local str = ""
   while true do
@@ -106,22 +107,15 @@ read_table[""] = function (s)
       break
     end
   end
-  if str == "true" then
-    return(true)
+  local e = literals[str]
+  if is63(e) then
+    return(e)
   else
-    if str == "false" then
-      return(false)
+    local n = number(str)
+    if nil63(n) or nan63(n) or inf63(n) then
+      return(str)
     else
-      if str == "inf" or str == "-inf" or str == "nan" or str == "-nan" then
-        return(str)
-      else
-        local n = number(str)
-        if is63(n) then
-          return(n)
-        else
-          return(str)
-        end
-      end
+      return(n)
     end
   end
 end
@@ -215,4 +209,4 @@ read_table[","] = function (s)
     return(wrap(s, "unquote"))
   end
 end
-return({stream = stream, read = read, ["read-all"] = read_all, ["read-string"] = read_string})
+return({["read-all"] = read_all, read = read, ["read-string"] = read_string, stream = stream})

--- a/reader.l
+++ b/reader.l
@@ -68,6 +68,10 @@
     (if (= y (get s 'more)) y
       (list x y))))
 
+(define literals (obj true: true false: false
+                      nan: '(/ 0 0) -nan: '(/ 0 0) 
+                      inf: '(/ 1 0) -inf: '(/ -1 0)))
+
 (define-reader ("" s) ; atom
   (let (str "")
     (while true
@@ -76,13 +80,10 @@
 			(not (get delimiters c))))
 	    (cat! str (read-char s))
 	  (break))))
-    (if (= str "true") true
-        (= str "false") false
-        (or (= str "inf") (= str "-inf")
-            (= str "nan") (= str "-nan"))
-        str
-      (let n (number str)
-        (if (is? n) n str)))))
+    (let e (get literals str)
+      (if (is? e) e
+        (let n (number str)
+          (if (or (nil? n) (nan? n) (inf? n)) str n))))))
 
 (define-reader ("(" s)
   (read-char s)

--- a/runtime.l
+++ b/runtime.l
@@ -38,10 +38,6 @@
 (define-global atom? (x)
   (or (nil? x) (string? x) (number? x) (boolean? x)))
 
-(define-global nan (/ 0 0))
-(define-global inf (/ 1 0))
-(define-global -inf (- (/ 1 0)))
-
 (define-global nan? (n)
   (not (= n n)))
 
@@ -282,9 +278,6 @@
 (define-global string (x depth)
   (if (and depth (> depth 7)) "circular"
       (nil? x) "nil"
-      (nan? x) "nan"
-      (= x inf) "inf"
-      (= x -inf) "-inf"
       (boolean? x) (if x "true" "false")
       (string? x) (escape x)
       (atom? x) (tostring x)

--- a/test.l
+++ b/test.l
@@ -661,16 +661,33 @@ c"
     (let-unique (ham)
       (test= '_ham1 ham))))
 
-(define-test globals
-  (test= true true)
-  (test= false false)
+(define-macro infnan-tests ()
+  `(do
   (test= true (< -inf -1e10))
   (test= false (< inf -1e10))
   (test= false (= nan nan))
   (test= true (nan? nan))
   (test= true (nan? (* nan 20)))
   (test= -inf (- inf))
-  (test= inf (- -inf)))
+  (test= inf (- -inf))))
+
+
+(define-test globals
+  (test= true true)
+  (test= false false)
+  (let-macro ((retest () `(do
+      (test= true (< -inf -1e10))
+      (test= false (< inf -1e10))
+      (test= false (= nan nan))
+      (test= true (nan? nan))
+      (test= true (nan? (* nan 20)))
+      (test= -inf (- inf))
+      (test= inf (- -inf)))))
+    (retest)
+    (let Inf 42 (test= Inf 42) (retest))
+    (let NaN 42 (test= NaN 42) (retest))
+    (let -Inf 42 (test= -Inf 42) (retest))
+    (let -NaN 42 (test= -NaN 42) (retest))))
 
 (define-test add
   (let l ()


### PR DESCRIPTION
Implemented as per https://github.com/sctb/lumen/pull/2#issuecomment-142413079.

Also added new tests that verify `-NaN` is a valid identifier whereas `-nan` compiles to `(/ 0 0)` etc.

```scheme
(define-test globals
  (test= true true)
  (test= false false)
  (let-macro ((retest () `(do
      (test= true (< -inf -1e10))
      (test= false (< inf -1e10))
      (test= false (= nan nan))
      (test= true (nan? nan))
      (test= true (nan? (* nan 20)))
      (test= -inf (- inf))
      (test= inf (- -inf)))))
    (retest)
    (let Inf 42 (test= Inf 42) (retest))
    (let NaN 42 (test= NaN 42) (retest))
    (let -Inf 42 (test= -Inf 42) (retest))
    (let -NaN 42 (test= -NaN 42) (retest))))
```

```
$ make test
js:
 547 passed, 0 failed
lua:
 547 passed, 0 failed
```
```
$ LUMEN_HOST=luajit make test
js:
 547 passed, 0 failed
lua:
 547 passed, 0 failed
```