### PR TITLE
makefile: Use luajit by default if available, else use lua.

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,10 @@
 .PHONY: all clean test
 
+ifeq (, $(shell which luajit))
 LUMEN_LUA  ?= lua
+else
+LUMEN_LUA  ?= luajit
+endif
 LUMEN_NODE ?= node
 LUMEN_HOST ?= $(LUMEN_LUA)
 


### PR DESCRIPTION
GNU make can detect whether a program is available on the user's PATH.  This PR modifies Lumen's makefile to use luajit by default, if present:

```make
.PHONY: all clean test

ifeq (, $(shell which luajit))
LUMEN_LUA  ?= lua
else
LUMEN_LUA  ?= luajit
endif
...
````


