### PR TITLE
Most reserved words can now be used as identifiers.

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -565,30 +565,36 @@ var escape_newlines = function (s) {
   return(s1);
 };
 var id = function (id) {
-  var id1 = "";
+  var _e21;
+  if (reserved63(id) && ! infix63(id)) {
+    _e21 = "_";
+  } else {
+    _e21 = "";
+  }
+  var id1 = _e21;
   var i = 0;
   while (i < _35(id)) {
     var c = char(id, i);
     var n = code(c);
-    var _e21;
+    var _e22;
     if (c === "-") {
-      _e21 = "_";
+      _e22 = "_";
     } else {
-      var _e22;
+      var _e23;
       if (valid_code63(n)) {
-        _e22 = c;
+        _e23 = c;
       } else {
-        var _e23;
+        var _e24;
         if (i === 0) {
-          _e23 = "_" + n;
+          _e24 = "_" + n;
         } else {
-          _e23 = n;
+          _e24 = n;
         }
-        _e22 = _e23;
+        _e23 = _e24;
       }
-      _e21 = _e22;
+      _e22 = _e23;
     }
-    var c1 = _e21;
+    var c1 = _e22;
     id1 = id1 + c1;
     i = i + 1;
   }
@@ -680,13 +686,13 @@ var op_delims = function (parent, child) {
   var _r56 = unstash(Array.prototype.slice.call(arguments, 2));
   var _id7 = _r56;
   var right = _id7.right;
-  var _e24;
+  var _e25;
   if (right) {
-    _e24 = _6261;
+    _e25 = _6261;
   } else {
-    _e24 = _62;
+    _e25 = _62;
   }
-  if (_e24(precedence(child), precedence(parent))) {
+  if (_e25(precedence(child), precedence(parent))) {
     return(["(", ")"]);
   } else {
     return(["", ""]);
@@ -718,33 +724,33 @@ compile_function = function (args, body) {
   var _id12 = _r58;
   var name = _id12.name;
   var prefix = _id12.prefix;
-  var _e25;
+  var _e26;
   if (name) {
-    _e25 = compile(name);
+    _e26 = compile(name);
   } else {
-    _e25 = "";
+    _e26 = "";
   }
-  var _id13 = _e25;
+  var _id13 = _e26;
   var _args = compile_args(args);
   indent_level = indent_level + 1;
   var _x74 = compile(body, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
   var _body = _x74;
   var ind = indentation();
-  var _e26;
-  if (prefix) {
-    _e26 = prefix + " ";
-  } else {
-    _e26 = "";
-  }
-  var p = _e26;
   var _e27;
-  if (target === "js") {
-    _e27 = "";
+  if (prefix) {
+    _e27 = prefix + " ";
   } else {
-    _e27 = "end";
+    _e27 = "";
   }
-  var tr = _e27;
+  var p = _e27;
+  var _e28;
+  if (target === "js") {
+    _e28 = "";
+  } else {
+    _e28 = "end";
+  }
+  var tr = _e28;
   if (name) {
     tr = tr + "\n";
   }
@@ -768,26 +774,26 @@ compile = function (form) {
       return(compile_special(form, stmt));
     } else {
       var tr = terminator(stmt);
-      var _e28;
-      if (stmt) {
-        _e28 = indentation();
-      } else {
-        _e28 = "";
-      }
-      var ind = _e28;
       var _e29;
-      if (atom63(form)) {
-        _e29 = compile_atom(form);
+      if (stmt) {
+        _e29 = indentation();
       } else {
-        var _e30;
-        if (infix63(hd(form))) {
-          _e30 = compile_infix(form);
-        } else {
-          _e30 = compile_call(form);
-        }
-        _e29 = _e30;
+        _e29 = "";
       }
-      var _form = _e29;
+      var ind = _e29;
+      var _e30;
+      if (atom63(form)) {
+        _e30 = compile_atom(form);
+      } else {
+        var _e31;
+        if (infix63(hd(form))) {
+          _e31 = compile_infix(form);
+        } else {
+          _e31 = compile_call(form);
+        }
+        _e30 = _e31;
+      }
+      var _form = _e30;
       return(ind + _form + tr);
     }
   }
@@ -855,19 +861,19 @@ var lower_if = function (args, hoist, stmt63, tail63) {
   var _then = _id16[1];
   var _else = _id16[2];
   if (stmt63 || tail63) {
-    var _e32;
+    var _e33;
     if (_else) {
-      _e32 = [lower_body([_else], tail63)];
+      _e33 = [lower_body([_else], tail63)];
     }
-    return(add(hoist, join(["%if", lower(cond, hoist), lower_body([_then], tail63)], _e32)));
+    return(add(hoist, join(["%if", lower(cond, hoist), lower_body([_then], tail63)], _e33)));
   } else {
     var e = unique("e");
     add(hoist, ["%local", e]);
-    var _e31;
+    var _e32;
     if (_else) {
-      _e31 = [lower(["set", e, _else])];
+      _e32 = [lower(["set", e, _else])];
     }
-    add(hoist, join(["%if", lower(cond, hoist), lower(["set", e, _then])], _e31));
+    add(hoist, join(["%if", lower(cond, hoist), lower(["set", e, _then])], _e32));
     return(e);
   }
 };
@@ -879,13 +885,13 @@ var lower_short = function (x, args, hoist) {
   var b1 = lower(b, hoist1);
   if (some63(hoist1)) {
     var _id18 = unique("id");
-    var _e33;
+    var _e34;
     if (x === "and") {
-      _e33 = ["%if", _id18, b, _id18];
+      _e34 = ["%if", _id18, b, _id18];
     } else {
-      _e33 = ["%if", _id18, _id18, b];
+      _e34 = ["%if", _id18, _id18, b];
     }
-    return(lower(["do", ["%local", _id18, a], _e33], hoist));
+    return(lower(["do", ["%local", _id18, a], _e34], hoist));
   } else {
     return([x, lower(a, hoist), b1]);
   }
@@ -1039,14 +1045,14 @@ setenv("%if", {_stash: true, tr: true, special: function (cond, cons, alt) {
   var _x110 = compile(cons, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
   var _cons1 = _x110;
-  var _e34;
+  var _e35;
   if (alt) {
     indent_level = indent_level + 1;
     var _x111 = compile(alt, {_stash: true, stmt: true});
     indent_level = indent_level - 1;
-    _e34 = _x111;
+    _e35 = _x111;
   }
-  var _alt1 = _e34;
+  var _alt1 = _e35;
   var ind = indentation();
   var s = "";
   if (target === "js") {
@@ -1133,57 +1139,60 @@ setenv("%local-function", {_stash: true, tr: true, special: function (name, args
   }
 }, stmt: true});
 setenv("return", {_stash: true, special: function (x) {
-  var _e35;
+  var _e36;
   if (nil63(x)) {
-    _e35 = "return";
+    _e36 = "return";
   } else {
-    _e35 = "return(" + compile(x) + ")";
+    _e36 = "return(" + compile(x) + ")";
   }
-  var _x135 = _e35;
+  var _x135 = _e36;
   return(indentation() + _x135);
 }, stmt: true});
 setenv("new", {_stash: true, special: function (x) {
   return("new " + compile(x));
 }});
+setenv("typeof", {_stash: true, special: function (x) {
+  return("typeof(" + compile(x) + ")");
+}});
 setenv("error", {_stash: true, special: function (x) {
-  var _e36;
+  var _e37;
   if (target === "js") {
-    _e36 = "throw " + compile(["new", ["Error", x]]);
+    _e37 = "throw " + compile(["new", ["Error", x]]);
   } else {
-    _e36 = "error(" + compile(x) + ")";
+    _e37 = "error(" + compile(x) + ")";
   }
-  var e = _e36;
+  var e = _e37;
   return(indentation() + e);
 }, stmt: true});
 setenv("%local", {_stash: true, special: function (name, value) {
   var _id26 = compile(name);
   var value1 = compile(value);
-  var _e37;
-  if (is63(value)) {
-    _e37 = " = " + value1;
-  } else {
-    _e37 = "";
-  }
-  var rh = _e37;
   var _e38;
-  if (target === "js") {
-    _e38 = "var ";
+  if (is63(value)) {
+    _e38 = " = " + value1;
   } else {
-    _e38 = "local ";
+    _e38 = "";
   }
-  var keyword = _e38;
+  var rh = _e38;
+  var _e39;
+  if (target === "js") {
+    _e39 = "var ";
+  } else {
+    _e39 = "local ";
+  }
+  var keyword = _e39;
   var ind = indentation();
   return(ind + keyword + _id26 + rh);
 }, stmt: true});
 setenv("set", {_stash: true, special: function (lh, rh) {
   var _lh1 = compile(lh);
-  var _e39;
+  var _e40;
   if (nil63(rh)) {
-    _e39 = "nil";
+    _e40 = "nil";
   } else {
-    _e39 = rh;
+    _e40 = rh;
   }
-  var _rh1 = compile(_e39);
+  var _rh1 = compile(_e40);
   return(indentation() + _lh1 + " = " + _rh1);
 }, stmt: true});
 setenv("get", {_stash: true, special: function (t, k) {
@@ -1200,33 +1209,33 @@ setenv("get", {_stash: true, special: function (t, k) {
 }});
 setenv("%array", {_stash: true, special: function () {
   var forms = unstash(Array.prototype.slice.call(arguments, 0));
-  var _e40;
-  if (target === "lua") {
-    _e40 = "{";
-  } else {
-    _e40 = "[";
-  }
-  var open = _e40;
   var _e41;
   if (target === "lua") {
-    _e41 = "}";
+    _e41 = "{";
   } else {
-    _e41 = "]";
+    _e41 = "[";
   }
-  var close = _e41;
+  var open = _e41;
+  var _e42;
+  if (target === "lua") {
+    _e42 = "}";
+  } else {
+    _e42 = "]";
+  }
+  var close = _e42;
   var s = "";
   var c = "";
   var _o9 = forms;
   var k = undefined;
   for (k in _o9) {
     var v = _o9[k];
-    var _e42;
+    var _e43;
     if (numeric63(k)) {
-      _e42 = parseInt(k);
+      _e43 = parseInt(k);
     } else {
-      _e42 = k;
+      _e43 = k;
     }
-    var _k7 = _e42;
+    var _k7 = _e43;
     if (number63(_k7)) {
       s = s + c + compile(v);
       c = ", ";
@@ -1238,24 +1247,24 @@ setenv("%object", {_stash: true, special: function () {
   var forms = unstash(Array.prototype.slice.call(arguments, 0));
   var s = "{";
   var c = "";
-  var _e43;
+  var _e44;
   if (target === "lua") {
-    _e43 = " = ";
+    _e44 = " = ";
   } else {
-    _e43 = ": ";
+    _e44 = ": ";
   }
-  var sep = _e43;
+  var sep = _e44;
   var _o11 = pair(forms);
   var k = undefined;
   for (k in _o11) {
     var v = _o11[k];
-    var _e44;
+    var _e45;
     if (numeric63(k)) {
-      _e44 = parseInt(k);
+      _e45 = parseInt(k);
     } else {
-      _e44 = k;
+      _e45 = k;
     }
-    var _k9 = _e44;
+    var _k9 = _e45;
     if (number63(_k9)) {
       var _id28 = v;
       var _k10 = _id28[0];

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -511,30 +511,36 @@ local function escape_newlines(s)
   return(s1)
 end
 local function id(id)
-  local id1 = ""
+  local _e13
+  if reserved63(id) and not infix63(id) then
+    _e13 = "_"
+  else
+    _e13 = ""
+  end
+  local id1 = _e13
   local i = 0
   while i < _35(id) do
     local c = char(id, i)
     local n = code(c)
-    local _e13
+    local _e14
     if c == "-" then
-      _e13 = "_"
+      _e14 = "_"
     else
-      local _e14
+      local _e15
       if valid_code63(n) then
-        _e14 = c
+        _e15 = c
       else
-        local _e15
+        local _e16
         if i == 0 then
-          _e15 = "_" .. n
+          _e16 = "_" .. n
         else
-          _e15 = n
+          _e16 = n
         end
-        _e14 = _e15
+        _e15 = _e16
       end
-      _e13 = _e14
+      _e14 = _e15
     end
-    local c1 = _e13
+    local c1 = _e14
     id1 = id1 .. c1
     i = i + 1
   end
@@ -626,13 +632,13 @@ local function op_delims(parent, child, ...)
   local _r56 = unstash({...})
   local _id7 = _r56
   local right = _id7.right
-  local _e16
+  local _e17
   if right then
-    _e16 = _6261
+    _e17 = _6261
   else
-    _e16 = _62
+    _e17 = _62
   end
-  if _e16(precedence(child), precedence(parent)) then
+  if _e17(precedence(child), precedence(parent)) then
     return({"(", ")"})
   else
     return({"", ""})
@@ -664,33 +670,33 @@ function compile_function(args, body, ...)
   local _id12 = _r58
   local name = _id12.name
   local prefix = _id12.prefix
-  local _e17
+  local _e18
   if name then
-    _e17 = compile(name)
+    _e18 = compile(name)
   else
-    _e17 = ""
+    _e18 = ""
   end
-  local _id13 = _e17
+  local _id13 = _e18
   local _args = compile_args(args)
   indent_level = indent_level + 1
   local _x76 = compile(body, {_stash = true, stmt = true})
   indent_level = indent_level - 1
   local _body = _x76
   local ind = indentation()
-  local _e18
-  if prefix then
-    _e18 = prefix .. " "
-  else
-    _e18 = ""
-  end
-  local p = _e18
   local _e19
-  if target == "js" then
-    _e19 = ""
+  if prefix then
+    _e19 = prefix .. " "
   else
-    _e19 = "end"
+    _e19 = ""
   end
-  local tr = _e19
+  local p = _e19
+  local _e20
+  if target == "js" then
+    _e20 = ""
+  else
+    _e20 = "end"
+  end
+  local tr = _e20
   if name then
     tr = tr .. "\n"
   end
@@ -714,26 +720,26 @@ function compile(form, ...)
       return(compile_special(form, stmt))
     else
       local tr = terminator(stmt)
-      local _e20
-      if stmt then
-        _e20 = indentation()
-      else
-        _e20 = ""
-      end
-      local ind = _e20
       local _e21
-      if atom63(form) then
-        _e21 = compile_atom(form)
+      if stmt then
+        _e21 = indentation()
       else
-        local _e22
-        if infix63(hd(form)) then
-          _e22 = compile_infix(form)
-        else
-          _e22 = compile_call(form)
-        end
-        _e21 = _e22
+        _e21 = ""
       end
-      local _form = _e21
+      local ind = _e21
+      local _e22
+      if atom63(form) then
+        _e22 = compile_atom(form)
+      else
+        local _e23
+        if infix63(hd(form)) then
+          _e23 = compile_infix(form)
+        else
+          _e23 = compile_call(form)
+        end
+        _e22 = _e23
+      end
+      local _form = _e22
       return(ind .. _form .. tr)
     end
   end
@@ -801,19 +807,19 @@ local function lower_if(args, hoist, stmt63, tail63)
   local _then = _id16[2]
   local _else = _id16[3]
   if stmt63 or tail63 then
-    local _e24
+    local _e25
     if _else then
-      _e24 = {lower_body({_else}, tail63)}
+      _e25 = {lower_body({_else}, tail63)}
     end
-    return(add(hoist, join({"%if", lower(cond, hoist), lower_body({_then}, tail63)}, _e24)))
+    return(add(hoist, join({"%if", lower(cond, hoist), lower_body({_then}, tail63)}, _e25)))
   else
     local e = unique("e")
     add(hoist, {"%local", e})
-    local _e23
+    local _e24
     if _else then
-      _e23 = {lower({"set", e, _else})}
+      _e24 = {lower({"set", e, _else})}
     end
-    add(hoist, join({"%if", lower(cond, hoist), lower({"set", e, _then})}, _e23))
+    add(hoist, join({"%if", lower(cond, hoist), lower({"set", e, _then})}, _e24))
     return(e)
   end
 end
@@ -825,13 +831,13 @@ local function lower_short(x, args, hoist)
   local b1 = lower(b, hoist1)
   if some63(hoist1) then
     local _id18 = unique("id")
-    local _e25
+    local _e26
     if x == "and" then
-      _e25 = {"%if", _id18, b, _id18}
+      _e26 = {"%if", _id18, b, _id18}
     else
-      _e25 = {"%if", _id18, _id18, b}
+      _e26 = {"%if", _id18, _id18, b}
     end
-    return(lower({"do", {"%local", _id18, a}, _e25}, hoist))
+    return(lower({"do", {"%local", _id18, a}, _e26}, hoist))
   else
     return({x, lower(a, hoist), b1})
   end
@@ -992,14 +998,14 @@ setenv("%if", {_stash = true, tr = true, special = function (cond, cons, alt)
   local _x114 = compile(cons, {_stash = true, stmt = true})
   indent_level = indent_level - 1
   local _cons1 = _x114
-  local _e26
+  local _e27
   if alt then
     indent_level = indent_level + 1
     local _x115 = compile(alt, {_stash = true, stmt = true})
     indent_level = indent_level - 1
-    _e26 = _x115
+    _e27 = _x115
   end
-  local _alt1 = _e26
+  local _alt1 = _e27
   local ind = indentation()
   local s = ""
   if target == "js" then
@@ -1086,57 +1092,60 @@ setenv("%local-function", {_stash = true, tr = true, special = function (name, a
   end
 end, stmt = true})
 setenv("return", {_stash = true, special = function (x)
-  local _e27
+  local _e28
   if nil63(x) then
-    _e27 = "return"
+    _e28 = "return"
   else
-    _e27 = "return(" .. compile(x) .. ")"
+    _e28 = "return(" .. compile(x) .. ")"
   end
-  local _x139 = _e27
+  local _x139 = _e28
   return(indentation() .. _x139)
 end, stmt = true})
 setenv("new", {_stash = true, special = function (x)
   return("new " .. compile(x))
 end})
+setenv("typeof", {_stash = true, special = function (x)
+  return("typeof(" .. compile(x) .. ")")
+end})
 setenv("error", {_stash = true, special = function (x)
-  local _e28
+  local _e29
   if target == "js" then
-    _e28 = "throw " .. compile({"new", {"Error", x}})
+    _e29 = "throw " .. compile({"new", {"Error", x}})
   else
-    _e28 = "error(" .. compile(x) .. ")"
+    _e29 = "error(" .. compile(x) .. ")"
   end
-  local e = _e28
+  local e = _e29
   return(indentation() .. e)
 end, stmt = true})
 setenv("%local", {_stash = true, special = function (name, value)
   local _id26 = compile(name)
   local value1 = compile(value)
-  local _e29
-  if is63(value) then
-    _e29 = " = " .. value1
-  else
-    _e29 = ""
-  end
-  local rh = _e29
   local _e30
-  if target == "js" then
-    _e30 = "var "
+  if is63(value) then
+    _e30 = " = " .. value1
   else
-    _e30 = "local "
+    _e30 = ""
   end
-  local keyword = _e30
+  local rh = _e30
+  local _e31
+  if target == "js" then
+    _e31 = "var "
+  else
+    _e31 = "local "
+  end
+  local keyword = _e31
   local ind = indentation()
   return(ind .. keyword .. _id26 .. rh)
 end, stmt = true})
 setenv("set", {_stash = true, special = function (lh, rh)
   local _lh1 = compile(lh)
-  local _e31
+  local _e32
   if nil63(rh) then
-    _e31 = "nil"
+    _e32 = "nil"
   else
-    _e31 = rh
+    _e32 = rh
   end
-  local _rh1 = compile(_e31)
+  local _rh1 = compile(_e32)
   return(indentation() .. _lh1 .. " = " .. _rh1)
 end, stmt = true})
 setenv("get", {_stash = true, special = function (t, k)
@@ -1153,20 +1162,20 @@ setenv("get", {_stash = true, special = function (t, k)
 end})
 setenv("%array", {_stash = true, special = function (...)
   local forms = unstash({...})
-  local _e32
-  if target == "lua" then
-    _e32 = "{"
-  else
-    _e32 = "["
-  end
-  local open = _e32
   local _e33
   if target == "lua" then
-    _e33 = "}"
+    _e33 = "{"
   else
-    _e33 = "]"
+    _e33 = "["
   end
-  local close = _e33
+  local open = _e33
+  local _e34
+  if target == "lua" then
+    _e34 = "}"
+  else
+    _e34 = "]"
+  end
+  local close = _e34
   local s = ""
   local c = ""
   local _o9 = forms
@@ -1184,13 +1193,13 @@ setenv("%object", {_stash = true, special = function (...)
   local forms = unstash({...})
   local s = "{"
   local c = ""
-  local _e34
+  local _e35
   if target == "lua" then
-    _e34 = " = "
+    _e35 = " = "
   else
-    _e34 = ": "
+    _e35 = ": "
   end
-  local sep = _e34
+  local sep = _e35
   local _o11 = pair(forms)
   local k = nil
   for k in next, _o11 do

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -779,7 +779,7 @@ setenv("let", {_stash: true, macro: function (bs) {
       var val = _id13[1];
       var bs1 = cut(_id13, 2);
       var renames = [];
-      if (bound63(id) || reserved63(id) || toplevel63()) {
+      if (bound63(id) || toplevel63()) {
         var id1 = unique(id);
         renames = [id, id1];
         id = id1;

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -678,7 +678,7 @@ setenv("let", {_stash = true, macro = function (bs, ...)
       local val = _id13[2]
       local bs1 = cut(_id13, 2)
       local renames = {}
-      if bound63(id) or reserved63(id) or toplevel63() then
+      if bound63(id) or toplevel63() then
         local id1 = unique(id)
         renames = {id, id1}
         id = id1

--- a/compiler.l
+++ b/compiler.l
@@ -303,7 +303,7 @@
         (cat! s1 (if (= c "\n") "\\n" c))))))
 
 (define id (id)
-  (with id1 ""
+  (with id1 (if (and (reserved? id) (not (infix? id))) "_" "")
     (for i (# id)
       (let (c (char id i)
             n (code c)
@@ -623,6 +623,9 @@
 
 (define-special new (x)
   (cat "new " (compile x)))
+
+(define-special typeof (x)
+  (cat "typeof(" (compile x) ")"))
 
 (define-special error (x) :stmt
   (let e (if (= target 'js)

--- a/macros.l
+++ b/macros.l
@@ -55,7 +55,7 @@
     (let ((lh rh rest: bs2) bs
           (id val rest: bs1) (bind lh rh))
       (let renames ()
-        (if (or (bound? id) (reserved? id) (toplevel?))
+        (if (or (bound? id) (toplevel?))
             (let id1 (unique id)
               (set renames (list id id1))
               (set id id1))

--- a/test.l
+++ b/test.l
@@ -550,7 +550,13 @@ c"
         return 99)
     (test= 'zz end)
     (test= 'yy try)
-    (test= '99 return)))
+    (test= '99 return))
+  (define in (in) (+ in 1))
+  (test= '22 (in 21))
+  (define in (end try return) (list (+ end 1) (cat try " " return)))
+  (test= (list 22 "foo bar") (in 21 'foo 'bar))
+  (define var (var if) (+ var if))
+  (test= '22 (var 21 1)))
 
 (define-test destructuring
   (let ((a b c) '(1 2 3))


### PR DESCRIPTION
Closes #24.

![image](https://cloud.githubusercontent.com/assets/13237912/11109243/7757ae10-88a3-11e5-918a-414662677ec0.png)

To check whether this was a safe change, I wrote a script to rebuild Lumen three times on each of the three Lumen hosts. 

```sh
#!/bin/sh
for host in node lua luajit; do export LUMEN_HOST=$host; make clean; time for i in {1..3}; do echo "LUMEN_HOST=$host rebuild #$i"; time make -B; rm -f obj/test.js obj/test.lua; time make test; done; done
```

The script is a way to ensure that none of the hosts break after multiple rebuilds.  It also prints how long it takes to compile and run the tests, which is handy for catching whether any slowdowns were introduced by any given change.

This change doesn't seem to have any impact on compilation speed or runtime performance.  

The `reserved?` check was successfully removed from the `let` macro with no problems.  I had to add a new `define-special` for `typeof`, though.  This was necessary since `(typeof x)` ended up being compiled to `_typeof(x)`, which breaks.  I think it makes sense for reserved words to be special forms (most of them are).  But it was surprising that this turned out to be a necessary change, so I wanted to get a second pair of eyes on it in case it's a sign of anything strange.

The logic for adding reserved words to identifiers turned out to be very simple, but maybe not ideal:

```
(with id1 (if (and (reserved? id) (not (infix? id))) "_" "")
   ...
```

It prefixes any `reserved?` identifier with an underscore, excluding `infix?` identifiers.

The reason it works that way is because of special characters.  For example, `<` compiles to `_60`.  `(reserved? '<)` returns true.  Without the `(not (infix? id))` check, the final result would be `__60`. The extra underscore causes it to break.

To be clear, the point of the `infix?` check is simply to exclude all of these reserved words: `"=" "==" "+" "-" "%" "*" "/" "<" ">" "<=" ">="`.

(Note: `==` isn't an infix operator, so `infix?` won't exclude it.  But `==` isn't used anywhere, which is why it happens to work.)

The correct fix would be to create a new function whose behavior is identical to `valid-id?` but doesn't call `(reserved? id)`.   It could be called `valid-codes?`, since it takes a string and returns false if any character code isn't a `valid-code?`.  Then the logic could become:

```
(with id1 (if (and (reserved? id) (valid-codes? id)) "_" "")
   ...
```

But that extra complexity didn't seem worth it, since this PR seems to enable most of the reserved words.  It's better to leave that decision up to you anyway.

The PR should be ready to merge with no additional effort.  E.g. you won't need to rebuild Lumen after merging or anything like that.

Let me know what you think, or any changes you'd like to see.

(I'm curious what else is on Lumen's TODO list.  This one was pretty interesting.)
