### PR TITLE
Add stack traces to errors.

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -1101,14 +1101,14 @@ setenv("%try", {_stash: true, tr: true, special: function (form) {
   var e = unique("e");
   var ind = indentation();
   indent_level = indent_level + 1;
-  var _x121 = compile(form, {_stash: true, stmt: true});
+  var _x122 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var body = _x121;
-  var hf = ["return", ["%array", false, ["get", e, "\"message\""]]];
+  var body = _x122;
+  var hf = ["return", ["%array", false, ["get", e, "\"message\""], ["get", e, "\"stack\""]]];
   indent_level = indent_level + 1;
-  var _x125 = compile(hf, {_stash: true, stmt: true});
+  var _x127 = compile(hf, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var h = _x125;
+  var h = _x127;
   return(ind + "try {\n" + body + ind + "}\n" + ind + "catch (" + e + ") {\n" + h + ind + "}\n");
 }, stmt: true});
 setenv("%delete", {_stash: true, special: function (place) {
@@ -1143,8 +1143,8 @@ setenv("return", {_stash: true, special: function (x) {
   } else {
     _e35 = "return(" + compile(x) + ")";
   }
-  var _x135 = _e35;
-  return(indentation() + _x135);
+  var _x137 = _e35;
+  return(indentation() + _x137);
 }, stmt: true});
 setenv("new", {_stash: true, special: function (x) {
   return("new " + compile(x));

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -1054,14 +1054,14 @@ setenv("%try", {_stash = true, tr = true, special = function (form)
   local e = unique("e")
   local ind = indentation()
   indent_level = indent_level + 1
-  local _x125 = compile(form, {_stash = true, stmt = true})
+  local _x126 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local body = _x125
-  local hf = {"return", {"%array", false, {"get", e, "\"message\""}}}
+  local body = _x126
+  local hf = {"return", {"%array", false, {"get", e, "\"message\""}, {"get", e, "\"stack\""}}}
   indent_level = indent_level + 1
-  local _x129 = compile(hf, {_stash = true, stmt = true})
+  local _x131 = compile(hf, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local h = _x129
+  local h = _x131
   return(ind .. "try {\n" .. body .. ind .. "}\n" .. ind .. "catch (" .. e .. ") {\n" .. h .. ind .. "}\n")
 end, stmt = true})
 setenv("%delete", {_stash = true, special = function (place)
@@ -1096,8 +1096,8 @@ setenv("return", {_stash = true, special = function (x)
   else
     _e27 = "return(" .. compile(x) .. ")"
   end
-  local _x139 = _e27
-  return(indentation() .. _x139)
+  local _x141 = _e27
+  return(indentation() .. _x141)
 end, stmt = true})
 setenv("new", {_stash = true, special = function (x)
   return("new " .. compile(x))

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -925,7 +925,8 @@ setenv("guard", {_stash: true, macro: function (expr) {
     var e = unique("e");
     var x = unique("x");
     var msg = unique("msg");
-    return(["let", [x, "nil", msg, "nil", e, ["xpcall", ["fn", join(), ["set", x, expr]], ["fn", ["m"], ["set", msg, ["%message-handler", "m"]]]]], ["list", e, ["if", e, x, msg]]]);
+    var trace = unique("trace");
+    return(["let", [x, "nil", msg, "nil", trace, "nil", e, ["xpcall", ["fn", join(), ["set", x, expr]], ["fn", ["m"], ["set", trace, [["get", "debug", ["quote", "traceback"]]]], ["set", msg, ["%message-handler", "m", trace]]]]], ["list", e, ["if", e, x, msg], ["if", e, "nil", trace]]]);
   }
 }});
 setenv("each", {_stash: true, macro: function (x, t) {
@@ -1053,13 +1054,14 @@ var eval_print = function (form) {
       return([true, compiler.eval(form)]);
     }
     catch (_e) {
-      return([false, _e.message]);
+      return([false, _e.message, _e.stack]);
     }
   })();
   var ok = _id[0];
   var x = _id[1];
+  var trace = _id[2];
   if (! ok) {
-    return(print("error: " + x));
+    return(print(trace));
   } else {
     if (is63(x)) {
       return(print(string(x)));

--- a/bin/reader.js
+++ b/bin/reader.js
@@ -1,13 +1,13 @@
-var delimiters = {";": true, "\n": true, ")": true, "(": true};
-var whitespace = {"\t": true, " ": true, "\n": true};
+var delimiters = {"(": true, ")": true, "\n": true, ";": true};
+var whitespace = {" ": true, "\n": true, "\t": true};
 var stream = function (str, more) {
-  return({more: more, string: str, len: _35(str), pos: 0});
+  return({more: more, pos: 0, len: _35(str), string: str});
 };
 var peek_char = function (s) {
   var _id = s;
-  var string = _id.string;
-  var len = _id.len;
   var pos = _id.pos;
+  var len = _id.len;
+  var string = _id.string;
   if (pos < len) {
     return(char(string, pos));
   }

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -1,13 +1,13 @@
-local delimiters = {["\n"] = true, [")"] = true, [";"] = true, ["("] = true}
-local whitespace = {["\n"] = true, ["\t"] = true, [" "] = true}
+local delimiters = {["("] = true, [")"] = true, ["\n"] = true, [";"] = true}
+local whitespace = {[" "] = true, ["\n"] = true, ["\t"] = true}
 local function stream(str, more)
-  return({more = more, pos = 0, string = str, len = _35(str)})
+  return({more = more, pos = 0, len = _35(str), string = str})
 end
 local function peek_char(s)
   local _id = s
-  local string = _id.string
-  local len = _id.len
   local pos = _id.pos
+  local len = _id.len
+  local string = _id.string
   if pos < len then
     return(char(string, pos))
   end
@@ -231,4 +231,4 @@ read_table[","] = function (s)
     return(wrap(s, "unquote"))
   end
 end
-return({read = read, stream = stream, ["read-table"] = read_table, ["read-all"] = read_all, ["read-string"] = read_string})
+return({["read-string"] = read_string, ["read-all"] = read_all, read = read, ["read-table"] = read_table, stream = stream})

--- a/compiler.l
+++ b/compiler.l
@@ -592,7 +592,7 @@
   (let-unique (e)
     (let (ind (indentation)
           body (with-indent (compile form :stmt))
-          hf `(return (%array false (get ,e "message")))
+          hf `(return (%array false (get ,e "message") (get ,e "stack")))
           h (with-indent (compile hf :stmt)))
       (cat ind "try {\n" body ind "}\n"
            ind "catch (" e ") {\n" h ind "}\n"))))

--- a/macros.l
+++ b/macros.l
@@ -143,13 +143,17 @@
 (define-macro guard (expr)
   (if (= target 'js)
       `((fn () (%try (list true ,expr))))
-    (let-unique (e x msg)
+    (let-unique (e x msg trace)
       `(let (,x nil
              ,msg nil
+             ,trace nil
              ,e (xpcall
                  (fn () (set ,x ,expr))
-                 (fn (m) (set ,msg (%message-handler m)))))
-         (list ,e (if ,e ,x ,msg))))))
+                 (fn (m)
+                   (set ,trace ((get debug 'traceback)))
+                   (set ,msg (%message-handler m ,trace)))))
+         (list ,e (if ,e ,x ,msg)
+                  (if ,e nil ,trace))))))
 
 (define-macro each (x t rest: body)
   (let-unique (o n i)

--- a/main.l
+++ b/main.l
@@ -5,8 +5,9 @@
 (define system (require 'system))
 
 (define eval-print (form)
-  (let ((ok x) (guard ((get compiler 'eval) form)))
-    (if (not ok) (print (cat "error: " x))
+  (let ((ok x trace) (guard ((get compiler 'eval) form)))
+    (if (not ok) (print (target js: trace
+                                lua: (cat "error: " x "\n" trace)))
         (is? x) (print (string x)))))
 
 (define rep (s)

--- a/test.l
+++ b/test.l
@@ -72,7 +72,7 @@
       (test= more (read "`(a b ,(z" more))
       (test= more (read "`\"biz" more))
       (test= more (read "'\"boz" more)))
-    (test= (list false "Expected ) at 5") (guard (read "(open")))))
+    (test= (list false "Expected ) at 5") (cut (guard (read "(open")) 0 2))))
 
 (define-test boolean
   (test= true (or true false))
@@ -466,12 +466,13 @@ c"
       (test= 12 a))))
 
 (define-test guard
-  (test= '(true 42) (guard 42))
-  (test= '(false foo) (guard (error "foo")))
-  (test= '(false foo) (guard (do (error "foo") (error "baz"))))
-  (test= '(false baz) (guard (do (guard (error "foo")) (error "baz"))))
-  (test= '(true 42) (guard (if true 42 (error "baz"))))
-  (test= '(false baz) (guard (if false 42 (error "baz")))))
+  (let-macro ((guard2 (x) `(cut (guard ,x) 0 2)))
+    (test= '(true 42) (guard2 42))
+    (test= '(false foo) (guard2 (error "foo")))
+    (test= '(false foo) (guard2 (do (error "foo") (error "baz"))))
+    (test= '(false baz) (guard2 (do (guard2 (error "foo")) (error "baz"))))
+    (test= '(true 42) (guard2 (if true 42 (error "baz"))))
+    (test= '(false baz) (guard2 (if false 42 (error "baz"))))))
 
 (define-test let
   (let a 10


### PR DESCRIPTION
- The repl now prints a stacktrace along with error messages.

- The GUARD macro now yields (ok x trace)

Lua:

```
$ bin/lumen
> (let ((ok x trace) (guard (error "x"))) (print trace))
stack traceback:
	[string "local __x6 = nil..."]:9: in function <[string "local __x6 = nil..."]:8>
	[C]: in function 'error'
	[string "local __x6 = nil..."]:5: in function <[string "local __x6 = nil..."]:4>
	[C]: in function 'xpcall'
	[string "local __x6 = nil..."]:4: in function 'f'
	lumen/bin/compiler.lua:966: in function 'run'
	lumen/bin/compiler.lua:977: in function 'eval'
	lumen/bin/lumen.lua:941: in function <lumen/bin/lumen.lua:940>
	[C]: in function 'xpcall'
	lumen/bin/lumen.lua:940: in function 'eval_print'
	lumen/bin/lumen.lua:982: in function 'rep1'
	lumen/bin/lumen.lua:991: in function 'repl'
	lumen/bin/lumen.lua:1074: in function 'main'
	lumen/bin/lumen.lua:1088: in main chunk
	[C]: at 0x0100001240
```

Node:

```
$ LUMEN_HOST=node bin/lumen 
> (let ((ok x trace) (guard (error "x"))) (print trace))
Error: x
    at eval (eval at <anonymous> (lumen/bin/compiler.js:1024:3), <anonymous>:3:11)
    at eval (eval at <anonymous> (lumen/bin/compiler.js:1024:3), <anonymous>:9:3)
    at eval (native)
    at Object.eval (lumen/bin/compiler.js:1024:3)
    at lumen/bin/lumen.js:1054:30
    at eval_print (lumen/bin/lumen.js:1059:5)
    at ReadStream.rep1 (lumen/bin/lumen.js:1081:7)
    at ReadStream.emit (events.js:107:17)
    at readableAddChunk (_stream_readable.js:163:16)
    at ReadStream.Readable.push (_stream_readable.js:126:10)
```

Future work:

- (error "foo" x) should result in some kind of error object containing `"foo"` and `x` separately.

