### PR TITLE
Additions and fixes

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -79,13 +79,13 @@ var stash42 = function (args) {
     var k = undefined;
     for (k in _o) {
       var v = _o[k];
-      var _e9;
+      var _e;
       if (numeric63(k)) {
-        _e9 = parseInt(k);
+        _e = parseInt(k);
       } else {
-        _e9 = k;
+        _e = k;
       }
-      var _k = _e9;
+      var _k = _e;
       if (! number63(_k)) {
         add(l, literal(_k));
         add(l, v);
@@ -116,28 +116,28 @@ bind = function (lh, rh) {
     var k = undefined;
     for (k in _o1) {
       var v = _o1[k];
-      var _e10;
+      var _e1;
       if (numeric63(k)) {
-        _e10 = parseInt(k);
+        _e1 = parseInt(k);
       } else {
-        _e10 = k;
+        _e1 = k;
       }
-      var _k1 = _e10;
-      var _e11;
+      var _k1 = _e1;
+      var _e2;
       if (_k1 === "rest") {
-        _e11 = ["cut", id, _35(lh)];
+        _e2 = ["cut", id, _35(lh)];
       } else {
-        _e11 = ["get", id, ["quote", bias(_k1)]];
+        _e2 = ["get", id, ["quote", bias(_k1)]];
       }
-      var x = _e11;
+      var x = _e2;
       if (is63(_k1)) {
-        var _e12;
+        var _e3;
         if (v === true) {
-          _e12 = _k1;
+          _e3 = _k1;
         } else {
-          _e12 = v;
+          _e3 = v;
         }
-        var _k2 = _e12;
+        var _k2 = _e3;
         bs = join(bs, bind(_k2, x));
       }
     }
@@ -166,13 +166,13 @@ bind42 = function (args, body) {
     var k = undefined;
     for (k in _o2) {
       var v = _o2[k];
-      var _e13;
+      var _e4;
       if (numeric63(k)) {
-        _e13 = parseInt(k);
+        _e4 = parseInt(k);
       } else {
-        _e13 = k;
+        _e4 = k;
       }
-      var _k3 = _e13;
+      var _k3 = _e4;
       if (number63(_k3)) {
         if (atom63(v)) {
           add(args1, v);
@@ -219,13 +219,13 @@ var expand_function = function (_x36) {
   var _i3 = undefined;
   for (_i3 in _o3) {
     var _x37 = _o3[_i3];
-    var _e14;
+    var _e5;
     if (numeric63(_i3)) {
-      _e14 = parseInt(_i3);
+      _e5 = parseInt(_i3);
     } else {
-      _e14 = _i3;
+      _e5 = _i3;
     }
-    var __i3 = _e14;
+    var __i3 = _e5;
     setenv(_x37, {_stash: true, variable: true});
   }
   var _x38 = join(["%function", args], macroexpand(body));
@@ -243,13 +243,13 @@ var expand_definition = function (_x40) {
   var _i4 = undefined;
   for (_i4 in _o4) {
     var _x41 = _o4[_i4];
-    var _e15;
+    var _e6;
     if (numeric63(_i4)) {
-      _e15 = parseInt(_i4);
+      _e6 = parseInt(_i4);
     } else {
-      _e15 = _i4;
+      _e6 = _i4;
     }
-    var __i4 = _e15;
+    var __i4 = _e6;
     setenv(_x41, {_stash: true, variable: true});
   }
   var _x42 = join([x, name, args], macroexpand(body));
@@ -300,21 +300,21 @@ var quasiquote_list = function (form, depth) {
   var k = undefined;
   for (k in _o5) {
     var v = _o5[k];
-    var _e16;
+    var _e7;
     if (numeric63(k)) {
-      _e16 = parseInt(k);
+      _e7 = parseInt(k);
     } else {
-      _e16 = k;
+      _e7 = k;
     }
-    var _k4 = _e16;
+    var _k4 = _e7;
     if (! number63(_k4)) {
-      var _e17;
+      var _e8;
       if (quasisplice63(v, depth)) {
-        _e17 = quasiexpand(v[1]);
+        _e8 = quasiexpand(v[1]);
       } else {
-        _e17 = quasiexpand(v, depth);
+        _e8 = quasiexpand(v, depth);
       }
-      var _v = _e17;
+      var _v = _e8;
       last(xs)[_k4] = _v;
     }
   }
@@ -440,13 +440,13 @@ mapo = function (f, t) {
   var k = undefined;
   for (k in _o6) {
     var v = _o6[k];
-    var _e18;
+    var _e9;
     if (numeric63(k)) {
-      _e18 = parseInt(k);
+      _e9 = parseInt(k);
     } else {
-      _e18 = k;
+      _e9 = k;
     }
-    var _k5 = _e18;
+    var _k5 = _e9;
     var x = f(v);
     if (is63(x)) {
       add(o, literal(_k5));
@@ -505,13 +505,13 @@ var precedence = function (form) {
     var k = undefined;
     for (k in _o7) {
       var v = _o7[k];
-      var _e19;
+      var _e10;
       if (numeric63(k)) {
-        _e19 = parseInt(k);
+        _e10 = parseInt(k);
       } else {
-        _e19 = k;
+        _e10 = k;
       }
-      var _k6 = _e19;
+      var _k6 = _e10;
       if (v[hd(form)]) {
         return(index(_k6));
       }
@@ -553,13 +553,13 @@ var escape_newlines = function (s) {
   var i = 0;
   while (i < _35(s)) {
     var c = char(s, i);
-    var _e20;
+    var _e11;
     if (c === "\n") {
-      _e20 = "\\n";
+      _e11 = "\\n";
     } else {
-      _e20 = c;
+      _e11 = c;
     }
-    s1 = s1 + _e20;
+    s1 = s1 + _e11;
     i = i + 1;
   }
   return(s1);
@@ -570,25 +570,25 @@ var id = function (id) {
   while (i < _35(id)) {
     var c = char(id, i);
     var n = code(c);
-    var _e21;
+    var _e12;
     if (c === "-") {
-      _e21 = "_";
+      _e12 = "_";
     } else {
-      var _e22;
+      var _e13;
       if (valid_code63(n)) {
-        _e22 = c;
+        _e13 = c;
       } else {
-        var _e23;
+        var _e14;
         if (i === 0) {
-          _e23 = "_" + n;
+          _e14 = "_" + n;
         } else {
-          _e23 = n;
+          _e14 = n;
         }
-        _e22 = _e23;
+        _e13 = _e14;
       }
-      _e21 = _e22;
+      _e12 = _e13;
     }
-    var c1 = _e21;
+    var c1 = _e12;
     id1 = id1 + c1;
     i = i + 1;
   }
@@ -668,13 +668,13 @@ var op_delims = function (parent, child) {
   var _r56 = unstash(Array.prototype.slice.call(arguments, 2));
   var _id7 = _r56;
   var right = _id7.right;
-  var _e24;
+  var _e15;
   if (right) {
-    _e24 = _6261;
+    _e15 = _6261;
   } else {
-    _e24 = _62;
+    _e15 = _62;
   }
-  if (_e24(precedence(child), precedence(parent))) {
+  if (_e15(precedence(child), precedence(parent))) {
     return(["(", ")"]);
   } else {
     return(["", ""]);
@@ -706,33 +706,33 @@ compile_function = function (args, body) {
   var _id12 = _r58;
   var name = _id12.name;
   var prefix = _id12.prefix;
-  var _e25;
+  var _e16;
   if (name) {
-    _e25 = compile(name);
+    _e16 = compile(name);
   } else {
-    _e25 = "";
+    _e16 = "";
   }
-  var _id13 = _e25;
+  var _id13 = _e16;
   var _args = compile_args(args);
   indent_level = indent_level + 1;
   var _x74 = compile(body, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
   var _body = _x74;
   var ind = indentation();
-  var _e26;
+  var _e17;
   if (prefix) {
-    _e26 = prefix + " ";
+    _e17 = prefix + " ";
   } else {
-    _e26 = "";
+    _e17 = "";
   }
-  var p = _e26;
-  var _e27;
+  var p = _e17;
+  var _e18;
   if (target === "js") {
-    _e27 = "";
+    _e18 = "";
   } else {
-    _e27 = "end";
+    _e18 = "end";
   }
-  var tr = _e27;
+  var tr = _e18;
   if (name) {
     tr = tr + "\n";
   }
@@ -756,26 +756,26 @@ compile = function (form) {
       return(compile_special(form, stmt));
     } else {
       var tr = terminator(stmt);
-      var _e28;
+      var _e19;
       if (stmt) {
-        _e28 = indentation();
+        _e19 = indentation();
       } else {
-        _e28 = "";
+        _e19 = "";
       }
-      var ind = _e28;
-      var _e29;
+      var ind = _e19;
+      var _e20;
       if (atom63(form)) {
-        _e29 = compile_atom(form);
+        _e20 = compile_atom(form);
       } else {
-        var _e30;
+        var _e21;
         if (infix63(hd(form))) {
-          _e30 = compile_infix(form);
+          _e21 = compile_infix(form);
         } else {
-          _e30 = compile_call(form);
+          _e21 = compile_call(form);
         }
-        _e29 = _e30;
+        _e20 = _e21;
       }
-      var _form = _e29;
+      var _form = _e20;
       return(ind + _form + tr);
     }
   }
@@ -843,19 +843,19 @@ var lower_if = function (args, hoist, stmt63, tail63) {
   var _then = _id16[1];
   var _else = _id16[2];
   if (stmt63 || tail63) {
-    var _e32;
+    var _e23;
     if (_else) {
-      _e32 = [lower_body([_else], tail63)];
+      _e23 = [lower_body([_else], tail63)];
     }
-    return(add(hoist, join(["%if", lower(cond, hoist), lower_body([_then], tail63)], _e32)));
+    return(add(hoist, join(["%if", lower(cond, hoist), lower_body([_then], tail63)], _e23)));
   } else {
     var e = unique("e");
     add(hoist, ["%local", e]);
-    var _e31;
+    var _e22;
     if (_else) {
-      _e31 = [lower(["set", e, _else])];
+      _e22 = [lower(["set", e, _else])];
     }
-    add(hoist, join(["%if", lower(cond, hoist), lower(["set", e, _then])], _e31));
+    add(hoist, join(["%if", lower(cond, hoist), lower(["set", e, _then])], _e22));
     return(e);
   }
 };
@@ -867,13 +867,13 @@ var lower_short = function (x, args, hoist) {
   var b1 = lower(b, hoist1);
   if (some63(hoist1)) {
     var _id18 = unique("id");
-    var _e33;
+    var _e24;
     if (x === "and") {
-      _e33 = ["%if", _id18, b, _id18];
+      _e24 = ["%if", _id18, b, _id18];
     } else {
-      _e33 = ["%if", _id18, _id18, b];
+      _e24 = ["%if", _id18, _id18, b];
     }
-    return(lower(["do", ["%local", _id18, a], _e33], hoist));
+    return(lower(["do", ["%local", _id18, a], _e24], hoist));
   } else {
     return([x, lower(a, hoist), b1]);
   }
@@ -1011,42 +1011,56 @@ eval = function (form) {
 var run_file = function (path) {
   return(run(read_file(path)));
 };
+var compile_string = function (s) {
+  var out = "";
+  var _x105 = read_from_string(s);
+  var _n11 = _35(_x105);
+  var _i11 = 0;
+  while (_i11 < _n11) {
+    var expr = _x105[_i11];
+    var form = expand(["do", expr]);
+    out = out + compile(form, {_stash: true, stmt: true});
+    _i11 = _i11 + 1;
+  }
+  return(out);
+};
 var compile_file = function (path) {
-  var s = reader.stream(read_file(path));
-  var body = reader["read-all"](s);
-  var form = expand(join(["do"], body));
-  return(compile(form, {_stash: true, stmt: true}));
+  return(compile_string(read_file(path)));
+};
+load_string = function (s) {
+  run(compile_string("(set %result ((fn () " + s + ")))"));
+  return(_37result);
 };
 load = function (path) {
-  return(run(compile_file(path)));
+  return(load_string(read_file(path)));
 };
 setenv("do", {_stash: true, tr: true, special: function () {
   var forms = unstash(Array.prototype.slice.call(arguments, 0));
   var s = "";
-  var _x108 = forms;
-  var _n12 = _35(_x108);
-  var _i12 = 0;
-  while (_i12 < _n12) {
-    var x = _x108[_i12];
+  var _x109 = forms;
+  var _n13 = _35(_x109);
+  var _i13 = 0;
+  while (_i13 < _n13) {
+    var x = _x109[_i13];
     s = s + compile(x, {_stash: true, stmt: true});
-    _i12 = _i12 + 1;
+    _i13 = _i13 + 1;
   }
   return(s);
 }, stmt: true});
 setenv("%if", {_stash: true, tr: true, special: function (cond, cons, alt) {
   var _cond1 = compile(cond);
   indent_level = indent_level + 1;
-  var _x111 = compile(cons, {_stash: true, stmt: true});
+  var _x112 = compile(cons, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var _cons1 = _x111;
-  var _e34;
+  var _cons1 = _x112;
+  var _e26;
   if (alt) {
     indent_level = indent_level + 1;
-    var _x112 = compile(alt, {_stash: true, stmt: true});
+    var _x113 = compile(alt, {_stash: true, stmt: true});
     indent_level = indent_level - 1;
-    _e34 = _x112;
+    _e26 = _x113;
   }
-  var _alt1 = _e34;
+  var _alt1 = _e26;
   var ind = indentation();
   var s = "";
   if (target === "js") {
@@ -1070,9 +1084,9 @@ setenv("%if", {_stash: true, tr: true, special: function (cond, cons, alt) {
 setenv("while", {_stash: true, tr: true, special: function (cond, form) {
   var _cond3 = compile(cond);
   indent_level = indent_level + 1;
-  var _x114 = compile(form, {_stash: true, stmt: true});
+  var _x115 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var body = _x114;
+  var body = _x115;
   var ind = indentation();
   if (target === "js") {
     return(ind + "while (" + _cond3 + ") {\n" + body + ind + "}\n");
@@ -1084,9 +1098,9 @@ setenv("%for", {_stash: true, tr: true, special: function (t, k, form) {
   var _t1 = compile(t);
   var ind = indentation();
   indent_level = indent_level + 1;
-  var _x116 = compile(form, {_stash: true, stmt: true});
+  var _x117 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var body = _x116;
+  var body = _x117;
   if (target === "lua") {
     return(ind + "for " + k + " in next, " + _t1 + " do\n" + body + ind + "end\n");
   } else {
@@ -1097,14 +1111,14 @@ setenv("%try", {_stash: true, tr: true, special: function (form) {
   var e = unique("e");
   var ind = indentation();
   indent_level = indent_level + 1;
-  var _x122 = compile(form, {_stash: true, stmt: true});
+  var _x123 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var body = _x122;
+  var body = _x123;
   var hf = ["return", ["%array", false, ["get", e, "\"message\""]]];
   indent_level = indent_level + 1;
-  var _x126 = compile(hf, {_stash: true, stmt: true});
+  var _x127 = compile(hf, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var h = _x126;
+  var h = _x127;
   return(ind + "try {\n" + body + ind + "}\n" + ind + "catch (" + e + ") {\n" + h + ind + "}\n");
 }, stmt: true});
 setenv("%delete", {_stash: true, special: function (place) {
@@ -1133,57 +1147,57 @@ setenv("%local-function", {_stash: true, tr: true, special: function (name, args
   }
 }, stmt: true});
 setenv("return", {_stash: true, special: function (x) {
-  var _e35;
+  var _e28;
   if (nil63(x)) {
-    _e35 = "return";
+    _e28 = "return";
   } else {
-    _e35 = "return(" + compile(x) + ")";
+    _e28 = "return(" + compile(x) + ")";
   }
-  var _x136 = _e35;
-  return(indentation() + _x136);
+  var _x137 = _e28;
+  return(indentation() + _x137);
 }, stmt: true});
 setenv("new", {_stash: true, special: function (x) {
   return("new " + compile(x));
 }});
 setenv("error", {_stash: true, special: function (x) {
-  var _e36;
+  var _e30;
   if (target === "js") {
-    _e36 = "throw " + compile(["new", ["Error", x]]);
+    _e30 = "throw " + compile(["new", ["Error", x]]);
   } else {
-    _e36 = "error(" + compile(x) + ")";
+    _e30 = "error(" + compile(x) + ")";
   }
-  var e = _e36;
+  var e = _e30;
   return(indentation() + e);
 }, stmt: true});
 setenv("%local", {_stash: true, special: function (name, value) {
   var _id26 = compile(name);
   var value1 = compile(value);
-  var _e37;
+  var _e33;
   if (is63(value)) {
-    _e37 = " = " + value1;
+    _e33 = " = " + value1;
   } else {
-    _e37 = "";
+    _e33 = "";
   }
-  var rh = _e37;
-  var _e38;
+  var rh = _e33;
+  var _e34;
   if (target === "js") {
-    _e38 = "var ";
+    _e34 = "var ";
   } else {
-    _e38 = "local ";
+    _e34 = "local ";
   }
-  var keyword = _e38;
+  var keyword = _e34;
   var ind = indentation();
   return(ind + keyword + _id26 + rh);
 }, stmt: true});
 setenv("set", {_stash: true, special: function (lh, rh) {
   var _lh1 = compile(lh);
-  var _e39;
+  var _e36;
   if (nil63(rh)) {
-    _e39 = "nil";
+    _e36 = "nil";
   } else {
-    _e39 = rh;
+    _e36 = rh;
   }
-  var _rh1 = compile(_e39);
+  var _rh1 = compile(_e36);
   return(indentation() + _lh1 + " = " + _rh1);
 }, stmt: true});
 setenv("get", {_stash: true, special: function (t, k) {
@@ -1200,33 +1214,33 @@ setenv("get", {_stash: true, special: function (t, k) {
 }});
 setenv("%array", {_stash: true, special: function () {
   var forms = unstash(Array.prototype.slice.call(arguments, 0));
+  var _e39;
+  if (target === "lua") {
+    _e39 = "{";
+  } else {
+    _e39 = "[";
+  }
+  var open = _e39;
   var _e40;
   if (target === "lua") {
-    _e40 = "{";
+    _e40 = "}";
   } else {
-    _e40 = "[";
+    _e40 = "]";
   }
-  var open = _e40;
-  var _e41;
-  if (target === "lua") {
-    _e41 = "}";
-  } else {
-    _e41 = "]";
-  }
-  var close = _e41;
+  var close = _e40;
   var s = "";
   var c = "";
   var _o9 = forms;
   var k = undefined;
   for (k in _o9) {
     var v = _o9[k];
-    var _e42;
+    var _e41;
     if (numeric63(k)) {
-      _e42 = parseInt(k);
+      _e41 = parseInt(k);
     } else {
-      _e42 = k;
+      _e41 = k;
     }
-    var _k7 = _e42;
+    var _k7 = _e41;
     if (number63(_k7)) {
       s = s + c + compile(v);
       c = ", ";
@@ -1271,7 +1285,9 @@ setenv("%object", {_stash: true, special: function () {
 }});
 exports.eval = eval;
 exports["run-file"] = run_file;
+exports["compile-string"] = compile_string;
 exports["compile-file"] = compile_file;
+exports["load-string"] = load_string;
 exports.load = load;
 exports.expand = expand;
 exports.compile = compile;

--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -401,7 +401,7 @@ indentation = function () {
   }
   return(s);
 };
-var reserved = {"repeat": true, "delete": true, "typeof": true, "case": true, "do": true, "<=": true, "catch": true, "else": true, "for": true, "with": true, ">": true, "elseif": true, "local": true, "break": true, "void": true, "<": true, "return": true, "false": true, "while": true, "/": true, "%": true, "throw": true, "-": true, "+": true, "new": true, "nil": true, "default": true, "instanceof": true, "end": true, "==": true, "and": true, "=": true, "in": true, "until": true, "or": true, "if": true, "var": true, "debugger": true, "this": true, "switch": true, "*": true, "not": true, "continue": true, "finally": true, "try": true, "true": true, "function": true, ">=": true, "then": true};
+var reserved = {"else": true, "<": true, "true": true, "/": true, "end": true, "typeof": true, "function": true, "switch": true, "=": true, "or": true, "try": true, "catch": true, "until": true, "local": true, "repeat": true, "-": true, "false": true, "continue": true, "==": true, "and": true, "if": true, "for": true, ">=": true, "<=": true, "with": true, "return": true, "finally": true, "nil": true, "new": true, "do": true, "case": true, "break": true, "elseif": true, "+": true, "not": true, "void": true, "var": true, "%": true, "in": true, "delete": true, "throw": true, "debugger": true, "instanceof": true, "this": true, "while": true, "then": true, "default": true, "*": true, ">": true};
 reserved63 = function (x) {
   return(reserved[x]);
 };
@@ -461,22 +461,22 @@ _x58.lua = "not ";
 _x58.js = "!";
 __x57["not"] = _x58;
 var __x59 = [];
-__x59["*"] = true;
 __x59["/"] = true;
+__x59["*"] = true;
 __x59["%"] = true;
 var __x60 = [];
-__x60["-"] = true;
 __x60["+"] = true;
+__x60["-"] = true;
 var __x61 = [];
 var _x62 = [];
 _x62.lua = "..";
 _x62.js = "+";
 __x61.cat = _x62;
 var __x63 = [];
-__x63[">"] = true;
+__x63["<="] = true;
 __x63[">="] = true;
 __x63["<"] = true;
-__x63["<="] = true;
+__x63[">"] = true;
 var __x64 = [];
 var _x65 = [];
 _x65.lua = "==";
@@ -645,8 +645,8 @@ var compile_special = function (form, stmt63) {
   var x = _id5[0];
   var args = cut(_id5, 1);
   var _id6 = getenv(x);
-  var stmt = _id6.stmt;
   var self_tr63 = _id6.tr;
+  var stmt = _id6.stmt;
   var special = _id6.special;
   var tr = terminator(stmt63 && ! self_tr63);
   return(apply(special, args) + tr);
@@ -704,8 +704,8 @@ var compile_infix = function (form) {
 compile_function = function (args, body) {
   var _r58 = unstash(Array.prototype.slice.call(arguments, 2));
   var _id12 = _r58;
-  var prefix = _id12.prefix;
   var name = _id12.name;
+  var prefix = _id12.prefix;
   var _e25;
   if (name) {
     _e25 = compile(name);
@@ -1020,7 +1020,7 @@ var compile_file = function (path) {
 load = function (path) {
   return(run(compile_file(path)));
 };
-setenv("do", {_stash: true, stmt: true, tr: true, special: function () {
+setenv("do", {_stash: true, tr: true, special: function () {
   var forms = unstash(Array.prototype.slice.call(arguments, 0));
   var s = "";
   var _x108 = forms;
@@ -1032,8 +1032,8 @@ setenv("do", {_stash: true, stmt: true, tr: true, special: function () {
     _i12 = _i12 + 1;
   }
   return(s);
-}});
-setenv("%if", {_stash: true, stmt: true, tr: true, special: function (cond, cons, alt) {
+}, stmt: true});
+setenv("%if", {_stash: true, tr: true, special: function (cond, cons, alt) {
   var _cond1 = compile(cond);
   indent_level = indent_level + 1;
   var _x111 = compile(cons, {_stash: true, stmt: true});
@@ -1066,8 +1066,8 @@ setenv("%if", {_stash: true, stmt: true, tr: true, special: function (cond, cons
   } else {
     return(s + "\n");
   }
-}});
-setenv("while", {_stash: true, stmt: true, tr: true, special: function (cond, form) {
+}, stmt: true});
+setenv("while", {_stash: true, tr: true, special: function (cond, form) {
   var _cond3 = compile(cond);
   indent_level = indent_level + 1;
   var _x114 = compile(form, {_stash: true, stmt: true});
@@ -1079,8 +1079,8 @@ setenv("while", {_stash: true, stmt: true, tr: true, special: function (cond, fo
   } else {
     return(ind + "while " + _cond3 + " do\n" + body + ind + "end\n");
   }
-}});
-setenv("%for", {_stash: true, stmt: true, tr: true, special: function (t, k, form) {
+}, stmt: true});
+setenv("%for", {_stash: true, tr: true, special: function (t, k, form) {
   var _t1 = compile(t);
   var ind = indentation();
   indent_level = indent_level + 1;
@@ -1092,8 +1092,8 @@ setenv("%for", {_stash: true, stmt: true, tr: true, special: function (t, k, for
   } else {
     return(ind + "for (" + k + " in " + _t1 + ") {\n" + body + ind + "}\n");
   }
-}});
-setenv("%try", {_stash: true, stmt: true, tr: true, special: function (form) {
+}, stmt: true});
+setenv("%try", {_stash: true, tr: true, special: function (form) {
   var e = unique("e");
   var ind = indentation();
   indent_level = indent_level + 1;
@@ -1106,7 +1106,7 @@ setenv("%try", {_stash: true, stmt: true, tr: true, special: function (form) {
   indent_level = indent_level - 1;
   var h = _x126;
   return(ind + "try {\n" + body + ind + "}\n" + ind + "catch (" + e + ") {\n" + h + ind + "}\n");
-}});
+}, stmt: true});
 setenv("%delete", {_stash: true, special: function (place) {
   return(indentation() + "delete " + compile(place));
 }, stmt: true});
@@ -1116,22 +1116,22 @@ setenv("break", {_stash: true, special: function () {
 setenv("%function", {_stash: true, special: function (args, body) {
   return(compile_function(args, body));
 }});
-setenv("%global-function", {_stash: true, stmt: true, tr: true, special: function (name, args, body) {
+setenv("%global-function", {_stash: true, tr: true, special: function (name, args, body) {
   if (target === "lua") {
     var x = compile_function(args, body, {_stash: true, name: name});
     return(indentation() + x);
   } else {
     return(compile(["set", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}});
-setenv("%local-function", {_stash: true, stmt: true, tr: true, special: function (name, args, body) {
+}, stmt: true});
+setenv("%local-function", {_stash: true, tr: true, special: function (name, args, body) {
   if (target === "lua") {
-    var x = compile_function(args, body, {_stash: true, prefix: "local", name: name});
+    var x = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
     return(indentation() + x);
   } else {
     return(compile(["%local", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}});
+}, stmt: true});
 setenv("return", {_stash: true, special: function (x) {
   var _e35;
   if (nil63(x)) {

--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -1283,6 +1283,7 @@ setenv("%object", {_stash: true, special: function () {
   }
   return(s + "}");
 }});
+var _124exports124 = exports || {};
 exports.eval = eval;
 exports["run-file"] = run_file;
 exports["compile-string"] = compile_string;
@@ -1291,3 +1292,4 @@ exports["load-string"] = load_string;
 exports.load = load;
 exports.expand = expand;
 exports.compile = compile;
+exports;

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -109,21 +109,21 @@ function bind(lh, rh)
     local k = nil
     for k in next, _o1 do
       local v = _o1[k]
-      local _e9
+      local _e
       if k == "rest" then
-        _e9 = {"cut", id, _35(lh)}
+        _e = {"cut", id, _35(lh)}
       else
-        _e9 = {"get", id, {"quote", bias(k)}}
+        _e = {"get", id, {"quote", bias(k)}}
       end
-      local x = _e9
+      local x = _e
       if is63(k) then
-        local _e10
+        local _e1
         if v == true then
-          _e10 = k
+          _e1 = k
         else
-          _e10 = v
+          _e1 = v
         end
-        local _k = _e10
+        local _k = _e1
         bs = join(bs, bind(_k, x))
       end
     end
@@ -266,13 +266,13 @@ local function quasiquote_list(form, depth)
   for k in next, _o5 do
     local v = _o5[k]
     if not  number63(k) then
-      local _e11
+      local _e2
       if quasisplice63(v, depth) then
-        _e11 = quasiexpand(v[2])
+        _e2 = quasiexpand(v[2])
       else
-        _e11 = quasiexpand(v, depth)
+        _e2 = quasiexpand(v, depth)
       end
-      local _v = _e11
+      local _v = _e2
       last(xs)[k] = _v
     end
   end
@@ -499,13 +499,13 @@ local function escape_newlines(s)
   local i = 0
   while i < _35(s) do
     local c = char(s, i)
-    local _e12
+    local _e3
     if c == "\n" then
-      _e12 = "\\n"
+      _e3 = "\\n"
     else
-      _e12 = c
+      _e3 = c
     end
-    s1 = s1 .. _e12
+    s1 = s1 .. _e3
     i = i + 1
   end
   return(s1)
@@ -516,25 +516,25 @@ local function id(id)
   while i < _35(id) do
     local c = char(id, i)
     local n = code(c)
-    local _e13
+    local _e4
     if c == "-" then
-      _e13 = "_"
+      _e4 = "_"
     else
-      local _e14
+      local _e5
       if valid_code63(n) then
-        _e14 = c
+        _e5 = c
       else
-        local _e15
+        local _e6
         if i == 0 then
-          _e15 = "_" .. n
+          _e6 = "_" .. n
         else
-          _e15 = n
+          _e6 = n
         end
-        _e14 = _e15
+        _e5 = _e6
       end
-      _e13 = _e14
+      _e4 = _e5
     end
-    local c1 = _e13
+    local c1 = _e4
     id1 = id1 .. c1
     i = i + 1
   end
@@ -614,13 +614,13 @@ local function op_delims(parent, child, ...)
   local _r56 = unstash({...})
   local _id7 = _r56
   local right = _id7.right
-  local _e16
+  local _e7
   if right then
-    _e16 = _6261
+    _e7 = _6261
   else
-    _e16 = _62
+    _e7 = _62
   end
-  if _e16(precedence(child), precedence(parent)) then
+  if _e7(precedence(child), precedence(parent)) then
     return({"(", ")"})
   else
     return({"", ""})
@@ -652,33 +652,33 @@ function compile_function(args, body, ...)
   local _id12 = _r58
   local name = _id12.name
   local prefix = _id12.prefix
-  local _e17
+  local _e8
   if name then
-    _e17 = compile(name)
+    _e8 = compile(name)
   else
-    _e17 = ""
+    _e8 = ""
   end
-  local _id13 = _e17
+  local _id13 = _e8
   local _args = compile_args(args)
   indent_level = indent_level + 1
   local _x76 = compile(body, {_stash = true, stmt = true})
   indent_level = indent_level - 1
   local _body = _x76
   local ind = indentation()
-  local _e18
+  local _e9
   if prefix then
-    _e18 = prefix .. " "
+    _e9 = prefix .. " "
   else
-    _e18 = ""
+    _e9 = ""
   end
-  local p = _e18
-  local _e19
+  local p = _e9
+  local _e10
   if target == "js" then
-    _e19 = ""
+    _e10 = ""
   else
-    _e19 = "end"
+    _e10 = "end"
   end
-  local tr = _e19
+  local tr = _e10
   if name then
     tr = tr .. "\n"
   end
@@ -702,26 +702,26 @@ function compile(form, ...)
       return(compile_special(form, stmt))
     else
       local tr = terminator(stmt)
-      local _e20
+      local _e11
       if stmt then
-        _e20 = indentation()
+        _e11 = indentation()
       else
-        _e20 = ""
+        _e11 = ""
       end
-      local ind = _e20
-      local _e21
+      local ind = _e11
+      local _e12
       if atom63(form) then
-        _e21 = compile_atom(form)
+        _e12 = compile_atom(form)
       else
-        local _e22
+        local _e13
         if infix63(hd(form)) then
-          _e22 = compile_infix(form)
+          _e13 = compile_infix(form)
         else
-          _e22 = compile_call(form)
+          _e13 = compile_call(form)
         end
-        _e21 = _e22
+        _e12 = _e13
       end
-      local _form = _e21
+      local _form = _e12
       return(ind .. _form .. tr)
     end
   end
@@ -789,19 +789,19 @@ local function lower_if(args, hoist, stmt63, tail63)
   local _then = _id16[2]
   local _else = _id16[3]
   if stmt63 or tail63 then
-    local _e24
+    local _e15
     if _else then
-      _e24 = {lower_body({_else}, tail63)}
+      _e15 = {lower_body({_else}, tail63)}
     end
-    return(add(hoist, join({"%if", lower(cond, hoist), lower_body({_then}, tail63)}, _e24)))
+    return(add(hoist, join({"%if", lower(cond, hoist), lower_body({_then}, tail63)}, _e15)))
   else
     local e = unique("e")
     add(hoist, {"%local", e})
-    local _e23
+    local _e14
     if _else then
-      _e23 = {lower({"set", e, _else})}
+      _e14 = {lower({"set", e, _else})}
     end
-    add(hoist, join({"%if", lower(cond, hoist), lower({"set", e, _then})}, _e23))
+    add(hoist, join({"%if", lower(cond, hoist), lower({"set", e, _then})}, _e14))
     return(e)
   end
 end
@@ -813,13 +813,13 @@ local function lower_short(x, args, hoist)
   local b1 = lower(b, hoist1)
   if some63(hoist1) then
     local _id18 = unique("id")
-    local _e25
+    local _e16
     if x == "and" then
-      _e25 = {"%if", _id18, b, _id18}
+      _e16 = {"%if", _id18, b, _id18}
     else
-      _e25 = {"%if", _id18, _id18, b}
+      _e16 = {"%if", _id18, _id18, b}
     end
-    return(lower({"do", {"%local", _id18, a}, _e25}, hoist))
+    return(lower({"do", {"%local", _id18, a}, _e16}, hoist))
   else
     return({x, lower(a, hoist), b1})
   end
@@ -964,42 +964,56 @@ end
 local function run_file(path)
   return(run(read_file(path)))
 end
+local function compile_string(s)
+  local out = ""
+  local _x108 = read_from_string(s)
+  local _n11 = _35(_x108)
+  local _i11 = 0
+  while _i11 < _n11 do
+    local expr = _x108[_i11 + 1]
+    local form = expand({"do", expr})
+    out = out .. compile(form, {_stash = true, stmt = true})
+    _i11 = _i11 + 1
+  end
+  return(out)
+end
 local function compile_file(path)
-  local s = reader.stream(read_file(path))
-  local body = reader["read-all"](s)
-  local form = expand(join({"do"}, body))
-  return(compile(form, {_stash = true, stmt = true}))
+  return(compile_string(read_file(path)))
+end
+function load_string(s)
+  run(compile_string("(set %result ((fn () " .. s .. ")))"))
+  return(_37result)
 end
 function load(path)
-  return(run(compile_file(path)))
+  return(load_string(read_file(path)))
 end
 setenv("do", {_stash = true, tr = true, special = function (...)
   local forms = unstash({...})
   local s = ""
-  local _x112 = forms
-  local _n12 = _35(_x112)
-  local _i12 = 0
-  while _i12 < _n12 do
-    local x = _x112[_i12 + 1]
+  local _x113 = forms
+  local _n13 = _35(_x113)
+  local _i13 = 0
+  while _i13 < _n13 do
+    local x = _x113[_i13 + 1]
     s = s .. compile(x, {_stash = true, stmt = true})
-    _i12 = _i12 + 1
+    _i13 = _i13 + 1
   end
   return(s)
 end, stmt = true})
 setenv("%if", {_stash = true, tr = true, special = function (cond, cons, alt)
   local _cond1 = compile(cond)
   indent_level = indent_level + 1
-  local _x115 = compile(cons, {_stash = true, stmt = true})
+  local _x116 = compile(cons, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local _cons1 = _x115
-  local _e26
+  local _cons1 = _x116
+  local _e18
   if alt then
     indent_level = indent_level + 1
-    local _x116 = compile(alt, {_stash = true, stmt = true})
+    local _x117 = compile(alt, {_stash = true, stmt = true})
     indent_level = indent_level - 1
-    _e26 = _x116
+    _e18 = _x117
   end
-  local _alt1 = _e26
+  local _alt1 = _e18
   local ind = indentation()
   local s = ""
   if target == "js" then
@@ -1023,9 +1037,9 @@ end, stmt = true})
 setenv("while", {_stash = true, tr = true, special = function (cond, form)
   local _cond3 = compile(cond)
   indent_level = indent_level + 1
-  local _x118 = compile(form, {_stash = true, stmt = true})
+  local _x119 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local body = _x118
+  local body = _x119
   local ind = indentation()
   if target == "js" then
     return(ind .. "while (" .. _cond3 .. ") {\n" .. body .. ind .. "}\n")
@@ -1037,9 +1051,9 @@ setenv("%for", {_stash = true, tr = true, special = function (t, k, form)
   local _t1 = compile(t)
   local ind = indentation()
   indent_level = indent_level + 1
-  local _x120 = compile(form, {_stash = true, stmt = true})
+  local _x121 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local body = _x120
+  local body = _x121
   if target == "lua" then
     return(ind .. "for " .. k .. " in next, " .. _t1 .. " do\n" .. body .. ind .. "end\n")
   else
@@ -1050,14 +1064,14 @@ setenv("%try", {_stash = true, tr = true, special = function (form)
   local e = unique("e")
   local ind = indentation()
   indent_level = indent_level + 1
-  local _x126 = compile(form, {_stash = true, stmt = true})
+  local _x127 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local body = _x126
+  local body = _x127
   local hf = {"return", {"%array", false, {"get", e, "\"message\""}}}
   indent_level = indent_level + 1
-  local _x130 = compile(hf, {_stash = true, stmt = true})
+  local _x131 = compile(hf, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local h = _x130
+  local h = _x131
   return(ind .. "try {\n" .. body .. ind .. "}\n" .. ind .. "catch (" .. e .. ") {\n" .. h .. ind .. "}\n")
 end, stmt = true})
 setenv("%delete", {_stash = true, special = function (place)
@@ -1086,57 +1100,57 @@ setenv("%local-function", {_stash = true, tr = true, special = function (name, a
   end
 end, stmt = true})
 setenv("return", {_stash = true, special = function (x)
-  local _e27
+  local _e20
   if nil63(x) then
-    _e27 = "return"
+    _e20 = "return"
   else
-    _e27 = "return(" .. compile(x) .. ")"
+    _e20 = "return(" .. compile(x) .. ")"
   end
-  local _x140 = _e27
-  return(indentation() .. _x140)
+  local _x141 = _e20
+  return(indentation() .. _x141)
 end, stmt = true})
 setenv("new", {_stash = true, special = function (x)
   return("new " .. compile(x))
 end})
 setenv("error", {_stash = true, special = function (x)
-  local _e28
+  local _e22
   if target == "js" then
-    _e28 = "throw " .. compile({"new", {"Error", x}})
+    _e22 = "throw " .. compile({"new", {"Error", x}})
   else
-    _e28 = "error(" .. compile(x) .. ")"
+    _e22 = "error(" .. compile(x) .. ")"
   end
-  local e = _e28
+  local e = _e22
   return(indentation() .. e)
 end, stmt = true})
 setenv("%local", {_stash = true, special = function (name, value)
   local _id26 = compile(name)
   local value1 = compile(value)
-  local _e29
+  local _e25
   if is63(value) then
-    _e29 = " = " .. value1
+    _e25 = " = " .. value1
   else
-    _e29 = ""
+    _e25 = ""
   end
-  local rh = _e29
-  local _e30
+  local rh = _e25
+  local _e26
   if target == "js" then
-    _e30 = "var "
+    _e26 = "var "
   else
-    _e30 = "local "
+    _e26 = "local "
   end
-  local keyword = _e30
+  local keyword = _e26
   local ind = indentation()
   return(ind .. keyword .. _id26 .. rh)
 end, stmt = true})
 setenv("set", {_stash = true, special = function (lh, rh)
   local _lh1 = compile(lh)
-  local _e31
+  local _e28
   if nil63(rh) then
-    _e31 = "nil"
+    _e28 = "nil"
   else
-    _e31 = rh
+    _e28 = rh
   end
-  local _rh1 = compile(_e31)
+  local _rh1 = compile(_e28)
   return(indentation() .. _lh1 .. " = " .. _rh1)
 end, stmt = true})
 setenv("get", {_stash = true, special = function (t, k)
@@ -1153,20 +1167,20 @@ setenv("get", {_stash = true, special = function (t, k)
 end})
 setenv("%array", {_stash = true, special = function (...)
   local forms = unstash({...})
+  local _e31
+  if target == "lua" then
+    _e31 = "{"
+  else
+    _e31 = "["
+  end
+  local open = _e31
   local _e32
   if target == "lua" then
-    _e32 = "{"
+    _e32 = "}"
   else
-    _e32 = "["
+    _e32 = "]"
   end
-  local open = _e32
-  local _e33
-  if target == "lua" then
-    _e33 = "}"
-  else
-    _e33 = "]"
-  end
-  local close = _e33
+  local close = _e32
   local s = ""
   local c = ""
   local _o9 = forms
@@ -1208,4 +1222,4 @@ setenv("%object", {_stash = true, special = function (...)
   end
   return(s .. "}")
 end})
-return({["compile-file"] = compile_file, compile = compile, ["run-file"] = run_file, load = load, eval = eval, expand = expand})
+return({eval = eval, load = load, compile = compile, ["compile-file"] = compile_file, ["load-string"] = load_string, expand = expand, ["run-file"] = run_file, ["compile-string"] = compile_string})

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -359,7 +359,7 @@ function indentation()
   end
   return(s)
 end
-local reserved = {["debugger"] = true, ["try"] = true, ["delete"] = true, ["+"] = true, ["=="] = true, ["-"] = true, ["function"] = true, ["switch"] = true, ["else"] = true, ["or"] = true, ["throw"] = true, ["for"] = true, ["continue"] = true, ["default"] = true, ["void"] = true, ["/"] = true, ["not"] = true, ["case"] = true, ["typeof"] = true, ["return"] = true, ["until"] = true, [">="] = true, ["local"] = true, ["<="] = true, ["do"] = true, ["finally"] = true, ["<"] = true, ["true"] = true, [">"] = true, ["in"] = true, ["then"] = true, ["while"] = true, ["elseif"] = true, ["end"] = true, ["and"] = true, ["with"] = true, ["break"] = true, ["var"] = true, ["repeat"] = true, ["false"] = true, ["*"] = true, ["%"] = true, ["="] = true, ["this"] = true, ["nil"] = true, ["instanceof"] = true, ["catch"] = true, ["new"] = true, ["if"] = true}
+local reserved = {["else"] = true, ["<"] = true, ["true"] = true, ["/"] = true, ["end"] = true, ["typeof"] = true, ["function"] = true, ["switch"] = true, ["="] = true, ["or"] = true, ["try"] = true, ["catch"] = true, ["until"] = true, ["local"] = true, ["repeat"] = true, ["-"] = true, ["false"] = true, ["continue"] = true, ["=="] = true, ["and"] = true, ["if"] = true, ["for"] = true, [">="] = true, ["<="] = true, ["with"] = true, ["return"] = true, ["finally"] = true, ["nil"] = true, ["new"] = true, ["do"] = true, ["case"] = true, ["break"] = true, ["elseif"] = true, ["+"] = true, ["not"] = true, ["void"] = true, ["var"] = true, ["%"] = true, ["in"] = true, ["delete"] = true, ["throw"] = true, ["debugger"] = true, ["instanceof"] = true, ["this"] = true, ["while"] = true, ["then"] = true, ["default"] = true, ["*"] = true, [">"] = true}
 function reserved63(x)
   return(reserved[x])
 end
@@ -416,18 +416,18 @@ __x59["/"] = true
 __x59["*"] = true
 __x59["%"] = true
 local __x60 = {}
-__x60["-"] = true
 __x60["+"] = true
+__x60["-"] = true
 local __x61 = {}
 local _x62 = {}
 _x62.lua = ".."
 _x62.js = "+"
 __x61.cat = _x62
 local __x63 = {}
-__x63[">="] = true
 __x63["<="] = true
-__x63[">"] = true
+__x63[">="] = true
 __x63["<"] = true
+__x63[">"] = true
 local __x64 = {}
 local _x65 = {}
 _x65.lua = "=="
@@ -592,8 +592,8 @@ local function compile_special(form, stmt63)
   local args = cut(_id5, 1)
   local _id6 = getenv(x)
   local self_tr63 = _id6.tr
-  local special = _id6.special
   local stmt = _id6.stmt
+  local special = _id6.special
   local tr = terminator(stmt63 and not  self_tr63)
   return(apply(special, args) .. tr)
 end
@@ -1208,4 +1208,4 @@ setenv("%object", {_stash = true, special = function (...)
   end
   return(s .. "}")
 end})
-return({expand = expand, load = load, ["run-file"] = run_file, eval = eval, compile = compile, ["compile-file"] = compile_file})
+return({["compile-file"] = compile_file, compile = compile, ["run-file"] = run_file, load = load, eval = eval, expand = expand})

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -945,19 +945,21 @@ setenv("fn", {_stash: true, macro: function (args) {
   var body = cut(_id43, 0);
   return(join(["%function"], bind42(args, body)));
 }});
-setenv("guard", {_stash: true, macro: function (expr) {
+setenv("guard", {_stash: true, macro: function () {
+  var body = unstash(Array.prototype.slice.call(arguments, 0));
+  var expr = [join(["fn", join()], body)];
   if (target === "js") {
     return([["fn", join(), ["%try", ["list", true, expr]]]]);
   } else {
     var e = unique("e");
     var x = unique("x");
-    var ex = "|" + e + "," + x + "|";
-    return(["let", ex, ["xpcall", ["fn", join(), expr], "%message-handler"], ["list", e, x]]);
+    var msg = unique("msg");
+    return(["let", [x, "nil", msg, "nil", e, ["xpcall", ["fn", join(), ["set", x, expr]], ["fn", "l", ["set", msg, ["apply", "%message-handler", "l"]]]]], ["list", e, ["if", e, x, msg]]]);
   }
 }});
 setenv("each", {_stash: true, macro: function (x, t) {
-  var _r55 = unstash(Array.prototype.slice.call(arguments, 2));
-  var _id46 = _r55;
+  var _r53 = unstash(Array.prototype.slice.call(arguments, 2));
+  var _id46 = _r53;
   var body = cut(_id46, 0);
   var o = unique("o");
   var n = unique("n");
@@ -986,14 +988,14 @@ setenv("each", {_stash: true, macro: function (x, t) {
   return(["let", [o, t, k, "nil"], ["%for", o, k, join(["let", [v, ["get", o, k]]], _e6)]]);
 }});
 setenv("for", {_stash: true, macro: function (i, to) {
-  var _r57 = unstash(Array.prototype.slice.call(arguments, 2));
-  var _id49 = _r57;
+  var _r55 = unstash(Array.prototype.slice.call(arguments, 2));
+  var _id49 = _r55;
   var body = cut(_id49, 0);
   return(["let", i, 0, join(["while", ["<", i, to]], body, [["inc", i]])]);
 }});
 setenv("step", {_stash: true, macro: function (v, t) {
-  var _r59 = unstash(Array.prototype.slice.call(arguments, 2));
-  var _id51 = _r59;
+  var _r57 = unstash(Array.prototype.slice.call(arguments, 2));
+  var _id51 = _r57;
   var body = cut(_id51, 0);
   var x = unique("x");
   var n = unique("n");
@@ -1026,14 +1028,14 @@ setenv("target", {_stash: true, macro: function () {
   return(clauses[target]);
 }});
 setenv("join!", {_stash: true, macro: function (a) {
-  var _r63 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _id53 = _r63;
+  var _r61 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _id53 = _r61;
   var bs = cut(_id53, 0);
   return(["set", a, join(["join", a], bs)]);
 }});
 setenv("cat!", {_stash: true, macro: function (a) {
-  var _r65 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _id55 = _r65;
+  var _r63 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _id55 = _r63;
   var bs = cut(_id55, 0);
   return(["set", a, join(["cat", a], bs)]);
 }});
@@ -1076,7 +1078,9 @@ var compiler = require("compiler");
 var eval_print = function (form) {
   var _id = (function () {
     try {
-      return([true, compiler.eval(form)]);
+      return([true, (function () {
+        return(compiler.eval(form));
+      })()]);
     }
     catch (_e) {
       return([false, _e.message]);
@@ -1122,15 +1126,15 @@ var usage = function () {
   return(exit());
 };
 var end_is63 = function (str) {
-  var _r6 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _id1 = _r6;
+  var _r7 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _id1 = _r7;
   var l = cut(_id1, 0);
   var s = apply(cat, l);
   return(clip(str, _35(str) - _35(s)) === s);
 };
 var cat_end = function (str) {
-  var _r7 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _id2 = _r7;
+  var _r8 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _id2 = _r8;
   var l = cut(_id2, 0);
   var s = apply(cat, l);
   if (end_is63(str, s)) {

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -1195,12 +1195,16 @@ var main = function () {
     compiler["run-file"](cat_end(file, ".", target));
     _i = _i + 1;
   }
-  if (input && output) {
+  if (input) {
     if (target1) {
       target = target1;
     }
     var code = compiler["compile-file"](input);
-    return(write_file(output, code));
+    if (nil63(output) || output === "-") {
+      return(print(code));
+    } else {
+      return(write_file(output, code));
+    }
   } else {
     if (expr) {
       return(rep(expr));

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -1121,6 +1121,7 @@ var usage = function () {
   print("  -e <expr>\tExpression to evaluate");
   return(exit());
 };
+args = [];
 var main = function () {
   if (hd(argv) === "-h" || hd(argv) === "--help") {
     usage();
@@ -1134,31 +1135,36 @@ var main = function () {
   var i = 0;
   while (i < n) {
     var a = argv[i];
-    if (a === "-c" || a === "-o" || a === "-t" || a === "-e") {
-      if (i === n - 1) {
-        print("missing argument for " + a);
-      } else {
-        i = i + 1;
-        var val = argv[i];
-        if (a === "-c") {
-          input = val;
+    if (a === "--") {
+      args = cut(argv, i + 1);
+      break;
+    } else {
+      if (a === "-c" || a === "-o" || a === "-t" || a === "-e") {
+        if (i === n - 1) {
+          print("missing argument for " + a);
         } else {
-          if (a === "-o") {
-            output = val;
+          i = i + 1;
+          var val = argv[i];
+          if (a === "-c") {
+            input = val;
           } else {
-            if (a === "-t") {
-              target1 = val;
+            if (a === "-o") {
+              output = val;
             } else {
-              if (a === "-e") {
-                expr = val;
+              if (a === "-t") {
+                target1 = val;
+              } else {
+                if (a === "-e") {
+                  expr = val;
+                }
               }
             }
           }
         }
-      }
-    } else {
-      if (!( "-" === char(a, 0))) {
-        add(pre, a);
+      } else {
+        if (!( "-" === char(a, 0))) {
+          add(pre, a);
+        }
       }
     }
     i = i + 1;

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -1052,9 +1052,9 @@ setenv("with-indent", {_stash: true, macro: function (form) {
 setenv("export", {_stash: true, macro: function () {
   var names = unstash(Array.prototype.slice.call(arguments, 0));
   if (target === "js") {
-    return(join(["do"], map(function (k) {
+    return(join(["let", "|exports|", ["or", "exports", ["obj"]]], map(function (k) {
       return(["set", ["get", "exports", ["quote", k]], k]);
-    }, names)));
+    }, names), ["exports"]));
   } else {
     var x = {};
     var _o5 = names;

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -730,13 +730,13 @@ setenv("list", {_stash: true, macro: function () {
   var k = undefined;
   for (k in _o1) {
     var v = _o1[k];
-    var _e3;
+    var _e;
     if (numeric63(k)) {
-      _e3 = parseInt(k);
+      _e = parseInt(k);
     } else {
-      _e3 = k;
+      _e = k;
     }
-    var _k = _e3;
+    var _k = _e;
     if (number63(_k)) {
       l[_k] = v;
     } else {

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -1121,6 +1121,24 @@ var usage = function () {
   print("  -e <expr>\tExpression to evaluate");
   return(exit());
 };
+var end_is63 = function (str) {
+  var _r6 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _id1 = _r6;
+  var l = cut(_id1, 0);
+  var s = apply(cat, l);
+  return(clip(str, _35(str) - _35(s)) === s);
+};
+var cat_end = function (str) {
+  var _r7 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _id2 = _r7;
+  var l = cut(_id2, 0);
+  var s = apply(cat, l);
+  if (end_is63(str, s)) {
+    return(str);
+  } else {
+    return(str + s);
+  }
+};
 args = [];
 var main = function () {
   if (hd(argv) === "-h" || hd(argv) === "--help") {
@@ -1174,7 +1192,7 @@ var main = function () {
   var _i = 0;
   while (_i < _n) {
     var file = _x1[_i];
-    compiler["run-file"](file);
+    compiler["run-file"](cat_end(file, ".", target));
     _i = _i + 1;
   }
   if (input && output) {

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -1017,6 +1017,24 @@ local function usage()
   print("  -e <expr>\tExpression to evaluate")
   return(exit())
 end
+local function end_is63(str, ...)
+  local _r6 = unstash({...})
+  local _id1 = _r6
+  local l = cut(_id1, 0)
+  local s = apply(cat, l)
+  return(clip(str, _35(str) - _35(s)) == s)
+end
+local function cat_end(str, ...)
+  local _r7 = unstash({...})
+  local _id2 = _r7
+  local l = cut(_id2, 0)
+  local s = apply(cat, l)
+  if end_is63(str, s) then
+    return(str)
+  else
+    return(str .. s)
+  end
+end
 args = {}
 local function main()
   if hd(argv) == "-h" or hd(argv) == "--help" then
@@ -1065,12 +1083,12 @@ local function main()
     end
     i = i + 1
   end
-  local _x2 = pre
-  local _n = _35(_x2)
+  local _x4 = pre
+  local _n = _35(_x4)
   local _i = 0
   while _i < _n do
-    local file = _x2[_i + 1]
-    compiler["run-file"](file)
+    local file = _x4[_i + 1]
+    compiler["run-file"](cat_end(file, ".", target))
     _i = _i + 1
   end
   if input and output then

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -969,9 +969,9 @@ end})
 setenv("export", {_stash = true, macro = function (...)
   local names = unstash({...})
   if target == "js" then
-    return(join({"do"}, map(function (k)
+    return(join({"let", "|exports|", {"or", "exports", {"obj"}}}, map(function (k)
       return({"set", {"get", "exports", {"quote", k}}, k})
-    end, names)))
+    end, names), {"exports"}))
   else
     local x = {}
     local _o5 = names

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -1017,6 +1017,7 @@ local function usage()
   print("  -e <expr>\tExpression to evaluate")
   return(exit())
 end
+args = {}
 local function main()
   if hd(argv) == "-h" or hd(argv) == "--help" then
     usage()
@@ -1030,31 +1031,36 @@ local function main()
   local i = 0
   while i < n do
     local a = argv[i + 1]
-    if a == "-c" or a == "-o" or a == "-t" or a == "-e" then
-      if i == n - 1 then
-        print("missing argument for " .. a)
-      else
-        i = i + 1
-        local val = argv[i + 1]
-        if a == "-c" then
-          input = val
+    if a == "--" then
+      args = cut(argv, i + 1)
+      break
+    else
+      if a == "-c" or a == "-o" or a == "-t" or a == "-e" then
+        if i == n - 1 then
+          print("missing argument for " .. a)
         else
-          if a == "-o" then
-            output = val
+          i = i + 1
+          local val = argv[i + 1]
+          if a == "-c" then
+            input = val
           else
-            if a == "-t" then
-              target1 = val
+            if a == "-o" then
+              output = val
             else
-              if a == "-e" then
-                expr = val
+              if a == "-t" then
+                target1 = val
+              else
+                if a == "-e" then
+                  expr = val
+                end
               end
             end
           end
         end
-      end
-    else
-      if not ( "-" == char(a, 0)) then
-        add(pre, a)
+      else
+        if not ( "-" == char(a, 0)) then
+          add(pre, a)
+        end
       end
     end
     i = i + 1

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -1091,12 +1091,16 @@ local function main()
     compiler["run-file"](cat_end(file, ".", target))
     _i = _i + 1
   end
-  if input and output then
+  if input then
     if target1 then
       target = target1
     end
     local code = compiler["compile-file"](input)
-    return(write_file(output, code))
+    if nil63(output) or output == "-" then
+      return(print(code))
+    else
+      return(write_file(output, code))
+    end
   else
     if expr then
       return(rep(expr))

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -61,21 +61,21 @@ end
 function cut(x, from, upto)
   local l = {}
   local j = 0
-  local _e1
+  local _e
   if nil63(from) or from < 0 then
-    _e1 = 0
+    _e = 0
   else
-    _e1 = from
+    _e = from
   end
-  local i = _e1
+  local i = _e
   local n = _35(x)
-  local _e2
+  local _e1
   if nil63(upto) or upto > n then
-    _e2 = n
+    _e1 = n
   else
-    _e2 = upto
+    _e1 = upto
   end
-  local _upto = _e2
+  local _upto = _e1
   while i < _upto do
     l[j + 1] = x[i + 1]
     i = i + 1
@@ -116,11 +116,11 @@ function char(s, n)
   return(clip(s, n, n + 1))
 end
 function code(s, n)
-  local _e3
+  local _e2
   if n then
-    _e3 = n + 1
+    _e2 = n + 1
   end
-  return(sbyte(s, _e3))
+  return(sbyte(s, _e2))
 end
 function string_literal63(x)
   return(string63(x) and char(x, 0) == "\"")
@@ -326,11 +326,11 @@ function unstash(args)
   end
 end
 function search(s, pattern, start)
-  local _e4
+  local _e3
   if start then
-    _e4 = start + 1
+    _e3 = start + 1
   end
-  local _start = _e4
+  local _start = _e3
   local i = sfind(s, pattern, _start, true)
   return(i and i - 1)
 end
@@ -430,25 +430,25 @@ function escape(s)
   local i = 0
   while i < _35(s) do
     local c = char(s, i)
-    local _e5
+    local _e4
     if c == "\n" then
-      _e5 = "\\n"
+      _e4 = "\\n"
     else
-      local _e6
+      local _e5
       if c == "\"" then
-        _e6 = "\\\""
+        _e5 = "\\\""
       else
-        local _e7
+        local _e6
         if c == "\\" then
-          _e7 = "\\\\"
+          _e6 = "\\\\"
         else
-          _e7 = c
+          _e6 = c
         end
-        _e6 = _e7
+        _e5 = _e6
       end
-      _e5 = _e6
+      _e4 = _e5
     end
-    local c1 = _e5
+    local c1 = _e4
     s1 = s1 .. c1
     i = i + 1
   end
@@ -540,13 +540,13 @@ function setenv(k, ...)
   local _id1 = _r66
   local _keys = cut(_id1, 0)
   if string63(k) then
-    local _e8
+    local _e7
     if _keys.toplevel then
-      _e8 = hd(environment)
+      _e7 = hd(environment)
     else
-      _e8 = last(environment)
+      _e7 = last(environment)
     end
-    local frame = _e8
+    local frame = _e7
     local entry = frame[k] or {}
     local _o12 = _keys
     local _k = nil
@@ -561,7 +561,7 @@ end
 local function call_with_file(path, f)
   local _x12 = nil
   local _msg = nil
-  local _e = xpcall(function ()
+  local _e8 = xpcall(function ()
     _x12 = (function ()
       return(f(path))
     end)()
@@ -572,12 +572,12 @@ local function call_with_file(path, f)
     return(_msg)
   end)
   local _e9
-  if _e then
+  if _e8 then
     _e9 = _x12
   else
     _e9 = _msg
   end
-  local _id2 = {_e, _e9}
+  local _id2 = {_e8, _e9}
   local ok = _id2[1]
   local s = _id2[2]
   path.close(path)

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -559,10 +559,25 @@ function setenv(k, ...)
   end
 end
 local function call_with_file(path, f)
-  local _e,_x12 = xpcall(function ()
-    return(f(path))
-  end, _37message_handler)
-  local _id2 = {_e, _x12}
+  local _x12 = nil
+  local _msg = nil
+  local _e = xpcall(function ()
+    _x12 = (function ()
+      return(f(path))
+    end)()
+    return(_x12)
+  end, function (...)
+    local l = unstash({...})
+    _msg = apply(_37message_handler, l)
+    return(_msg)
+  end)
+  local _e9
+  if _e then
+    _e9 = _x12
+  else
+    _e9 = _msg
+  end
+  local _id2 = {_e, _e9}
   local ok = _id2[1]
   local s = _id2[2]
   path.close(path)
@@ -854,19 +869,21 @@ setenv("fn", {_stash = true, macro = function (args, ...)
   local body = cut(_id43, 0)
   return(join({"%function"}, bind42(args, body)))
 end})
-setenv("guard", {_stash = true, macro = function (expr)
+setenv("guard", {_stash = true, macro = function (...)
+  local body = unstash({...})
+  local expr = {join({"fn", join()}, body)}
   if target == "js" then
     return({{"fn", join(), {"%try", {"list", true, expr}}}})
   else
     local e = unique("e")
     local x = unique("x")
-    local ex = "|" .. e .. "," .. x .. "|"
-    return({"let", ex, {"xpcall", {"fn", join(), expr}, "%message-handler"}, {"list", e, x}})
+    local msg = unique("msg")
+    return({"let", {x, "nil", msg, "nil", e, {"xpcall", {"fn", join(), {"set", x, expr}}, {"fn", "l", {"set", msg, {"apply", "%message-handler", "l"}}}}}, {"list", e, {"if", e, x, msg}}})
   end
 end})
 setenv("each", {_stash = true, macro = function (x, t, ...)
-  local _r55 = unstash({...})
-  local _id46 = _r55
+  local _r53 = unstash({...})
+  local _id46 = _r53
   local body = cut(_id46, 0)
   local o = unique("o")
   local n = unique("n")
@@ -895,14 +912,14 @@ setenv("each", {_stash = true, macro = function (x, t, ...)
   return({"let", {o, t, k, "nil"}, {"%for", o, k, join({"let", {v, {"get", o, k}}}, _e5)}})
 end})
 setenv("for", {_stash = true, macro = function (i, to, ...)
-  local _r57 = unstash({...})
-  local _id49 = _r57
+  local _r55 = unstash({...})
+  local _id49 = _r55
   local body = cut(_id49, 0)
   return({"let", i, 0, join({"while", {"<", i, to}}, body, {{"inc", i}})})
 end})
 setenv("step", {_stash = true, macro = function (v, t, ...)
-  local _r59 = unstash({...})
-  local _id51 = _r59
+  local _r57 = unstash({...})
+  local _id51 = _r57
   local body = cut(_id51, 0)
   local x = unique("x")
   local n = unique("n")
@@ -928,14 +945,14 @@ setenv("target", {_stash = true, macro = function (...)
   return(clauses[target])
 end})
 setenv("join!", {_stash = true, macro = function (a, ...)
-  local _r63 = unstash({...})
-  local _id53 = _r63
+  local _r61 = unstash({...})
+  local _id53 = _r61
   local bs = cut(_id53, 0)
   return({"set", a, join({"join", a}, bs)})
 end})
 setenv("cat!", {_stash = true, macro = function (a, ...)
-  local _r65 = unstash({...})
-  local _id55 = _r65
+  local _r63 = unstash({...})
+  local _id55 = _r63
   local bs = cut(_id55, 0)
   return({"set", a, join({"cat", a}, bs)})
 end})
@@ -969,10 +986,25 @@ end})
 local reader = require("reader")
 local compiler = require("compiler")
 local function eval_print(form)
-  local _e,_x = xpcall(function ()
-    return(compiler.eval(form))
-  end, _37message_handler)
-  local _id = {_e, _x}
+  local _x = nil
+  local _msg = nil
+  local _e = xpcall(function ()
+    _x = (function ()
+      return(compiler.eval(form))
+    end)()
+    return(_x)
+  end, function (...)
+    local l = unstash({...})
+    _msg = apply(_37message_handler, l)
+    return(_msg)
+  end)
+  local _e1
+  if _e then
+    _e1 = _x
+  else
+    _e1 = _msg
+  end
+  local _id = {_e, _e1}
   local ok = _id[1]
   local x = _id[2]
   if not  ok then
@@ -1018,15 +1050,15 @@ local function usage()
   return(exit())
 end
 local function end_is63(str, ...)
-  local _r6 = unstash({...})
-  local _id1 = _r6
+  local _r7 = unstash({...})
+  local _id1 = _r7
   local l = cut(_id1, 0)
   local s = apply(cat, l)
   return(clip(str, _35(str) - _35(s)) == s)
 end
 local function cat_end(str, ...)
-  local _r7 = unstash({...})
-  local _id2 = _r7
+  local _r8 = unstash({...})
+  local _id2 = _r8
   local l = cut(_id2, 0)
   local s = apply(cat, l)
   if end_is63(str, s) then
@@ -1083,11 +1115,11 @@ local function main()
     end
     i = i + 1
   end
-  local _x4 = pre
-  local _n = _35(_x4)
+  local _x5 = pre
+  local _n = _35(_x5)
   local _i = 0
   while _i < _n do
-    local file = _x4[_i + 1]
+    local file = _x5[_i + 1]
     compiler["run-file"](cat_end(file, ".", target))
     _i = _i + 1
   end

--- a/bin/reader.js
+++ b/bin/reader.js
@@ -225,8 +225,10 @@ read_table[","] = function (s) {
     return(wrap(s, "unquote"));
   }
 };
+var _124exports124 = exports || {};
 exports.stream = stream;
 exports.read = read;
 exports["read-all"] = read_all;
 exports["read-string"] = read_string;
 exports["read-from-string"] = read_from_string;
+exports;

--- a/bin/reader.js
+++ b/bin/reader.js
@@ -68,6 +68,16 @@ var read_string = function (str, more) {
     return(x);
   }
 };
+read_from_string = function (s) {
+  var _r7 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _id1 = _r7;
+  var one = _id1.one;
+  if (one) {
+    return(read_string(s));
+  } else {
+    return(read_all(stream(s)));
+  }
+};
 var key63 = function (atom) {
   return(string63(atom) && _35(atom) > 1 && char(atom, edge(atom)) === ":");
 };
@@ -75,13 +85,13 @@ var flag63 = function (atom) {
   return(string63(atom) && _35(atom) > 1 && char(atom, 0) === ":");
 };
 var expected = function (s, c) {
-  var _id1 = s;
-  var more = _id1.more;
-  var pos = _id1.pos;
-  var _id2 = more;
+  var _id2 = s;
+  var more = _id2.more;
+  var pos = _id2.pos;
+  var _id3 = more;
   var _e;
-  if (_id2) {
-    _e = _id2;
+  if (_id3) {
+    _e = _id3;
   } else {
     throw new Error("Expected " + c + " at " + pos);
     _e = undefined;
@@ -219,3 +229,4 @@ exports.stream = stream;
 exports.read = read;
 exports["read-all"] = read_all;
 exports["read-string"] = read_string;
+exports["read-from-string"] = read_from_string;

--- a/bin/reader.js
+++ b/bin/reader.js
@@ -1,13 +1,13 @@
-var delimiters = {"\n": true, "(": true, ";": true, ")": true};
-var whitespace = {"\n": true, "\t": true, " ": true};
+var delimiters = {"(": true, ")": true, "\n": true, ";": true};
+var whitespace = {" ": true, "\n": true, "\t": true};
 var stream = function (str, more) {
-  return({string: str, pos: 0, more: more, len: _35(str)});
+  return({more: more, pos: 0, len: _35(str), string: str});
 };
 var peek_char = function (s) {
   var _id = s;
   var pos = _id.pos;
-  var string = _id.string;
   var len = _id.len;
+  var string = _id.string;
   if (pos < len) {
     return(char(string, pos));
   }

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -1,5 +1,5 @@
-local delimiters = {["\n"] = true, [";"] = true, ["("] = true, [")"] = true}
-local whitespace = {[" "] = true, ["\t"] = true, ["\n"] = true}
+local delimiters = {["("] = true, [")"] = true, ["\n"] = true, [";"] = true}
+local whitespace = {[" "] = true, ["\n"] = true, ["\t"] = true}
 local function stream(str, more)
   return({more = more, pos = 0, len = _35(str), string = str})
 end
@@ -76,8 +76,8 @@ local function flag63(atom)
 end
 local function expected(s, c)
   local _id1 = s
-  local pos = _id1.pos
   local more = _id1.more
+  local pos = _id1.pos
   local _id2 = more
   local _e
   if _id2 then
@@ -215,4 +215,4 @@ read_table[","] = function (s)
     return(wrap(s, "unquote"))
   end
 end
-return({stream = stream, ["read-string"] = read_string, read = read, ["read-all"] = read_all})
+return({["read-string"] = read_string, read = read, ["read-all"] = read_all, stream = stream})

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -68,6 +68,16 @@ local function read_string(str, more)
     return(x)
   end
 end
+function read_from_string(s, ...)
+  local _r7 = unstash({...})
+  local _id1 = _r7
+  local one = _id1.one
+  if one then
+    return(read_string(s))
+  else
+    return(read_all(stream(s)))
+  end
+end
 local function key63(atom)
   return(string63(atom) and _35(atom) > 1 and char(atom, edge(atom)) == ":")
 end
@@ -75,13 +85,13 @@ local function flag63(atom)
   return(string63(atom) and _35(atom) > 1 and char(atom, 0) == ":")
 end
 local function expected(s, c)
-  local _id1 = s
-  local more = _id1.more
-  local pos = _id1.pos
-  local _id2 = more
+  local _id2 = s
+  local more = _id2.more
+  local pos = _id2.pos
+  local _id3 = more
   local _e
-  if _id2 then
-    _e = _id2
+  if _id3 then
+    _e = _id3
   else
     error("Expected " .. c .. " at " .. pos)
     _e = nil
@@ -215,4 +225,4 @@ read_table[","] = function (s)
     return(wrap(s, "unquote"))
   end
 end
-return({["read-string"] = read_string, read = read, ["read-all"] = read_all, stream = stream})
+return({["read-string"] = read_string, ["read-all"] = read_all, read = read, ["read-from-string"] = read_from_string, stream = stream})

--- a/compiler.l
+++ b/compiler.l
@@ -549,14 +549,22 @@
 (define run-file (path)
   (run (read-file path)))
 
+(define compile-string (s)
+  (let out ""
+    (step expr (read-from-string s)
+      (let form (expand `(do ,expr))
+        (cat! out (compile form :stmt))))
+    out))
+
 (define compile-file (path)
-  (let (s ((get reader 'stream) (read-file path))
-        body ((get reader 'read-all) s)
-        form (expand `(do ,@body)))
-    (compile form :stmt)))
+  (compile-string (read-file path)))
+
+(define-global load-string (s)
+  (run (compile-string (cat "(set %result ((fn () " s ")))")))
+  %result)
 
 (define-global load (path)
-  (run (compile-file path)))
+  (load-string (read-file path)))
 
 (define-special do forms :stmt :tr
   (with s ""
@@ -688,7 +696,9 @@
 
 (export eval
         run-file
+        compile-string
         compile-file
+        load-string
         load
         expand
         compile)

--- a/macros.l
+++ b/macros.l
@@ -140,13 +140,15 @@
 (define-macro fn (args rest: body)
   `(%function ,@(bind* args body)))
 
-(define-macro guard (expr)
-  (if (= target 'js)
-      `((fn () (%try (list true ,expr))))
-    (let-unique (e x)
-      (let ex (cat "|" e "," x "|")
-        `(let ,ex (xpcall (fn () ,expr) %message-handler)
-           (list ,e ,x))))))
+(define-macro guard body
+  (let expr `((fn () ,@body))
+    (if (= target 'js)
+        `((fn () (%try (list true ,expr))))
+      (let-unique (e x msg)
+        `(let (,x nil ,msg nil
+               ,e (xpcall (fn () (set ,x ,expr))
+                          (fn l (set ,msg (apply %message-handler l)))))
+           (list ,e (if ,e ,x ,msg)))))))
 
 (define-macro each (x t rest: body)
   (let-unique (o n i)

--- a/macros.l
+++ b/macros.l
@@ -208,9 +208,11 @@
 
 (define-macro export names
   (if (= target 'js)
-      `(do ,@(map (fn (k)
+      `(let |exports| (or exports (obj))
+           ,@(map (fn (k)
                     `(set (get exports ',k) ,k))
-                  names))
+                  names)
+           exports)
     (let x (obj)
       (each k names
         (set (get x k) k))

--- a/main.l
+++ b/main.l
@@ -39,6 +39,8 @@
   (print "  -e <expr>\tExpression to evaluate")
   (exit))
 
+(define-global args ())
+
 (define main ()
   (when (or (= (hd argv) "-h")
             (= (hd argv) "--help"))
@@ -51,7 +53,8 @@
         n (# argv))
     (for i n
       (let a (at argv i)
-        (if (or (= a "-c") (= a "-o") (= a "-t") (= a "-e"))
+        (if (= a "--") (do (set args (cut argv (+ i 1))) (break))
+            (or (= a "-c") (= a "-o") (= a "-t") (= a "-e"))
             (if (= i (- n 1))
                 (print (cat "missing argument for " a))
               (do (inc i)

--- a/main.l
+++ b/main.l
@@ -39,6 +39,15 @@
   (print "  -e <expr>\tExpression to evaluate")
   (exit))
 
+(define end-is? (str rest: l)
+  (let s (apply cat l)
+    (= (clip str (- (# str) (# s))) s)))
+
+(define cat-end (str rest: l)
+  (let s (apply cat l)
+    (if (end-is? str s) str
+      (cat str s))))
+
 (define-global args ())
 
 (define main ()
@@ -65,7 +74,7 @@
                         (= a "-e") (set expr val)))))
             (not (= "-" (char a 0))) (add pre a))))
     (step file pre
-      ((get compiler 'run-file) file))
+      ((get compiler 'run-file) (cat-end file "." target)))
     (if (and input output)
         (do (if target1 (set target target1))
             (let code ((get compiler 'compile-file) input)

--- a/main.l
+++ b/main.l
@@ -75,10 +75,12 @@
             (not (= "-" (char a 0))) (add pre a))))
     (step file pre
       ((get compiler 'run-file) (cat-end file "." target)))
-    (if (and input output)
+    (if input
         (do (if target1 (set target target1))
             (let code ((get compiler 'compile-file) input)
-              (write-file output code)))
+              (if (or (nil? output) (= output "-"))
+                (print code)
+                (write-file output code))))
       (if expr (rep expr) (repl)))))
 
 (main)

--- a/reader.l
+++ b/reader.l
@@ -49,6 +49,10 @@
   (let x (read (stream str more))
     (unless (= x eof) x)))
 
+(define-global read-from-string (s :one)
+  (if one (read-string s)
+    (read-all (stream s))))
+
 (define key? (atom)
   (and (string? atom)
        (> (# atom) 1)
@@ -144,4 +148,5 @@
 (export stream
         read
         read-all
-        read-string)
+        read-string
+        read-from-string)

--- a/test.l
+++ b/test.l
@@ -878,6 +878,22 @@ c"
     (test= 9 (eval '(do (define x 7) (+ x 2))))
     (test= 6 (eval '(apply + '(1 2 3))))))
 
+(define-test compiler
+  (let (eval (get compiler 'eval)
+        compile-string (get compiler 'compile-string))
+    (define-global test-foobar () 42)
+    (test= 42 (test-foobar))
+    (test= 99 (load-string "(define test-foobar () 99) (test-foobar)"))
+    (test= 42 (test-foobar))
+    (test= 99 (load-string "(define-global test-foobar () 99) (test-foobar)"))
+    (test= 99 (test-foobar))
+    (let module (load-string (inner '|
+      (define reader (require 'reader))
+      (define foobar (str) ((get reader 'read-from-string) str))
+      (export foobar)
+      |))
+      (test= '(42 99) ((get module 'foobar) "42 99")))))
+
 (define-test call
   (let f (fn () 42)
     (test= 42 (call f)))

--- a/test.l
+++ b/test.l
@@ -51,7 +51,9 @@
     (test= 2 (# (read "(1 2 a: 7)")))
     (test= 7 (get (read "(1 2 a: 7)") 'a))
     (test= true (get (read "(:a)") 'a))
-    (test= 1 (- -1))))
+    (test= 1 (- -1))
+    (test= '(foo bar) (read-from-string "foo bar"))
+    (test= 'foo (read-from-string "foo bar" :one))))
 
 (define-test guard
   (let i 0

--- a/test.l
+++ b/test.l
@@ -879,14 +879,17 @@ c"
     (test= 6 (eval '(apply + '(1 2 3))))))
 
 (define-test compiler
-  (let (eval (get compiler 'eval)
-        compile-string (get compiler 'compile-string))
+  (let compile-string (get compiler 'compile-string)
+    (let (code (compile-string "(+ 1 1)\n(+ 2 2)\nxyz\n(+ 3 3)")
+          lines (keep some? (split code "\n")))
+      (test= 4 (# lines)))
     (define-global test-foobar () 42)
     (test= 42 (test-foobar))
     (test= 99 (load-string "(define test-foobar () 99) (test-foobar)"))
     (test= 42 (test-foobar))
     (test= 99 (load-string "(define-global test-foobar () 99) (test-foobar)"))
     (test= 99 (test-foobar))
+    (test= 3 (load-string "((get ((fn () (define foo (x y) (+ x y)) (export foo))) 'foo) 1 2)"))
     (let module (load-string (inner '|
       (define reader (require 'reader))
       (define foobar (str) ((get reader 'read-from-string) str))

--- a/test.l
+++ b/test.l
@@ -53,6 +53,23 @@
     (test= true (get (read "(:a)") 'a))
     (test= 1 (- -1))))
 
+(define-test guard
+  (let i 0
+    (let ((ok x) (guard 1 2 (inc i) 3 4))
+      (test= 1 i)
+      (test= true ok)
+      (test= 4 x))
+    (let ((ok x) (guard 1 2 (bark) (inc i) 3 4))
+      (test= 1 i)
+      (test= false ok)
+      (target js: (test= "bark is not defined" x))
+      (target lua: (test= "attempt to call global 'bark' (a nil value)" x)))
+    (let ((ok x) (guard 1 2 (inc i) (bark) 3 4))
+      (test= 2 i)
+      (test= false ok)
+      (target js: (test= "bark is not defined" x))
+      (target lua: (test= "attempt to call global 'bark' (a nil value)" x)))))
+
 (define-test read-more
   (let read (get reader 'read-string)
     (test= 17 (read "17" true))


### PR DESCRIPTION
- `bin/lumen`:
  - The global variable `args` now contains any command line args after "--"
    - e.g. `bin/lumen -e args -- foo bar` displays `("foo" "bar")`
  - If the filename of a "pre-file" doesn't end with `(cat "." target)`, append it.
    - e.g.:
      - `LUMEN_HOST=node bin/lumen obj/test -e '(run)'` calls `(run-file "obj/test.js")`
      - `LUMEN_HOST=lua bin/lumen obj/test -e '(run)'` calls `(run-file "obj/test.lua")`
      - `LUMEN_HOST=lua bin/lumen obj/test.lua -e '(run)'` calls `(run-file "obj/test.lua")`
  - If `-o` is nil or `-` then compiled code is printed to stdout.
    - e.g. `bin/lumen -c foo.l -o -`
    - e.g. `bin/lumen -c foo.l`

- `macros.l`:
  - Fixed the `guard` macro.
  - The `guard` macro can now take multiple expressions, e.g.:
    - `$ LUMEN_HOST=node bin/lumen -e '(guard 1 2 3 4)'` => `(true 4)`
    - `$ LUMEN_HOST=lua bin/lumen -e '(guard 1 2 3 4)'` => `(true 4)`
    - `$ LUMEN_HOST=node bin/lumen -e '(guard 1 2 (foobar) 4)'` => `(false "foobar is not defined")`
    - `$ LUMEN_HOST=lua bin/lumen -e '(guard 1 2 (foobar) 4)'` => `(false "attempt to call global 'foobar' (a nil value)")`
    - `$ bin/lumen -e '(let i 0 (guard 1 2 (inc i)) i)'` => `1`
    - `$ bin/lumen -e '(let i 0 (guard 1 2 (foobar) (inc i)) i)'` => `0`

- `reader.l`:
  - Added global fn `(read-from-string str :one)`
    - E.g. `(read-from-string "foo bar")` => `("foo" "bar")`
    - E.g. `(read-from-string "foo bar" :one)` => `"foo"`

- `test.l`:
  - New tests:
    - `macros.l`: `(guard ...)` macro
    - `reader.l`: `(read-from-string str)` global



