### PR TITLE
Minor fixes

### DIFF
--- a/bin/lumen
+++ b/bin/lumen
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 dir="$(pwd)"
-cd "$(dirname $0)"
+cd "$(dirname "$0")"
 home="$(pwd)"
 cd "${dir}"
 

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -558,24 +558,34 @@ function setenv(k, ...)
     return(frame[k])
   end
 end
-local function call_with_file(path, f)
+local function call_with_file(file, f)
   local _e,_x12 = xpcall(function ()
-    return(f(path))
+    return(f(file))
   end, _37message_handler)
   local _id2 = {_e, _x12}
   local ok = _id2[1]
   local s = _id2[2]
-  path.close(path)
+  if file then
+    file.close(file)
+  end
   return(s)
 end
 function read_file(path)
   return(call_with_file(io.open(path), function (f)
-    return(f.read(f, "*a"))
+    if is63(f) then
+      return(f.read(f, "*a"))
+    else
+      error("read-file: Couldn't open file: " .. path)
+    end
   end))
 end
 function write_file(path, data)
   return(call_with_file(io.open(path, "w"), function (f)
-    return(f.write(f, data))
+    if is63(f) then
+      return(f.write(f, data))
+    else
+      error("write-file: Couldn't open file: " .. path)
+    end
   end))
 end
 function file_exists63(path)

--- a/runtime.l
+++ b/runtime.l
@@ -332,22 +332,25 @@
 (target js: (define fs (require 'fs)))
 
 (target lua:
-  (define call-with-file (path f)
-    (let ((ok s) (guard (f path)))
-      ((get path 'close) path)
+  (define call-with-file (file f)
+    (let ((ok s) (guard (f file)))
+      (when file
+        ((get file 'close) file))
       s)))
 
 (define-global read-file (path)
   (target
     js: ((get fs 'readFileSync) path 'utf8)
     lua: (call-with-file ((get io 'open) path)
-           (fn (f) ((get f 'read) f '*a)))))
+           (fn (f) (if (is? f) ((get f 'read) f '*a)
+                     (error (cat "read-file: Couldn't open file: " path)))))))
 
 (define-global write-file (path data)
   (target
     js: ((get fs 'writeFileSync) path data 'utf8)
     lua: (call-with-file ((get io 'open) path 'w)
-           (fn (f) ((get f 'write) f data)))))
+           (fn (f) (if (is? f) ((get f 'write) f data)
+                     (error (cat "write-file: Couldn't open file: " path)))))))
 
 (define-global file-exists? (path)
   (target


### PR DESCRIPTION
`bin/lumen` fixes:
- Fix bin/lumen to handle spaces in $0

`runtime.l` fixes:
- Generate an informative error when read-file or write-file fails
