### PR TITLE
LUMEN_HOST=node is broken.

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -401,7 +401,7 @@ indentation = function () {
   }
   return(s);
 };
-var reserved = {"else": true, "or": true, "delete": true, "until": true, "debugger": true, "new": true, ">": true, "*": true, "this": true, "default": true, "=": true, "elseif": true, "==": true, "local": true, "try": true, "false": true, "nil": true, "break": true, "do": true, "finally": true, "function": true, "switch": true, "void": true, "not": true, "and": true, "repeat": true, "while": true, "instanceof": true, "end": true, "then": true, "with": true, "case": true, "for": true, "-": true, "%": true, "if": true, "catch": true, "in": true, "+": true, "return": true, "continue": true, "true": true, "throw": true, ">=": true, "var": true, "typeof": true, "<=": true, "<": true, "/": true};
+var reserved = {"else": true, "<": true, "true": true, "/": true, "end": true, "typeof": true, "function": true, "switch": true, "=": true, "or": true, "try": true, "catch": true, "until": true, "local": true, "repeat": true, "-": true, "false": true, "continue": true, "==": true, "and": true, "if": true, "for": true, ">=": true, "<=": true, "with": true, "return": true, "finally": true, "nil": true, "new": true, "do": true, "case": true, "break": true, "elseif": true, "+": true, "not": true, "void": true, "var": true, "%": true, "in": true, "delete": true, "throw": true, "debugger": true, "instanceof": true, "this": true, "while": true, "then": true, "default": true, "*": true, ">": true};
 reserved63 = function (x) {
   return(reserved[x]);
 };
@@ -462,8 +462,8 @@ _x58.js = "!";
 __x57["not"] = _x58;
 var __x59 = [];
 __x59["/"] = true;
-__x59["%"] = true;
 __x59["*"] = true;
+__x59["%"] = true;
 var __x60 = [];
 __x60["+"] = true;
 __x60["-"] = true;
@@ -473,9 +473,9 @@ _x62.lua = "..";
 _x62.js = "+";
 __x61.cat = _x62;
 var __x63 = [];
+__x63["<="] = true;
 __x63[">="] = true;
 __x63["<"] = true;
-__x63["<="] = true;
 __x63[">"] = true;
 var __x64 = [];
 var _x65 = [];
@@ -617,10 +617,22 @@ var compile_atom = function (x) {
                 return("false");
               }
             } else {
-              if (number63(x)) {
-                return(x + "");
+              if (nan63(x)) {
+                return("nan");
               } else {
-                throw new Error("Cannot compile atom: " + string(x));
+                if (x === inf) {
+                  return("inf");
+                } else {
+                  if (x === -inf) {
+                    return("-inf");
+                  } else {
+                    if (number63(x)) {
+                      return(x + "");
+                    } else {
+                      throw new Error("Cannot compile atom: " + string(x));
+                    }
+                  }
+                }
               }
             }
           }
