### PR TITLE
Dot syntax, bug fixes

### DIFF
--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -39,6 +39,9 @@ boolean63 = function (x) {
 function63 = function (x) {
   return(type(x) === "function");
 };
+table63 = function (x) {
+  return(type(x) === "object");
+};
 atom63 = function (x) {
   return(nil63(x) || string63(x) || number63(x) || boolean63(x));
 };
@@ -560,44 +563,48 @@ string = function (x, depth) {
                   if (function63(x)) {
                     return("function");
                   } else {
-                    var s = "(";
-                    var sp = "";
-                    var xs = [];
-                    var ks = [];
-                    var d = (depth || 0) + 1;
-                    var _o10 = x;
-                    var k = undefined;
-                    for (k in _o10) {
-                      var v = _o10[k];
-                      var _e16;
-                      if (numeric63(k)) {
-                        _e16 = parseInt(k);
-                      } else {
-                        _e16 = k;
+                    if (table63(x)) {
+                      var s = "(";
+                      var sp = "";
+                      var xs = [];
+                      var ks = [];
+                      var d = (depth || 0) + 1;
+                      var _o10 = x;
+                      var k = undefined;
+                      for (k in _o10) {
+                        var v = _o10[k];
+                        var _e16;
+                        if (numeric63(k)) {
+                          _e16 = parseInt(k);
+                        } else {
+                          _e16 = k;
+                        }
+                        var _k8 = _e16;
+                        if (number63(_k8)) {
+                          xs[_k8] = string(v, d);
+                        } else {
+                          add(ks, _k8 + ":");
+                          add(ks, string(v, d));
+                        }
                       }
-                      var _k8 = _e16;
-                      if (number63(_k8)) {
-                        xs[_k8] = string(v, d);
-                      } else {
-                        add(ks, _k8 + ":");
-                        add(ks, string(v, d));
+                      var _o11 = join(xs, ks);
+                      var _i13 = undefined;
+                      for (_i13 in _o11) {
+                        var v = _o11[_i13];
+                        var _e17;
+                        if (numeric63(_i13)) {
+                          _e17 = parseInt(_i13);
+                        } else {
+                          _e17 = _i13;
+                        }
+                        var __i13 = _e17;
+                        s = s + sp + v;
+                        sp = " ";
                       }
+                      return(s + ")");
+                    } else {
+                      return(escape(tostring(x)));
                     }
-                    var _o11 = join(xs, ks);
-                    var _i13 = undefined;
-                    for (_i13 in _o11) {
-                      var v = _o11[_i13];
-                      var _e17;
-                      if (numeric63(_i13)) {
-                        _e17 = parseInt(_i13);
-                      } else {
-                        _e17 = _i13;
-                      }
-                      var __i13 = _e17;
-                      s = s + sp + v;
-                      sp = " ";
-                    }
-                    return(s + ")");
                   }
                 }
               }
@@ -619,8 +626,8 @@ toplevel63 = function () {
   return(one63(environment));
 };
 setenv = function (k) {
-  var _r68 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _id1 = _r68;
+  var _r69 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _id1 = _r69;
   var _keys = cut(_id1, 0);
   if (string63(k)) {
     var _e18;

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -853,7 +853,7 @@ setenv("define-global", {_stash: true, macro: function (name, x) {
   var _r35 = unstash(Array.prototype.slice.call(arguments, 2));
   var _id29 = _r35;
   var body = cut(_id29, 0);
-  setenv(name, {_stash: true, toplevel: true, variable: true});
+  setenv(name, {_stash: true, variable: true, toplevel: true});
   if (some63(body)) {
     return(join(["%global-function", name], bind42(x, body)));
   } else {

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -43,6 +43,9 @@ end
 function function63(x)
   return(type(x) == "function")
 end
+function table63(x)
+  return(type(x) == "table")
+end
 function atom63(x)
   return(nil63(x) or string63(x) or number63(x) or boolean63(x))
 end
@@ -485,30 +488,34 @@ function string(x, depth)
                   if function63(x) then
                     return("function")
                   else
-                    local s = "("
-                    local sp = ""
-                    local xs = {}
-                    local ks = {}
-                    local d = (depth or 0) + 1
-                    local _o10 = x
-                    local k = nil
-                    for k in next, _o10 do
-                      local v = _o10[k]
-                      if number63(k) then
-                        xs[k] = string(v, d)
-                      else
-                        add(ks, k .. ":")
-                        add(ks, string(v, d))
+                    if table63(x) then
+                      local s = "("
+                      local sp = ""
+                      local xs = {}
+                      local ks = {}
+                      local d = (depth or 0) + 1
+                      local _o10 = x
+                      local k = nil
+                      for k in next, _o10 do
+                        local v = _o10[k]
+                        if number63(k) then
+                          xs[k] = string(v, d)
+                        else
+                          add(ks, k .. ":")
+                          add(ks, string(v, d))
+                        end
                       end
+                      local _o11 = join(xs, ks)
+                      local _i13 = nil
+                      for _i13 in next, _o11 do
+                        local v = _o11[_i13]
+                        s = s .. sp .. v
+                        sp = " "
+                      end
+                      return(s .. ")")
+                    else
+                      return(escape(tostring(x)))
                     end
-                    local _o11 = join(xs, ks)
-                    local _i13 = nil
-                    for _i13 in next, _o11 do
-                      local v = _o11[_i13]
-                      s = s .. sp .. v
-                      sp = " "
-                    end
-                    return(s .. ")")
                   end
                 end
               end
@@ -531,8 +538,8 @@ function toplevel63()
   return(one63(environment))
 end
 function setenv(k, ...)
-  local _r65 = unstash({...})
-  local _id1 = _r65
+  local _r66 = unstash({...})
+  local _id1 = _r66
   local _keys = cut(_id1, 0)
   if string63(k) then
     local _e7

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -752,7 +752,7 @@ setenv("define-global", {_stash = true, macro = function (name, x, ...)
   local _r35 = unstash({...})
   local _id29 = _r35
   local body = cut(_id29, 0)
-  setenv(name, {_stash = true, toplevel = true, variable = true})
+  setenv(name, {_stash = true, variable = true, toplevel = true})
   if some63(body) then
     return(join({"%global-function", name}, bind42(x, body)))
   else
@@ -933,10 +933,22 @@ local reader = require("reader")
 local compiler = require("compiler")
 local system = require("system")
 local function eval_print(form)
-  local _e,_x = xpcall(function ()
-    return(compiler.eval(form))
-  end, _37message_handler)
-  local _id = {_e, _x}
+  local _x = nil
+  local _msg = nil
+  local _e = xpcall(function ()
+    _x = compiler.eval(form)
+    return(_x)
+  end, function (m)
+    _msg = _37message_handler(m)
+    return(_msg)
+  end)
+  local _e1
+  if _e then
+    _e1 = _x
+  else
+    _e1 = _msg
+  end
+  local _id = {_e, _e1}
   local ok = _id[1]
   local x = _id[2]
   if not ok then

--- a/bin/reader.js
+++ b/bin/reader.js
@@ -1,13 +1,13 @@
-var delimiters = {";": true, "\n": true, ")": true, "(": true};
-var whitespace = {"\t": true, " ": true, "\n": true};
+var delimiters = {"(": true, ")": true, ";": true, "\n": true};
+var whitespace = {" ": true, "\t": true, "\n": true};
 var stream = function (str, more) {
-  return({more: more, string: str, len: _35(str), pos: 0});
+  return({pos: 0, string: str, len: _35(str), more: more});
 };
 var peek_char = function (s) {
   var _id = s;
-  var string = _id.string;
-  var len = _id.len;
   var pos = _id.pos;
+  var len = _id.len;
+  var string = _id.string;
   if (pos < len) {
     return(char(string, pos));
   }
@@ -96,7 +96,7 @@ var wrap = function (s, x) {
     return([x, y]);
   }
 };
-var literals = {inf: 1 / 0, "-nan": 0 / 0, "false": false, nan: 0 / 0, "-inf": -1 / 0, "true": true};
+var literals = {"true": true, "false": false, nan: 0 / 0, "-nan": 0 / 0, inf: 1 / 0, "-inf": -1 / 0};
 read_table[""] = function (s) {
   var str = "";
   while (true) {
@@ -116,21 +116,6 @@ read_table[""] = function (s) {
       return(str);
     } else {
       return(n);
-    }
-  }
-};
-var _f = read_table[""];
-read_table[""] = function (s) {
-  var _y = _f(s);
-  if (_y) {
-    var expr = _y;
-    var i = search(expr, ".");
-    if (i && i > 0 && i < _35(expr)) {
-      var lh = clip(expr, 0, i);
-      var rh = clip(expr, i + 1, _35(expr));
-      return(["get", lh, ["quote", rh]]);
-    } else {
-      return(expr);
     }
   }
 };

--- a/bin/reader.js
+++ b/bin/reader.js
@@ -1,12 +1,12 @@
-var delimiters = {")": true, ";": true, "(": true, "\n": true};
+var delimiters = {"(": true, ";": true, ")": true, "\n": true};
 var whitespace = {" ": true, "\t": true, "\n": true};
 var stream = function (str, more) {
-  return({pos: 0, more: more, string: str, len: _35(str)});
+  return({more: more, string: str, pos: 0, len: _35(str)});
 };
 var peek_char = function (s) {
   var _id = s;
-  var pos = _id.pos;
   var string = _id.string;
+  var pos = _id.pos;
   var len = _id.len;
   if (pos < len) {
     return(char(string, pos));
@@ -96,7 +96,7 @@ var wrap = function (s, x) {
     return([x, y]);
   }
 };
-var literals = {"-inf": -1 / 0, "true": true, nan: 0 / 0, inf: 1 / 0, "-nan": 0 / 0, "false": false};
+var literals = {nan: 0 / 0, "false": false, "-inf": -1 / 0, "-nan": 0 / 0, "true": true, inf: 1 / 0};
 read_table[""] = function (s) {
   var str = "";
   while (true) {
@@ -112,26 +112,17 @@ read_table[""] = function (s) {
     return(x);
   } else {
     var n = number(str);
-    if (nil63(n) || nan63(n) || inf63(n)) {
-      return(str);
-    } else {
+    if (!( nil63(n) || nan63(n) || inf63(n))) {
       return(n);
-    }
-  }
-};
-var _f = read_table[""];
-read_table[""] = function (s) {
-  var expr = _f(s);
-  if (! expr) {
-    return("");
-  } else {
-    var i = search(expr, ".");
-    if (i && i > 0 && i < _35(expr)) {
-      var lh = clip(expr, 0, i);
-      var rh = clip(expr, i + 1, _35(expr));
-      return(["get", lh, ["quote", rh]]);
     } else {
-      return(expr);
+      var i = search(str, ".");
+      if (i && i > 0 && i < _35(str)) {
+        var lh = clip(str, 0, i);
+        var rh = clip(str, i + 1, _35(str));
+        return(["get", lh, ["quote", rh]]);
+      } else {
+        return(str);
+      }
     }
   }
 };

--- a/bin/reader.js
+++ b/bin/reader.js
@@ -1,13 +1,13 @@
-var delimiters = {"(": true, ")": true, ";": true, "\n": true};
+var delimiters = {")": true, ";": true, "(": true, "\n": true};
 var whitespace = {" ": true, "\t": true, "\n": true};
 var stream = function (str, more) {
-  return({pos: 0, string: str, len: _35(str), more: more});
+  return({pos: 0, more: more, string: str, len: _35(str)});
 };
 var peek_char = function (s) {
   var _id = s;
   var pos = _id.pos;
-  var len = _id.len;
   var string = _id.string;
+  var len = _id.len;
   if (pos < len) {
     return(char(string, pos));
   }
@@ -76,8 +76,8 @@ var flag63 = function (atom) {
 };
 var expected = function (s, c) {
   var _id1 = s;
-  var more = _id1.more;
   var pos = _id1.pos;
+  var more = _id1.more;
   var _id2 = more;
   var _e;
   if (_id2) {
@@ -96,7 +96,7 @@ var wrap = function (s, x) {
     return([x, y]);
   }
 };
-var literals = {"true": true, "false": false, nan: 0 / 0, "-nan": 0 / 0, inf: 1 / 0, "-inf": -1 / 0};
+var literals = {"-inf": -1 / 0, "true": true, nan: 0 / 0, inf: 1 / 0, "-nan": 0 / 0, "false": false};
 read_table[""] = function (s) {
   var str = "";
   while (true) {
@@ -116,6 +116,22 @@ read_table[""] = function (s) {
       return(str);
     } else {
       return(n);
+    }
+  }
+};
+var _f = read_table[""];
+read_table[""] = function (s) {
+  var expr = _f(s);
+  if (! expr) {
+    return("");
+  } else {
+    var i = search(expr, ".");
+    if (i && i > 0 && i < _35(expr)) {
+      var lh = clip(expr, 0, i);
+      var rh = clip(expr, i + 1, _35(expr));
+      return(["get", lh, ["quote", rh]]);
+    } else {
+      return(expr);
     }
   }
 };

--- a/bin/reader.js
+++ b/bin/reader.js
@@ -1,13 +1,13 @@
-var delimiters = {"(": true, ")": true, ";": true, "\n": true};
-var whitespace = {" ": true, "\t": true, "\n": true};
+var delimiters = {";": true, "\n": true, ")": true, "(": true};
+var whitespace = {"\t": true, " ": true, "\n": true};
 var stream = function (str, more) {
-  return({pos: 0, string: str, len: _35(str), more: more});
+  return({more: more, string: str, len: _35(str), pos: 0});
 };
 var peek_char = function (s) {
   var _id = s;
-  var pos = _id.pos;
-  var len = _id.len;
   var string = _id.string;
+  var len = _id.len;
+  var pos = _id.pos;
   if (pos < len) {
     return(char(string, pos));
   }
@@ -96,7 +96,7 @@ var wrap = function (s, x) {
     return([x, y]);
   }
 };
-var literals = {"true": true, "false": false, nan: 0 / 0, "-nan": 0 / 0, inf: 1 / 0, "-inf": -1 / 0};
+var literals = {inf: 1 / 0, "-nan": 0 / 0, "false": false, nan: 0 / 0, "-inf": -1 / 0, "true": true};
 read_table[""] = function (s) {
   var str = "";
   while (true) {
@@ -116,6 +116,21 @@ read_table[""] = function (s) {
       return(str);
     } else {
       return(n);
+    }
+  }
+};
+var _f = read_table[""];
+read_table[""] = function (s) {
+  var _y = _f(s);
+  if (_y) {
+    var expr = _y;
+    var i = search(expr, ".");
+    if (i && i > 0 && i < _35(expr)) {
+      var lh = clip(expr, 0, i);
+      var rh = clip(expr, i + 1, _35(expr));
+      return(["get", lh, ["quote", rh]]);
+    } else {
+      return(expr);
     }
   }
 };

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -1,13 +1,13 @@
-local delimiters = {[")"] = true, [";"] = true, ["\n"] = true, ["("] = true}
-local whitespace = {["\t"] = true, [" "] = true, ["\n"] = true}
+local delimiters = {["\n"] = true, ["("] = true, [")"] = true, [";"] = true}
+local whitespace = {[" "] = true, ["\n"] = true, ["\t"] = true}
 local function stream(str, more)
-  return({pos = 0, more = more, string = str, len = _35(str)})
+  return({more = more, len = _35(str), string = str, pos = 0})
 end
 local function peek_char(s)
   local _id = s
-  local len = _id.len
-  local string = _id.string
   local pos = _id.pos
+  local string = _id.string
+  local len = _id.len
   if pos < len then
     return(char(string, pos))
   end
@@ -76,8 +76,8 @@ local function flag63(atom)
 end
 local function expected(s, c)
   local _id1 = s
-  local pos = _id1.pos
   local more = _id1.more
+  local pos = _id1.pos
   local _id2 = more
   local _e
   if _id2 then
@@ -96,7 +96,7 @@ local function wrap(s, x)
     return({x, y})
   end
 end
-local literals = {["-nan"] = 0 / 0, ["true"] = true, ["false"] = false, inf = 1 / 0, nan = 0 / 0, ["-inf"] = -1 / 0}
+local literals = {nan = 0 / 0, ["true"] = true, inf = 1 / 0, ["-nan"] = 0 / 0, ["-inf"] = -1 / 0, ["false"] = false}
 read_table[""] = function (s)
   local str = ""
   while true do
@@ -112,26 +112,17 @@ read_table[""] = function (s)
     return(x)
   else
     local n = number(str)
-    if nil63(n) or nan63(n) or inf63(n) then
-      return(str)
-    else
+    if not( nil63(n) or nan63(n) or inf63(n)) then
       return(n)
-    end
-  end
-end
-local _f = read_table[""]
-read_table[""] = function (s)
-  local expr = _f(s)
-  if not expr then
-    return("")
-  else
-    local i = search(expr, ".")
-    if i and i > 0 and i < _35(expr) then
-      local lh = clip(expr, 0, i)
-      local rh = clip(expr, i + 1, _35(expr))
-      return({"get", lh, {"quote", rh}})
     else
-      return(expr)
+      local i = search(str, ".")
+      if i and i > 0 and i < _35(str) then
+        local lh = clip(str, 0, i)
+        local rh = clip(str, i + 1, _35(str))
+        return({"get", lh, {"quote", rh}})
+      else
+        return(str)
+      end
     end
   end
 end
@@ -225,4 +216,4 @@ read_table[","] = function (s)
     return(wrap(s, "unquote"))
   end
 end
-return({stream = stream, ["read-table"] = read_table, ["read-string"] = read_string, ["read-all"] = read_all, read = read})
+return({read = read, stream = stream, ["read-table"] = read_table, ["read-string"] = read_string, ["read-all"] = read_all})

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -1,12 +1,12 @@
 local delimiters = {["("] = true, [")"] = true, [";"] = true, ["\n"] = true}
-local whitespace = {["\n"] = true, [" "] = true, ["\t"] = true}
+local whitespace = {[" "] = true, ["\t"] = true, ["\n"] = true}
 local function stream(str, more)
-  return({len = _35(str), pos = 0, string = str, more = more})
+  return({pos = 0, string = str, len = _35(str), more = more})
 end
 local function peek_char(s)
   local _id = s
-  local len = _id.len
   local pos = _id.pos
+  local len = _id.len
   local string = _id.string
   if pos < len then
     return(char(string, pos))
@@ -76,8 +76,8 @@ local function flag63(atom)
 end
 local function expected(s, c)
   local _id1 = s
-  local pos = _id1.pos
   local more = _id1.more
+  local pos = _id1.pos
   local _id2 = more
   local _e
   if _id2 then
@@ -96,7 +96,7 @@ local function wrap(s, x)
     return({x, y})
   end
 end
-local literals = {["-inf"] = -1 / 0, ["true"] = true, nan = 0 / 0, ["false"] = false, ["-nan"] = 0 / 0, inf = 1 / 0}
+local literals = {["true"] = true, ["false"] = false, nan = 0 / 0, ["-nan"] = 0 / 0, inf = 1 / 0, ["-inf"] = -1 / 0}
 read_table[""] = function (s)
   local str = ""
   while true do
@@ -116,21 +116,6 @@ read_table[""] = function (s)
       return(str)
     else
       return(n)
-    end
-  end
-end
-local _f = read_table[""]
-read_table[""] = function (s)
-  local _y = _f(s)
-  if _y then
-    local expr = _y
-    local i = search(expr, ".")
-    if i and i > 0 and i < _35(expr) then
-      local lh = clip(expr, 0, i)
-      local rh = clip(expr, i + 1, _35(expr))
-      return({"get", lh, {"quote", rh}})
-    else
-      return(expr)
     end
   end
 end
@@ -224,4 +209,4 @@ read_table[","] = function (s)
     return(wrap(s, "unquote"))
   end
 end
-return({stream = stream, ["read-table"] = read_table, read = read, ["read-all"] = read_all, ["read-string"] = read_string})
+return({stream = stream, read = read, ["read-all"] = read_all, ["read-string"] = read_string, ["read-table"] = read_table})

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -1,12 +1,12 @@
 local delimiters = {["("] = true, [")"] = true, [";"] = true, ["\n"] = true}
-local whitespace = {[" "] = true, ["\t"] = true, ["\n"] = true}
+local whitespace = {["\n"] = true, [" "] = true, ["\t"] = true}
 local function stream(str, more)
-  return({pos = 0, string = str, len = _35(str), more = more})
+  return({len = _35(str), pos = 0, string = str, more = more})
 end
 local function peek_char(s)
   local _id = s
-  local pos = _id.pos
   local len = _id.len
+  local pos = _id.pos
   local string = _id.string
   if pos < len then
     return(char(string, pos))
@@ -76,8 +76,8 @@ local function flag63(atom)
 end
 local function expected(s, c)
   local _id1 = s
-  local more = _id1.more
   local pos = _id1.pos
+  local more = _id1.more
   local _id2 = more
   local _e
   if _id2 then
@@ -96,7 +96,7 @@ local function wrap(s, x)
     return({x, y})
   end
 end
-local literals = {["true"] = true, ["false"] = false, nan = 0 / 0, ["-nan"] = 0 / 0, inf = 1 / 0, ["-inf"] = -1 / 0}
+local literals = {["-inf"] = -1 / 0, ["true"] = true, nan = 0 / 0, ["false"] = false, ["-nan"] = 0 / 0, inf = 1 / 0}
 read_table[""] = function (s)
   local str = ""
   while true do
@@ -116,6 +116,21 @@ read_table[""] = function (s)
       return(str)
     else
       return(n)
+    end
+  end
+end
+local _f = read_table[""]
+read_table[""] = function (s)
+  local _y = _f(s)
+  if _y then
+    local expr = _y
+    local i = search(expr, ".")
+    if i and i > 0 and i < _35(expr) then
+      local lh = clip(expr, 0, i)
+      local rh = clip(expr, i + 1, _35(expr))
+      return({"get", lh, {"quote", rh}})
+    else
+      return(expr)
     end
   end
 end
@@ -209,4 +224,4 @@ read_table[","] = function (s)
     return(wrap(s, "unquote"))
   end
 end
-return({stream = stream, read = read, ["read-all"] = read_all, ["read-string"] = read_string, ["read-table"] = read_table})
+return({stream = stream, ["read-table"] = read_table, read = read, ["read-all"] = read_all, ["read-string"] = read_string})

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -1,13 +1,13 @@
-local delimiters = {["("] = true, [")"] = true, [";"] = true, ["\n"] = true}
-local whitespace = {[" "] = true, ["\t"] = true, ["\n"] = true}
+local delimiters = {[")"] = true, [";"] = true, ["\n"] = true, ["("] = true}
+local whitespace = {["\t"] = true, [" "] = true, ["\n"] = true}
 local function stream(str, more)
-  return({pos = 0, string = str, len = _35(str), more = more})
+  return({pos = 0, more = more, string = str, len = _35(str)})
 end
 local function peek_char(s)
   local _id = s
-  local pos = _id.pos
   local len = _id.len
   local string = _id.string
+  local pos = _id.pos
   if pos < len then
     return(char(string, pos))
   end
@@ -76,8 +76,8 @@ local function flag63(atom)
 end
 local function expected(s, c)
   local _id1 = s
-  local more = _id1.more
   local pos = _id1.pos
+  local more = _id1.more
   local _id2 = more
   local _e
   if _id2 then
@@ -96,7 +96,7 @@ local function wrap(s, x)
     return({x, y})
   end
 end
-local literals = {["true"] = true, ["false"] = false, nan = 0 / 0, ["-nan"] = 0 / 0, inf = 1 / 0, ["-inf"] = -1 / 0}
+local literals = {["-nan"] = 0 / 0, ["true"] = true, ["false"] = false, inf = 1 / 0, nan = 0 / 0, ["-inf"] = -1 / 0}
 read_table[""] = function (s)
   local str = ""
   while true do
@@ -116,6 +116,22 @@ read_table[""] = function (s)
       return(str)
     else
       return(n)
+    end
+  end
+end
+local _f = read_table[""]
+read_table[""] = function (s)
+  local expr = _f(s)
+  if not expr then
+    return("")
+  else
+    local i = search(expr, ".")
+    if i and i > 0 and i < _35(expr) then
+      local lh = clip(expr, 0, i)
+      local rh = clip(expr, i + 1, _35(expr))
+      return({"get", lh, {"quote", rh}})
+    else
+      return(expr)
     end
   end
 end
@@ -209,4 +225,4 @@ read_table[","] = function (s)
     return(wrap(s, "unquote"))
   end
 end
-return({stream = stream, read = read, ["read-all"] = read_all, ["read-string"] = read_string, ["read-table"] = read_table})
+return({stream = stream, ["read-table"] = read_table, ["read-string"] = read_string, ["read-all"] = read_all, read = read})

--- a/reader.l
+++ b/reader.l
@@ -88,13 +88,14 @@
 
 (let f (get read-table "")
   (define-reader ("" s)
-    (let-when expr (f s)
-      (let i (search expr ".")
-        (if (and i (> i 0) (< i (# expr)))
-          (let (lh (clip expr 0 i)
-                rh (clip expr (+ i 1) (# expr)))
-            `(get ,lh ',rh))
-          expr)))))
+    (let expr (f s)
+      (if (not expr) ""
+        (let i (search expr ".")
+          (if (and i (> i 0) (< i (# expr)))
+            (let (lh (clip expr 0 i)
+                  rh (clip expr (+ i 1) (# expr)))
+              `(get ,lh ',rh))
+            expr))))))
 
 (define-reader ("(" s)
   (read-char s)

--- a/reader.l
+++ b/reader.l
@@ -86,6 +86,16 @@
         (let n (number str)
           (if (or (nil? n) (nan? n) (inf? n)) str n))))))
 
+(let f (get read-table "")
+  (define-reader ("" s)
+    (let-when expr (f s)
+      (let i (search expr ".")
+        (if (and i (> i 0) (< i (# expr)))
+          (let (lh (clip expr 0 i)
+                rh (clip expr (+ i 1) (# expr)))
+            `(get ,lh ',rh))
+          expr)))))
+
 (define-reader ("(" s)
   (read-char s)
   (with r nil

--- a/reader.l
+++ b/reader.l
@@ -84,18 +84,13 @@
     (let x (get literals str)
       (if (is? x) x
         (let n (number str)
-          (if (or (nil? n) (nan? n) (inf? n)) str n))))))
-
-(let f (get read-table "")
-  (define-reader ("" s)
-    (let expr (f s)
-      (if (not expr) ""
-        (let i (search expr ".")
-          (if (and i (> i 0) (< i (# expr)))
-            (let (lh (clip expr 0 i)
-                  rh (clip expr (+ i 1) (# expr)))
-              `(get ,lh ',rh))
-            expr))))))
+          (if (not (or (nil? n) (nan? n) (inf? n))) n
+            (let i (search str ".")
+              (if (and i (> i 0) (< i (# str)))
+                (let (lh (clip str 0 i)
+                      rh (clip str (+ i 1) (# str)))
+                  `(get ,lh ',rh))
+                str))))))))
 
 (define-reader ("(" s)
   (read-char s)

--- a/runtime.l
+++ b/runtime.l
@@ -34,6 +34,7 @@
 (define-global number? (x) (= (type x) 'number))
 (define-global boolean? (x) (= (type x) 'boolean))
 (define-global function? (x) (= (type x) 'function))
+(define-global table? (x) (= (type x) (target js: 'object lua: 'table)))
 
 (define-global atom? (x)
   (or (nil? x) (string? x) (number? x) (boolean? x)))
@@ -288,18 +289,20 @@
       (string? x) (escape x)
       (atom? x) (tostring x)
       (function? x) "function"
-    (let (s "(" sp ""
-          xs () ks ()
-          d (+ (or depth 0) 1))
-      (each (k v) x
-        (if (number? k)
-            (set (get xs k) (string v d))
-          (do (add ks (cat k ":"))
-              (add ks (string v d)))))
-      (each v (join xs ks)
-        (cat! s sp v)
-        (set sp " "))
-      (cat s  ")"))))
+      (table? x)
+        (let (s "(" sp ""
+              xs () ks ()
+              d (+ (or depth 0) 1))
+          (each (k v) x
+            (if (number? k)
+                (set (get xs k) (string v d))
+              (do (add ks (cat k ":"))
+                  (add ks (string v d)))))
+          (each v (join xs ks)
+            (cat! s sp v)
+            (set sp " "))
+          (cat s  ")"))
+      (escape (tostring x))))
 
 (target lua:
   (define values (or unpack tunpack)))


### PR DESCRIPTION
- `make clean` followed by `make`
  - (The current mainline lumen was using an outdated `eval-print` definition in `bin/lumen.lua` that uses the old, broken `guard` macro.)
 
- `reader.l`:
  - `foo.bar` now becomes `(get foo 'bar)` as per https://github.com/sctb/lumen/issues/12#issuecomment-146050432
    - NOTE:  Don't bother examining commits for this feature except for c5b0874.  My first two attempts didn't work as expected.

- `runtime.l`:
  - New global fn `table?`
  - Fix the error "bad argument #1 to '(for generator)' (table expected, got userdata)"
    - E.g. previously: `LUMEN_HOST=luajit bin/lumen -e "(require 'ffi)"` => `luajit: lumen.lua:495: bad argument #1 to '(for generator)' (table expected, got userdata)`
    - Now:  `$ LUMEN_HOST=luajit bin/lumen -e "(require 'ffi)"` => `(new: function cast: function typeof: function sizeof: function alignof: function istype: function fill: function cdef: function abi: function metatype: function copy: function errno: function load: function arch: "x64" string: function gc: function os: "OSX" C: "userdata: 0x000825c0" offsetof: function)`
