### PR TITLE
reader.l: Fix (read-string "0?") to give "0?"

### DIFF
--- a/bin/reader.js
+++ b/bin/reader.js
@@ -96,6 +96,10 @@ var wrap = function (s, x) {
     return([x, y]);
   }
 };
+var digit63 = function (s, i) {
+  var c = code(s, i);
+  return(c >= 48 && c <= 57);
+};
 read_table[""] = function (s) {
   var str = "";
   while (true) {
@@ -124,11 +128,15 @@ read_table[""] = function (s) {
             if (str === "-inf") {
               return(-inf);
             } else {
-              var n = number(str);
-              if (nil63(n) || nan63(n) || inf63(n)) {
+              if (! digit63(str, edge(str))) {
                 return(str);
               } else {
-                return(n);
+                var n = number(str);
+                if (nil63(n) || nan63(n) || inf63(n)) {
+                  return(str);
+                } else {
+                  return(n);
+                }
               }
             }
           }

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -96,6 +96,10 @@ local function wrap(s, x)
     return({x, y})
   end
 end
+local function digit63(s, i)
+  local c = code(s, i)
+  return(c >= 48 and c <= 57)
+end
 read_table[""] = function (s)
   local str = ""
   while true do
@@ -124,11 +128,15 @@ read_table[""] = function (s)
             if str == "-inf" then
               return(-inf)
             else
-              local n = number(str)
-              if nil63(n) or nan63(n) or inf63(n) then
+              if not digit63(str, edge(str)) then
                 return(str)
               else
-                return(n)
+                local n = number(str)
+                if nil63(n) or nan63(n) or inf63(n) then
+                  return(str)
+                else
+                  return(n)
+                end
               end
             end
           end

--- a/reader.l
+++ b/reader.l
@@ -86,9 +86,9 @@
         (= str "-nan") nan
         (= str "inf") inf
         (= str "-inf") -inf
-      (if (not (digit? str (edge str))) str
-	(let n (number str)
-	  (if (or (nil? n) (nan? n) (inf? n)) str n))))))
+        (not (digit? str (edge str))) str
+      (let n (number str)
+        (if (or (nil? n) (nan? n) (inf? n)) str n)))))
 
 (define-reader ("(" s)
   (read-char s)

--- a/reader.l
+++ b/reader.l
@@ -68,6 +68,10 @@
     (if (= y (get s 'more)) y
       (list x y))))
 
+(define digit? (s i)
+  (let c (code s i)
+    (and (>= c 48) (<= c 57))))
+
 (define-reader ("" s) ; atom
   (let (str "")
     (while true
@@ -82,8 +86,9 @@
         (= str "-nan") nan
         (= str "inf") inf
         (= str "-inf") -inf
-      (let n (number str)
-        (if (or (nil? n) (nan? n) (inf? n)) str n)))))
+      (if (not (digit? str (edge str))) str
+	(let n (number str)
+	  (if (or (nil? n) (nan? n) (inf? n)) str n))))))
 
 (define-reader ("(" s)
   (read-char s)

--- a/test.l
+++ b/test.l
@@ -55,7 +55,10 @@
     (test= true (nan? (read "nan")))
     (test= true (nan? (read "-nan")))
     (test= true (inf? (read "inf")))
-    (test= true (inf? (read "-inf")))))
+    (test= true (inf? (read "-inf")))
+    (test= "0?" (read "0?"))
+    (test= "0!" (read "0!"))
+    (test= "0." (read "0."))))
 
 (define-test read-more
   (let read (get reader 'read-string)


### PR DESCRIPTION
On `LUMEN_HOST=node`, `"0?"` is incorrectly read as `0`.  (As is `"0!"`, etc.)  This prevents users from e.g. making a macro named `0?`

This PR modifies `reader.l` in the following way:

- When reading a string, try to convert it to a number only if it ends with a
digit (i.e. ends with "0", "1", ..., or "9").

Note that `"0."` will now be read as `"0."`  If it should be read as `0`, let me know and I'll add a case to handle this.