@@ -645,8 +657,8 @@ var compile_special = function (form, stmt63) {
   var x = _id5[0];
   var args = cut(_id5, 1);
   var _id6 = getenv(x);
-  var stmt = _id6.stmt;
   var self_tr63 = _id6.tr;
+  var stmt = _id6.stmt;
   var special = _id6.special;
   var tr = terminator(stmt63 && ! self_tr63);
   return(apply(special, args) + tr);
@@ -1008,7 +1020,7 @@ eval = function (form) {
   run(code);
   return(_37result);
 };
-setenv("do", {_stash: true, stmt: true, tr: true, special: function () {
+setenv("do", {_stash: true, tr: true, special: function () {
   var forms = unstash(Array.prototype.slice.call(arguments, 0));
   var s = "";
   var _x107 = forms;
@@ -1020,8 +1032,8 @@ setenv("do", {_stash: true, stmt: true, tr: true, special: function () {
     _i12 = _i12 + 1;
   }
   return(s);
-}});
-setenv("%if", {_stash: true, stmt: true, tr: true, special: function (cond, cons, alt) {
+}, stmt: true});
+setenv("%if", {_stash: true, tr: true, special: function (cond, cons, alt) {
   var _cond1 = compile(cond);
   indent_level = indent_level + 1;
   var _x110 = compile(cons, {_stash: true, stmt: true});
@@ -1054,8 +1066,8 @@ setenv("%if", {_stash: true, stmt: true, tr: true, special: function (cond, cons
   } else {
     return(s + "\n");
   }
-}});
-setenv("while", {_stash: true, stmt: true, tr: true, special: function (cond, form) {
+}, stmt: true});
+setenv("while", {_stash: true, tr: true, special: function (cond, form) {
   var _cond3 = compile(cond);
   indent_level = indent_level + 1;
   var _x113 = compile(form, {_stash: true, stmt: true});
@@ -1067,8 +1079,8 @@ setenv("while", {_stash: true, stmt: true, tr: true, special: function (cond, fo
   } else {
     return(ind + "while " + _cond3 + " do\n" + body + ind + "end\n");
   }
-}});
-setenv("%for", {_stash: true, stmt: true, tr: true, special: function (t, k, form) {
+}, stmt: true});
+setenv("%for", {_stash: true, tr: true, special: function (t, k, form) {
   var _t1 = compile(t);
   var ind = indentation();
   indent_level = indent_level + 1;
@@ -1080,8 +1092,8 @@ setenv("%for", {_stash: true, stmt: true, tr: true, special: function (t, k, for
   } else {
     return(ind + "for (" + k + " in " + _t1 + ") {\n" + body + ind + "}\n");
   }
-}});
-setenv("%try", {_stash: true, stmt: true, tr: true, special: function (form) {
+}, stmt: true});
+setenv("%try", {_stash: true, tr: true, special: function (form) {
   var e = unique("e");
   var ind = indentation();
   indent_level = indent_level + 1;
@@ -1094,7 +1106,7 @@ setenv("%try", {_stash: true, stmt: true, tr: true, special: function (form) {
   indent_level = indent_level - 1;
   var h = _x125;
   return(ind + "try {\n" + body + ind + "}\n" + ind + "catch (" + e + ") {\n" + h + ind + "}\n");
-}});
+}, stmt: true});
 setenv("%delete", {_stash: true, special: function (place) {
   return(indentation() + "delete " + compile(place));
 }, stmt: true});
@@ -1104,22 +1116,22 @@ setenv("break", {_stash: true, special: function () {
 setenv("%function", {_stash: true, special: function (args, body) {
   return(compile_function(args, body));
 }});
-setenv("%global-function", {_stash: true, stmt: true, tr: true, special: function (name, args, body) {
+setenv("%global-function", {_stash: true, tr: true, special: function (name, args, body) {
   if (target === "lua") {
     var x = compile_function(args, body, {_stash: true, name: name});
     return(indentation() + x);
   } else {
     return(compile(["set", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}});
-setenv("%local-function", {_stash: true, stmt: true, tr: true, special: function (name, args, body) {
+}, stmt: true});
+setenv("%local-function", {_stash: true, tr: true, special: function (name, args, body) {
   if (target === "lua") {
     var x = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
     return(indentation() + x);
   } else {
     return(compile(["%local", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}});
+}, stmt: true});
 setenv("return", {_stash: true, special: function (x) {
   var _e35;
   if (nil63(x)) {

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -359,7 +359,7 @@ function indentation()
   end
   return(s)
 end
-local reserved = {["instanceof"] = true, ["-"] = true, ["false"] = true, ["/"] = true, ["true"] = true, ["+"] = true, ["continue"] = true, ["<"] = true, [">"] = true, ["%"] = true, ["catch"] = true, ["in"] = true, ["then"] = true, ["not"] = true, ["while"] = true, ["void"] = true, ["finally"] = true, ["else"] = true, ["or"] = true, ["debugger"] = true, ["=="] = true, ["repeat"] = true, ["*"] = true, ["and"] = true, ["new"] = true, ["delete"] = true, ["<="] = true, ["for"] = true, ["elseif"] = true, ["typeof"] = true, ["="] = true, ["do"] = true, ["with"] = true, ["case"] = true, ["nil"] = true, ["local"] = true, ["throw"] = true, [">="] = true, ["switch"] = true, ["this"] = true, ["var"] = true, ["function"] = true, ["until"] = true, ["default"] = true, ["break"] = true, ["end"] = true, ["try"] = true, ["return"] = true, ["if"] = true}
+local reserved = {["else"] = true, ["<"] = true, ["true"] = true, ["/"] = true, ["end"] = true, ["typeof"] = true, ["function"] = true, ["switch"] = true, ["="] = true, ["or"] = true, ["try"] = true, ["catch"] = true, ["until"] = true, ["local"] = true, ["repeat"] = true, ["-"] = true, ["false"] = true, ["continue"] = true, ["=="] = true, ["and"] = true, ["if"] = true, ["for"] = true, [">="] = true, ["<="] = true, ["with"] = true, ["return"] = true, ["finally"] = true, ["nil"] = true, ["new"] = true, ["do"] = true, ["case"] = true, ["break"] = true, ["elseif"] = true, ["+"] = true, ["not"] = true, ["void"] = true, ["var"] = true, ["%"] = true, ["in"] = true, ["delete"] = true, ["throw"] = true, ["debugger"] = true, ["instanceof"] = true, ["this"] = true, ["while"] = true, ["then"] = true, ["default"] = true, ["*"] = true, [">"] = true}
 function reserved63(x)
   return(reserved[x])
 end
@@ -408,8 +408,8 @@ function mapo(f, t)
 end
 local __x57 = {}
 local _x58 = {}
-_x58.js = "!"
 _x58.lua = "not"
+_x58.js = "!"
 __x57["not"] = _x58
 local __x59 = {}
 __x59["/"] = true
@@ -420,28 +420,28 @@ __x60["+"] = true
 __x60["-"] = true
 local __x61 = {}
 local _x62 = {}
-_x62.js = "+"
 _x62.lua = ".."
+_x62.js = "+"
 __x61.cat = _x62
 local __x63 = {}
 __x63["<="] = true
-__x63[">"] = true
 __x63[">="] = true
 __x63["<"] = true
+__x63[">"] = true
 local __x64 = {}
 local _x65 = {}
-_x65.js = "==="
 _x65.lua = "=="
+_x65.js = "==="
 __x64["="] = _x65
 local __x66 = {}
 local _x67 = {}
-_x67.js = "&&"
 _x67.lua = "and"
+_x67.js = "&&"
 __x66["and"] = _x67
 local __x68 = {}
 local _x69 = {}
-_x69.js = "||"
 _x69.lua = "or"
+_x69.js = "||"
 __x68["or"] = _x69
 local infix = {__x57, __x59, __x60, __x61, __x63, __x64, __x66, __x68}
 local function unary63(form)
@@ -563,10 +563,22 @@ local function compile_atom(x)
                 return("false")
               end
             else
-              if number63(x) then
-                return(x .. "")
+              if nan63(x) then
+                return("nan")
               else
-                error("Cannot compile atom: " .. string(x))
+                if x == inf then
+                  return("inf")
+                else
+                  if x == -inf then
+                    return("-inf")
+                  else
+                    if number63(x) then
+                      return(x .. "")
+                    else
+                      error("Cannot compile atom: " .. string(x))
+                    end
+                  end
+                end
               end
             end
           end
@@ -591,9 +603,9 @@ local function compile_special(form, stmt63)
   local x = _id5[1]
   local args = cut(_id5, 1)
   local _id6 = getenv(x)
-  local special = _id6.special
-  local stmt = _id6.stmt
   local self_tr63 = _id6.tr
+  local stmt = _id6.stmt
+  local special = _id6.special
   local tr = terminator(stmt63 and not self_tr63)
   return(apply(special, args) .. tr)
 end
@@ -961,7 +973,7 @@ function eval(form)
   run(code)
   return(_37result)
 end
-setenv("do", {_stash = true, special = function (...)
+setenv("do", {_stash = true, tr = true, special = function (...)
   local forms = unstash({...})
   local s = ""
   local _x111 = forms
@@ -973,8 +985,8 @@ setenv("do", {_stash = true, special = function (...)
     _i12 = _i12 + 1
   end
   return(s)
-end, tr = true, stmt = true})
-setenv("%if", {_stash = true, special = function (cond, cons, alt)
+end, stmt = true})
+setenv("%if", {_stash = true, tr = true, special = function (cond, cons, alt)
   local _cond1 = compile(cond)
   indent_level = indent_level + 1
   local _x114 = compile(cons, {_stash = true, stmt = true})
@@ -1007,8 +1019,8 @@ setenv("%if", {_stash = true, special = function (cond, cons, alt)
   else
     return(s .. "\n")
   end
-end, tr = true, stmt = true})
-setenv("while", {_stash = true, special = function (cond, form)
+end, stmt = true})
+setenv("while", {_stash = true, tr = true, special = function (cond, form)
   local _cond3 = compile(cond)
   indent_level = indent_level + 1
   local _x117 = compile(form, {_stash = true, stmt = true})
@@ -1020,8 +1032,8 @@ setenv("while", {_stash = true, special = function (cond, form)
   else
     return(ind .. "while " .. _cond3 .. " do\n" .. body .. ind .. "end\n")
   end
-end, tr = true, stmt = true})
-setenv("%for", {_stash = true, special = function (t, k, form)
+end, stmt = true})
+setenv("%for", {_stash = true, tr = true, special = function (t, k, form)
   local _t1 = compile(t)
   local ind = indentation()
   indent_level = indent_level + 1
@@ -1033,8 +1045,8 @@ setenv("%for", {_stash = true, special = function (t, k, form)
   else
     return(ind .. "for (" .. k .. " in " .. _t1 .. ") {\n" .. body .. ind .. "}\n")
   end
-end, tr = true, stmt = true})
-setenv("%try", {_stash = true, special = function (form)
+end, stmt = true})
+setenv("%try", {_stash = true, tr = true, special = function (form)
   local e = unique("e")
   local ind = indentation()
   indent_level = indent_level + 1
@@ -1047,7 +1059,7 @@ setenv("%try", {_stash = true, special = function (form)
   indent_level = indent_level - 1
   local h = _x129
   return(ind .. "try {\n" .. body .. ind .. "}\n" .. ind .. "catch (" .. e .. ") {\n" .. h .. ind .. "}\n")
-end, tr = true, stmt = true})
+end, stmt = true})
 setenv("%delete", {_stash = true, special = function (place)
   return(indentation() .. "delete " .. compile(place))
 end, stmt = true})
@@ -1057,22 +1069,22 @@ end, stmt = true})
 setenv("%function", {_stash = true, special = function (args, body)
   return(compile_function(args, body))
 end})
-setenv("%global-function", {_stash = true, special = function (name, args, body)
+setenv("%global-function", {_stash = true, tr = true, special = function (name, args, body)
   if target == "lua" then
     local x = compile_function(args, body, {_stash = true, name = name})
     return(indentation() .. x)
   else
     return(compile({"set", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
-end, tr = true, stmt = true})
-setenv("%local-function", {_stash = true, special = function (name, args, body)
+end, stmt = true})
+setenv("%local-function", {_stash = true, tr = true, special = function (name, args, body)
   if target == "lua" then
     local x = compile_function(args, body, {_stash = true, name = name, prefix = "local"})
     return(indentation() .. x)
   else
     return(compile({"%local", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
-end, tr = true, stmt = true})
+end, stmt = true})
 setenv("return", {_stash = true, special = function (x)
   local _e27
   if nil63(x) then
@@ -1196,4 +1208,4 @@ setenv("%object", {_stash = true, special = function (...)
   end
   return(s .. "}")
 end})
-return({compile = compile, eval = eval, run = run, expand = expand})
+return({run = run, expand = expand, compile = compile, eval = eval})

--- a/bin/reader.js
+++ b/bin/reader.js
@@ -1,13 +1,13 @@
-var delimiters = {";": true, ")": true, "(": true, "\n": true};
-var whitespace = {"\t": true, " ": true, "\n": true};
+var delimiters = {"(": true, ")": true, "\n": true, ";": true};
+var whitespace = {" ": true, "\n": true, "\t": true};
 var stream = function (str, more) {
-  return({len: _35(str), string: str, more: more, pos: 0});
+  return({more: more, pos: 0, len: _35(str), string: str});
 };
 var peek_char = function (s) {
   var _id = s;
+  var pos = _id.pos;
   var len = _id.len;
   var string = _id.string;
-  var pos = _id.pos;
   if (pos < len) {
     return(char(string, pos));
   }
@@ -96,7 +96,6 @@ var wrap = function (s, x) {
     return([x, y]);
   }
 };
-var literals = {"true": true, nan: 0 / 0, inf: 1 / 0, "-nan": 0 / 0, "false": false, "-inf": -1 / 0};
 read_table[""] = function (s) {
   var str = "";
   while (true) {
@@ -107,15 +106,34 @@ read_table[""] = function (s) {
       break;
     }
   }
-  var x = literals[str];
-  if (is63(x)) {
-    return(x);
+  if (str === "true") {
+    return(true);
   } else {
-    var n = number(str);
-    if (nil63(n) || nan63(n) || inf63(n)) {
-      return(str);
+    if (str === "false") {
+      return(false);
     } else {
-      return(n);
+      if (str === "nan") {
+        return(nan);
+      } else {
+        if (str === "-nan") {
+          return(nan);
+        } else {
+          if (str === "inf") {
+            return(inf);
+          } else {
+            if (str === "-inf") {
+              return(-inf);
+            } else {
+              var n = number(str);
+              if (nil63(n) || nan63(n) || inf63(n)) {
+                return(str);
+              } else {
+                return(n);
+              }
+            }
+          }
+        }
+      }
     }
   }
 };

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -1,12 +1,12 @@
-local delimiters = {[")"] = true, ["("] = true, [";"] = true, ["\n"] = true}
-local whitespace = {["\t"] = true, ["\n"] = true, [" "] = true}
+local delimiters = {["("] = true, [")"] = true, ["\n"] = true, [";"] = true}
+local whitespace = {[" "] = true, ["\n"] = true, ["\t"] = true}
 local function stream(str, more)
-  return({len = _35(str), string = str, pos = 0, more = more})
+  return({more = more, pos = 0, len = _35(str), string = str})
 end
 local function peek_char(s)
   local _id = s
-  local len = _id.len
   local pos = _id.pos
+  local len = _id.len
   local string = _id.string
   if pos < len then
     return(char(string, pos))
@@ -76,8 +76,8 @@ local function flag63(atom)
 end
 local function expected(s, c)
   local _id1 = s
-  local pos = _id1.pos
   local more = _id1.more
+  local pos = _id1.pos
   local _id2 = more
   local _e
   if _id2 then
@@ -96,7 +96,6 @@ local function wrap(s, x)
     return({x, y})
   end
 end
-local literals = {["-inf"] = -1 / 0, nan = 0 / 0, ["false"] = false, ["true"] = true, ["-nan"] = 0 / 0, inf = 1 / 0}
 read_table[""] = function (s)
   local str = ""
   while true do
@@ -107,15 +106,34 @@ read_table[""] = function (s)
       break
     end
   end
-  local x = literals[str]
-  if is63(x) then
-    return(x)
+  if str == "true" then
+    return(true)
   else
-    local n = number(str)
-    if nil63(n) or nan63(n) or inf63(n) then
-      return(str)
+    if str == "false" then
+      return(false)
     else
-      return(n)
+      if str == "nan" then
+        return(nan)
+      else
+        if str == "-nan" then
+          return(nan)
+        else
+          if str == "inf" then
+            return(inf)
+          else
+            if str == "-inf" then
+              return(-inf)
+            else
+              local n = number(str)
+              if nil63(n) or nan63(n) or inf63(n) then
+                return(str)
+              else
+                return(n)
+              end
+            end
+          end
+        end
+      end
     end
   end
 end
@@ -209,4 +227,4 @@ read_table[","] = function (s)
     return(wrap(s, "unquote"))
   end
 end
-return({["read-string"] = read_string, ["read-table"] = read_table, read = read, ["read-all"] = read_all, stream = stream})
+return({["read-string"] = read_string, ["read-all"] = read_all, read = read, ["read-table"] = read_table, stream = stream})

--- a/bin/system.lua
+++ b/bin/system.lua
@@ -43,4 +43,4 @@ local function exit(code)
   return(os.exit(code))
 end
 local argv = arg
-return({["path-separator"] = path_separator, ["path-join"] = path_join, ["file-exists?"] = file_exists63, write = write, ["write-file"] = write_file, ["read-file"] = read_file, argv = argv, ["get-environment-variable"] = get_environment_variable, exit = exit})
+return({["write-file"] = write_file, write = write, ["read-file"] = read_file, argv = argv, ["path-join"] = path_join, ["get-environment-variable"] = get_environment_variable, exit = exit, ["file-exists?"] = file_exists63, ["path-separator"] = path_separator})

--- a/compiler.l
+++ b/compiler.l
@@ -320,6 +320,9 @@
       (string-literal? x) (escape-newlines x)
       (string? x) (id x)
       (boolean? x) (if x "true" "false")
+      (nan? x) "nan"
+      (= x inf) "inf"
+      (= x -inf) "-inf"
       (number? x) (cat x "")
     (error (cat "Cannot compile atom: " (string x)))))
 

--- a/reader.l
+++ b/reader.l
@@ -68,11 +68,6 @@
     (if (= y (get s 'more)) y
       (list x y))))
 
-(define literals
-  (obj true: true false: false
-       nan: (/ 0 0) -nan: (/ 0 0)
-       inf: (/ 1 0) -inf: (/ -1 0)))
-
 (define-reader ("" s) ; atom
   (let (str "")
     (while true
@@ -81,10 +76,14 @@
 			(not (get delimiters c))))
 	    (cat! str (read-char s))
 	  (break))))
-    (let x (get literals str)
-      (if (is? x) x
-        (let n (number str)
-          (if (or (nil? n) (nan? n) (inf? n)) str n))))))
+    (if (= str "true") true
+      (= str "false") false
+      (= str "nan") nan
+      (= str "-nan") nan
+      (= str "inf") inf
+      (= str "-inf") -inf
+      (let n (number str)
+        (if (or (nil? n) (nan? n) (inf? n)) str n)))))
 
 (define-reader ("(" s)
   (read-char s)


### PR DESCRIPTION
This PR fixes `LUMEN_HOST=node`. My earlier commit 435eb45 broke the node host in two different ways:

- I added the `literals` table into `reader.l`, causing `(read-string "toString")` to incorrectly return a `function` rather than `"toString"`:

```sh
$ LUMEN_HOST=node bin/lumen -e '((get (require "reader") "read-string") "toString")'
function
```

- I neglected to add `nan?` and `inf?` checks to `compile-atom`.  Since 435eb45 changed the reader to output literal `NaN` and `Infinity` rather than `"nan"` and `"inf"`, `compile-atom` therefore needed to check for those cases, just like it checks for `boolean?`.

```sh
$ LUMEN_HOST=node bin/lumen -e '(compile inf)'
"Infinity"
```

Sorry about that.  The root of the problem was that I was too reliant on unit tests.  I should have run `export LUMEN_HOST=node; make clean; make; make test` before submitting the pull request, which would have revealed the problem.

