### PR TITLE
bin/lumen: Let LUMEN_HOST contain spaces.

### DIFF
--- a/bin/lumen
+++ b/bin/lumen
@@ -5,9 +5,9 @@ cd "$(dirname "$0")"
 home="$(pwd)"
 cd "${dir}"
 
-if [ ! -z ${LUMEN_HOST} ]
+if [ ! -z "${LUMEN_HOST}" ]
 then
-    host=${LUMEN_HOST}
+    host="${LUMEN_HOST}"
 elif luajit -v > /dev/null 2>&1
 then
     host=luajit


### PR DESCRIPTION
This PR fixes `bin/lumen` to allow spaces in `LUMEN_HOST`.

(For example, Numen (https://github.com/gruseom/numen) sets `LUMEN_HOST` to `node --expose_debug_as=v8debug`.)
