### PR TITLE
makefile: Allow LUMEN_HOST to contain spaces.

### DIFF
--- a/makefile
+++ b/makefile
@@ -4,7 +4,7 @@ LUMEN_LUA  ?= lua
 LUMEN_NODE ?= node
 LUMEN_HOST ?= $(LUMEN_LUA)
 
-LUMEN := LUMEN_HOST=$(LUMEN_HOST) bin/lumen
+LUMEN := LUMEN_HOST="$(LUMEN_HOST)" bin/lumen
 
 OBJS :=	obj/runtime.o	\
 	obj/macros.o	\


### PR DESCRIPTION
This PR fixes `makefile` to allow spaces within `LUMEN_HOST`.

I discovered the recent `getenv` optimization by running LuaJIT 2.1's new profiler:

```
$ LUMEN_HOST="luajit -jp=s2" make -B
```

But in order to run that command, this PR was necessary.

I figured I should contribute the fix upstream before I forget about it.

