### PR TITLE
Fixes and simplifications.

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -406,7 +406,7 @@ indentation = function () {
   }
   return(s);
 };
-var reserved = {">": true, "not": true, "<": true, "default": true, "then": true, "delete": true, "true": true, "debugger": true, "for": true, "throw": true, "until": true, "*": true, "do": true, "else": true, "var": true, "new": true, "this": true, "/": true, "=": true, "finally": true, "elseif": true, "or": true, "repeat": true, "switch": true, "<=": true, "while": true, "local": true, "false": true, "function": true, "==": true, "if": true, "and": true, ">=": true, "typeof": true, "%": true, "catch": true, "nil": true, "instanceof": true, "in": true, "void": true, "try": true, "with": true, "return": true, "continue": true, "case": true, "end": true, "-": true, "break": true, "+": true};
+var reserved = {"else": true, "<": true, "true": true, "/": true, "end": true, "typeof": true, "function": true, "switch": true, "=": true, "or": true, "try": true, "catch": true, "until": true, "local": true, "repeat": true, "-": true, "false": true, "continue": true, "==": true, "and": true, "if": true, "for": true, ">=": true, "<=": true, "with": true, "return": true, "finally": true, "nil": true, "new": true, "do": true, "case": true, "break": true, "elseif": true, "+": true, "not": true, "void": true, "var": true, "%": true, "in": true, "delete": true, "throw": true, "debugger": true, "instanceof": true, "this": true, "while": true, "then": true, "default": true, "*": true, ">": true};
 reserved63 = function (x) {
   return(reserved[x]);
 };
@@ -462,8 +462,8 @@ mapo = function (f, t) {
 };
 var __x57 = [];
 var _x58 = [];
-_x58.js = "!";
 _x58.lua = "not";
+_x58.js = "!";
 __x57["not"] = _x58;
 var __x59 = [];
 __x59["/"] = true;
@@ -474,28 +474,28 @@ __x60["+"] = true;
 __x60["-"] = true;
 var __x61 = [];
 var _x62 = [];
-_x62.js = "+";
 _x62.lua = "..";
+_x62.js = "+";
 __x61.cat = _x62;
 var __x63 = [];
-__x63[">="] = true;
-__x63[">"] = true;
 __x63["<="] = true;
+__x63[">="] = true;
 __x63["<"] = true;
+__x63[">"] = true;
 var __x64 = [];
 var _x65 = [];
-_x65.js = "===";
 _x65.lua = "==";
+_x65.js = "===";
 __x64["="] = _x65;
 var __x66 = [];
 var _x67 = [];
-_x67.js = "&&";
 _x67.lua = "and";
+_x67.js = "&&";
 __x66["and"] = _x67;
 var __x68 = [];
 var _x69 = [];
-_x69.js = "||";
 _x69.lua = "or";
+_x69.js = "||";
 __x68["or"] = _x69;
 var infix = [__x57, __x59, __x60, __x61, __x63, __x64, __x66, __x68];
 var unary63 = function (form) {
@@ -667,8 +667,8 @@ var compile_special = function (form, stmt63) {
   var args = cut(_id5, 1);
   var _id6 = getenv(x);
   var self_tr63 = _id6.tr;
-  var special = _id6.special;
   var stmt = _id6.stmt;
+  var special = _id6.special;
   var tr = terminator(stmt63 && ! self_tr63);
   return(apply(special, args) + tr);
 };
@@ -944,8 +944,8 @@ var lower_infix = function (form, hoist) {
   var x = _id23[0];
   var args = cut(_id23, 1);
   return(lower(reduce(function (a, b) {
-    return([x, b, a]);
-  }, reverse(args)), hoist));
+    return([x, a, b]);
+  }, args), hoist));
 };
 var lower_special = function (form, hoist) {
   var e = lower_call(form, hoist);
@@ -1029,7 +1029,7 @@ eval = function (form) {
   run(code);
   return(_37result);
 };
-setenv("do", {_stash: true, stmt: true, special: function () {
+setenv("do", {_stash: true, tr: true, special: function () {
   var forms = unstash(Array.prototype.slice.call(arguments, 0));
   var s = "";
   var _x107 = forms;
@@ -1041,8 +1041,8 @@ setenv("do", {_stash: true, stmt: true, special: function () {
     _i12 = _i12 + 1;
   }
   return(s);
-}, tr: true});
-setenv("%if", {_stash: true, stmt: true, special: function (cond, cons, alt) {
+}, stmt: true});
+setenv("%if", {_stash: true, tr: true, special: function (cond, cons, alt) {
   var _cond1 = compile(cond);
   indent_level = indent_level + 1;
   var _x110 = compile(cons, {_stash: true, stmt: true});
@@ -1075,8 +1075,8 @@ setenv("%if", {_stash: true, stmt: true, special: function (cond, cons, alt) {
   } else {
     return(s + "\n");
   }
-}, tr: true});
-setenv("while", {_stash: true, stmt: true, special: function (cond, form) {
+}, stmt: true});
+setenv("while", {_stash: true, tr: true, special: function (cond, form) {
   var _cond3 = compile(cond);
   indent_level = indent_level + 1;
   var _x113 = compile(form, {_stash: true, stmt: true});
@@ -1088,8 +1088,8 @@ setenv("while", {_stash: true, stmt: true, special: function (cond, form) {
   } else {
     return(ind + "while " + _cond3 + " do\n" + body + ind + "end\n");
   }
-}, tr: true});
-setenv("%for", {_stash: true, stmt: true, special: function (t, k, form) {
+}, stmt: true});
+setenv("%for", {_stash: true, tr: true, special: function (t, k, form) {
   var _t1 = compile(t);
   var ind = indentation();
   indent_level = indent_level + 1;
@@ -1101,8 +1101,8 @@ setenv("%for", {_stash: true, stmt: true, special: function (t, k, form) {
   } else {
     return(ind + "for (" + k + " in " + _t1 + ") {\n" + body + ind + "}\n");
   }
-}, tr: true});
-setenv("%try", {_stash: true, stmt: true, special: function (form) {
+}, stmt: true});
+setenv("%try", {_stash: true, tr: true, special: function (form) {
   var e = unique("e");
   var ind = indentation();
   indent_level = indent_level + 1;
@@ -1115,7 +1115,7 @@ setenv("%try", {_stash: true, stmt: true, special: function (form) {
   indent_level = indent_level - 1;
   var h = _x127;
   return(ind + "try {\n" + body + ind + "}\n" + ind + "catch (" + e + ") {\n" + h + ind + "}\n");
-}, tr: true});
+}, stmt: true});
 setenv("%delete", {_stash: true, special: function (place) {
   return(indentation() + "delete " + compile(place));
 }, stmt: true});
@@ -1125,22 +1125,22 @@ setenv("break", {_stash: true, special: function () {
 setenv("%function", {_stash: true, special: function (args, body) {
   return(compile_function(args, body));
 }});
-setenv("%global-function", {_stash: true, stmt: true, special: function (name, args, body) {
+setenv("%global-function", {_stash: true, tr: true, special: function (name, args, body) {
   if (target === "lua") {
     var x = compile_function(args, body, {_stash: true, name: name});
     return(indentation() + x);
   } else {
     return(compile(["set", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}, tr: true});
-setenv("%local-function", {_stash: true, stmt: true, special: function (name, args, body) {
+}, stmt: true});
+setenv("%local-function", {_stash: true, tr: true, special: function (name, args, body) {
   if (target === "lua") {
     var x = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
     return(indentation() + x);
   } else {
     return(compile(["%local", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}, tr: true});
+}, stmt: true});
 setenv("return", {_stash: true, special: function (x) {
   var _e36;
   if (nil63(x)) {

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -364,7 +364,7 @@ function indentation()
   end
   return(s)
 end
-local reserved = {["new"] = true, ["in"] = true, ["false"] = true, ["typeof"] = true, ["*"] = true, ["or"] = true, ["if"] = true, ["do"] = true, ["function"] = true, ["="] = true, ["while"] = true, ["elseif"] = true, ["=="] = true, ["then"] = true, ["/"] = true, ["debugger"] = true, ["true"] = true, ["until"] = true, ["nil"] = true, ["and"] = true, ["switch"] = true, ["instanceof"] = true, ["var"] = true, ["default"] = true, ["end"] = true, ["return"] = true, ["repeat"] = true, ["-"] = true, ["this"] = true, ["try"] = true, ["else"] = true, ["with"] = true, ["+"] = true, [">"] = true, ["void"] = true, ["for"] = true, ["catch"] = true, ["break"] = true, [">="] = true, ["throw"] = true, ["%"] = true, ["case"] = true, ["<"] = true, ["<="] = true, ["finally"] = true, ["continue"] = true, ["not"] = true, ["local"] = true, ["delete"] = true}
+local reserved = {["else"] = true, ["<"] = true, ["true"] = true, ["/"] = true, ["end"] = true, ["typeof"] = true, ["function"] = true, ["switch"] = true, ["="] = true, ["or"] = true, ["try"] = true, ["catch"] = true, ["until"] = true, ["local"] = true, ["repeat"] = true, ["-"] = true, ["false"] = true, ["continue"] = true, ["=="] = true, ["and"] = true, ["if"] = true, ["for"] = true, [">="] = true, ["<="] = true, ["with"] = true, ["return"] = true, ["finally"] = true, ["nil"] = true, ["new"] = true, ["do"] = true, ["case"] = true, ["break"] = true, ["elseif"] = true, ["+"] = true, ["not"] = true, ["void"] = true, ["var"] = true, ["%"] = true, ["in"] = true, ["delete"] = true, ["throw"] = true, ["debugger"] = true, ["instanceof"] = true, ["this"] = true, ["while"] = true, ["then"] = true, ["default"] = true, ["*"] = true, [">"] = true}
 function reserved63(x)
   return(reserved[x])
 end
@@ -417,12 +417,12 @@ _x58.lua = "not"
 _x58.js = "!"
 __x57["not"] = _x58
 local __x59 = {}
-__x59["%"] = true
 __x59["/"] = true
 __x59["*"] = true
+__x59["%"] = true
 local __x60 = {}
-__x60["-"] = true
 __x60["+"] = true
+__x60["-"] = true
 local __x61 = {}
 local _x62 = {}
 _x62.lua = ".."
@@ -430,8 +430,8 @@ _x62.js = "+"
 __x61.cat = _x62
 local __x63 = {}
 __x63["<="] = true
-__x63["<"] = true
 __x63[">="] = true
+__x63["<"] = true
 __x63[">"] = true
 local __x64 = {}
 local _x65 = {}
@@ -612,9 +612,9 @@ local function compile_special(form, stmt63)
   local x = _id5[1]
   local args = cut(_id5, 1)
   local _id6 = getenv(x)
+  local self_tr63 = _id6.tr
   local stmt = _id6.stmt
   local special = _id6.special
-  local self_tr63 = _id6.tr
   local tr = terminator(stmt63 and not self_tr63)
   return(apply(special, args) .. tr)
 end
@@ -890,8 +890,8 @@ local function lower_infix(form, hoist)
   local x = _id23[1]
   local args = cut(_id23, 1)
   return(lower(reduce(function (a, b)
-    return({x, b, a})
-  end, reverse(args)), hoist))
+    return({x, a, b})
+  end, args), hoist))
 end
 local function lower_special(form, hoist)
   local e = lower_call(form, hoist)
@@ -1220,4 +1220,4 @@ setenv("%object", {_stash = true, special = function (...)
   end
   return(s .. "}")
 end})
-return({expand = expand, compile = compile, run = run, eval = eval})
+return({run = run, expand = expand, compile = compile, eval = eval})

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -1,5 +1,38 @@
 environment = [{}];
 target = "js";
+toplevel63 = function () {
+  return(one63(environment));
+};
+setenv = function (k) {
+  var _r1 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _id = _r1;
+  var keys = cut(_id, 0);
+  if (string63(k)) {
+    var _e;
+    if (keys.toplevel) {
+      _e = hd(environment);
+    } else {
+      _e = last(environment);
+    }
+    var frame = _e;
+    var entry = frame[k] || {};
+    var _o = keys;
+    var _k = undefined;
+    for (_k in _o) {
+      var v = _o[_k];
+      var _e1;
+      if (numeric63(_k)) {
+        _e1 = parseInt(_k);
+      } else {
+        _e1 = _k;
+      }
+      var _k1 = _e1;
+      entry[_k1] = v;
+    }
+    frame[k] = entry;
+    return(frame[k]);
+  }
+};
 nil63 = function (x) {
   return(x === undefined || x === null);
 };
@@ -56,61 +89,146 @@ clip = function (s, from, upto) {
 cut = function (x, from, upto) {
   var l = [];
   var j = 0;
-  var _e;
+  var _e2;
   if (nil63(from) || from < 0) {
-    _e = 0;
+    _e2 = 0;
   } else {
-    _e = from;
+    _e2 = from;
   }
-  var i = _e;
+  var i = _e2;
   var n = _35(x);
-  var _e1;
+  var _e3;
   if (nil63(upto) || upto > n) {
-    _e1 = n;
+    _e3 = n;
   } else {
-    _e1 = upto;
+    _e3 = upto;
   }
-  var _upto = _e1;
+  var _upto = _e3;
   while (i < _upto) {
     l[j] = x[i];
     i = i + 1;
     j = j + 1;
   }
-  var _o = x;
-  var k = undefined;
-  for (k in _o) {
-    var v = _o[k];
-    var _e2;
-    if (numeric63(k)) {
-      _e2 = parseInt(k);
-    } else {
-      _e2 = k;
-    }
-    var _k = _e2;
-    if (! number63(_k)) {
-      l[_k] = v;
-    }
-  }
-  return(l);
-};
-keys = function (x) {
-  var t = [];
   var _o1 = x;
   var k = undefined;
   for (k in _o1) {
     var v = _o1[k];
-    var _e3;
+    var _e4;
     if (numeric63(k)) {
-      _e3 = parseInt(k);
+      _e4 = parseInt(k);
     } else {
-      _e3 = k;
+      _e4 = k;
     }
-    var _k1 = _e3;
-    if (! number63(_k1)) {
-      t[_k1] = v;
+    var _k2 = _e4;
+    if (! number63(_k2)) {
+      l[_k2] = v;
+    }
+  }
+  return(l);
+};
+empty63 = function (t) {
+  var _o2 = t;
+  var _i2 = undefined;
+  for (_i2 in _o2) {
+    var x = _o2[_i2];
+    var _e5;
+    if (numeric63(_i2)) {
+      _e5 = parseInt(_i2);
+    } else {
+      _e5 = _i2;
+    }
+    var __i2 = _e5;
+    return(false);
+  }
+  return(true);
+};
+keys63 = function (t) {
+  var _o3 = t;
+  var k = undefined;
+  for (k in _o3) {
+    var v = _o3[k];
+    var _e6;
+    if (numeric63(k)) {
+      _e6 = parseInt(k);
+    } else {
+      _e6 = k;
+    }
+    var _k3 = _e6;
+    if (! number63(_k3)) {
+      return(true);
+    }
+  }
+  return(false);
+};
+keys = function (x) {
+  var t = [];
+  var _o4 = x;
+  var k = undefined;
+  for (k in _o4) {
+    var v = _o4[k];
+    var _e7;
+    if (numeric63(k)) {
+      _e7 = parseInt(k);
+    } else {
+      _e7 = k;
+    }
+    var _k4 = _e7;
+    if (! number63(_k4)) {
+      t[_k4] = v;
     }
   }
   return(t);
+};
+stash = function (args) {
+  if (keys63(args)) {
+    var p = [];
+    var _o5 = args;
+    var k = undefined;
+    for (k in _o5) {
+      var v = _o5[k];
+      var _e8;
+      if (numeric63(k)) {
+        _e8 = parseInt(k);
+      } else {
+        _e8 = k;
+      }
+      var _k5 = _e8;
+      if (! number63(_k5)) {
+        p[_k5] = v;
+      }
+    }
+    p._stash = true;
+    add(args, p);
+  }
+  return(args);
+};
+unstash = function (args) {
+  if (none63(args)) {
+    return([]);
+  } else {
+    var l = last(args);
+    if (! atom63(l) && l._stash) {
+      var args1 = almost(args);
+      var _o6 = l;
+      var k = undefined;
+      for (k in _o6) {
+        var v = _o6[k];
+        var _e9;
+        if (numeric63(k)) {
+          _e9 = parseInt(k);
+        } else {
+          _e9 = k;
+        }
+        var _k6 = _e9;
+        if (!( _k6 === "_stash")) {
+          args1[_k6] = v;
+        }
+      }
+      return(args1);
+    } else {
+      return(args);
+    }
+  }
 };
 edge = function (x) {
   return(_35(x) - 1);
@@ -132,6 +250,26 @@ string_literal63 = function (x) {
 };
 id_literal63 = function (x) {
   return(string63(x) && char(x, 0) === "|");
+};
+number = function (s) {
+  var n = parseFloat(s);
+  if (! isNaN(n)) {
+    return(n);
+  }
+};
+number_code63 = function (n) {
+  return(n > 47 && n < 58);
+};
+numeric63 = function (s) {
+  var n = _35(s);
+  var i = 0;
+  while (i < n) {
+    if (! number_code63(code(s, i))) {
+      return(false);
+    }
+    i = i + 1;
+  }
+  return(true);
 };
 add = function (l, x) {
   l.push(x);
@@ -155,54 +293,66 @@ reverse = function (l) {
   }
   return(l1);
 };
-reduce = function (f, x) {
+reduce = function (f, x, y) {
   if (none63(x)) {
-    return(x);
-  } else {
-    if (one63(x)) {
-      return(hd(x));
+    if (is63(y)) {
+      return(y);
     } else {
-      return(f(hd(x), reduce(f, tl(x))));
+      return(x);
     }
+  } else {
+    var a = hd(x);
+    var _x1 = tl(x);
+    var _n7 = _35(_x1);
+    var _i7 = 0;
+    while (_i7 < _n7) {
+      var b = _x1[_i7];
+      a = f(a, b);
+      _i7 = _i7 + 1;
+    }
+    return(a);
   }
 };
+setenv("reducing", {_stash: true, macro: function (f, x, y) {
+  return(["reduce", ["fn", ["a", "b"], [f, "a", "b"]], x, y]);
+}});
 join = function () {
   var ls = unstash(Array.prototype.slice.call(arguments, 0));
   if (two63(ls)) {
-    var _id = ls;
-    var a = _id[0];
-    var b = _id[1];
+    var _id1 = ls;
+    var a = _id1[0];
+    var b = _id1[1];
     if (a && b) {
       var c = [];
       var o = _35(a);
-      var _o2 = a;
+      var _o7 = a;
       var k = undefined;
-      for (k in _o2) {
-        var v = _o2[k];
-        var _e4;
+      for (k in _o7) {
+        var v = _o7[k];
+        var _e10;
         if (numeric63(k)) {
-          _e4 = parseInt(k);
+          _e10 = parseInt(k);
         } else {
-          _e4 = k;
+          _e10 = k;
         }
-        var _k2 = _e4;
-        c[_k2] = v;
+        var _k7 = _e10;
+        c[_k7] = v;
       }
-      var _o3 = b;
+      var _o8 = b;
       var k = undefined;
-      for (k in _o3) {
-        var v = _o3[k];
-        var _e5;
+      for (k in _o8) {
+        var v = _o8[k];
+        var _e11;
         if (numeric63(k)) {
-          _e5 = parseInt(k);
+          _e11 = parseInt(k);
         } else {
-          _e5 = k;
+          _e11 = k;
         }
-        var _k3 = _e5;
-        if (number63(_k3)) {
-          _k3 = _k3 + o;
+        var _k8 = _e11;
+        if (number63(_k8)) {
+          _k8 = _k8 + o;
         }
-        c[_k3] = v;
+        c[_k8] = v;
       }
       return(c);
     } else {
@@ -213,17 +363,17 @@ join = function () {
   }
 };
 find = function (f, t) {
-  var _o4 = t;
-  var _i4 = undefined;
-  for (_i4 in _o4) {
-    var x = _o4[_i4];
-    var _e6;
-    if (numeric63(_i4)) {
-      _e6 = parseInt(_i4);
+  var _o9 = t;
+  var _i10 = undefined;
+  for (_i10 in _o9) {
+    var x = _o9[_i10];
+    var _e12;
+    if (numeric63(_i10)) {
+      _e12 = parseInt(_i10);
     } else {
-      _e6 = _i4;
+      _e12 = _i10;
     }
-    var __i4 = _e6;
+    var __i10 = _e12;
     var y = f(x);
     if (y) {
       return(y);
@@ -231,16 +381,16 @@ find = function (f, t) {
   }
 };
 first = function (f, l) {
-  var _x1 = l;
-  var _n5 = _35(_x1);
-  var _i5 = 0;
-  while (_i5 < _n5) {
-    var x = _x1[_i5];
+  var _x10 = l;
+  var _n11 = _35(_x10);
+  var _i11 = 0;
+  while (_i11 < _n11) {
+    var x = _x10[_i11];
     var y = f(x);
     if (y) {
       return(y);
     }
-    _i5 = _i5 + 1;
+    _i11 = _i11 + 1;
   }
 };
 in63 = function (x, t) {
@@ -259,9 +409,9 @@ pair = function (l) {
   return(l1);
 };
 sort = function (l, f) {
-  var _e7;
+  var _e13;
   if (f) {
-    _e7 = function (a, b) {
+    _e13 = function (a, b) {
       if (f(a, b)) {
         return(-1);
       } else {
@@ -269,36 +419,27 @@ sort = function (l, f) {
       }
     };
   }
-  return(l.sort(_e7));
+  return(l.sort(_e13));
 };
 map = function (f, x) {
   var t = [];
-  var _x3 = x;
-  var _n6 = _35(_x3);
-  var _i6 = 0;
-  while (_i6 < _n6) {
-    var v = _x3[_i6];
+  var _o10 = x;
+  var k = undefined;
+  for (k in _o10) {
+    var v = _o10[k];
+    var _e14;
+    if (numeric63(k)) {
+      _e14 = parseInt(k);
+    } else {
+      _e14 = k;
+    }
+    var _k9 = _e14;
     var y = f(v);
     if (is63(y)) {
-      add(t, y);
-    }
-    _i6 = _i6 + 1;
-  }
-  var _o5 = x;
-  var k = undefined;
-  for (k in _o5) {
-    var v = _o5[k];
-    var _e8;
-    if (numeric63(k)) {
-      _e8 = parseInt(k);
-    } else {
-      _e8 = k;
-    }
-    var _k4 = _e8;
-    if (! number63(_k4)) {
-      var y = f(v);
-      if (is63(y)) {
-        t[_k4] = y;
+      if (number63(_k9)) {
+        add(t, y);
+      } else {
+        t[_k9] = y;
       }
     }
   }
@@ -310,91 +451,6 @@ keep = function (f, x) {
       return(v);
     }
   }, x));
-};
-keys63 = function (t) {
-  var _o6 = t;
-  var k = undefined;
-  for (k in _o6) {
-    var v = _o6[k];
-    var _e9;
-    if (numeric63(k)) {
-      _e9 = parseInt(k);
-    } else {
-      _e9 = k;
-    }
-    var _k5 = _e9;
-    if (! number63(_k5)) {
-      return(true);
-    }
-  }
-  return(false);
-};
-empty63 = function (t) {
-  var _o7 = t;
-  var _i9 = undefined;
-  for (_i9 in _o7) {
-    var x = _o7[_i9];
-    var _e10;
-    if (numeric63(_i9)) {
-      _e10 = parseInt(_i9);
-    } else {
-      _e10 = _i9;
-    }
-    var __i9 = _e10;
-    return(false);
-  }
-  return(true);
-};
-stash = function (args) {
-  if (keys63(args)) {
-    var p = [];
-    var _o8 = args;
-    var k = undefined;
-    for (k in _o8) {
-      var v = _o8[k];
-      var _e11;
-      if (numeric63(k)) {
-        _e11 = parseInt(k);
-      } else {
-        _e11 = k;
-      }
-      var _k6 = _e11;
-      if (! number63(_k6)) {
-        p[_k6] = v;
-      }
-    }
-    p._stash = true;
-    add(args, p);
-  }
-  return(args);
-};
-unstash = function (args) {
-  if (none63(args)) {
-    return([]);
-  } else {
-    var l = last(args);
-    if (! atom63(l) && l._stash) {
-      var args1 = almost(args);
-      var _o9 = l;
-      var k = undefined;
-      for (k in _o9) {
-        var v = _o9[k];
-        var _e12;
-        if (numeric63(k)) {
-          _e12 = parseInt(k);
-        } else {
-          _e12 = k;
-        }
-        var _k7 = _e12;
-        if (!( _k7 === "_stash")) {
-          args1[_k7] = v;
-        }
-      }
-      return(args1);
-    } else {
-      return(args);
-    }
-  }
 };
 search = function (s, pattern, start) {
   var i = s.indexOf(pattern, start);
@@ -423,43 +479,39 @@ split = function (s, sep) {
 };
 cat = function () {
   var xs = unstash(Array.prototype.slice.call(arguments, 0));
-  if (none63(xs)) {
-    return("");
-  } else {
-    return(reduce(function (a, b) {
-      return(a + b);
-    }, xs));
-  }
+  return(reduce(function (a, b) {
+    return(a + b);
+  }, xs, ""));
 };
 _43 = function () {
   var xs = unstash(Array.prototype.slice.call(arguments, 0));
   return(reduce(function (a, b) {
     return(a + b);
-  }, xs));
+  }, xs, 0));
 };
 _ = function () {
   var xs = unstash(Array.prototype.slice.call(arguments, 0));
-  return(reduce(function (b, a) {
+  return(reduce(function (a, b) {
     return(a - b);
-  }, reverse(xs)));
+  }, xs, 0));
 };
 _42 = function () {
   var xs = unstash(Array.prototype.slice.call(arguments, 0));
   return(reduce(function (a, b) {
     return(a * b);
-  }, xs));
+  }, xs, 1));
 };
 _47 = function () {
   var xs = unstash(Array.prototype.slice.call(arguments, 0));
-  return(reduce(function (b, a) {
+  return(reduce(function (a, b) {
     return(a / b);
-  }, reverse(xs)));
+  }, xs, 1));
 };
 _37 = function () {
   var xs = unstash(Array.prototype.slice.call(arguments, 0));
-  return(reduce(function (b, a) {
+  return(reduce(function (a, b) {
     return(a % b);
-  }, reverse(xs)));
+  }, xs, 1));
 };
 _62 = function (a, b) {
   return(a > b);
@@ -476,26 +528,6 @@ _6261 = function (a, b) {
 _6061 = function (a, b) {
   return(a <= b);
 };
-number = function (s) {
-  var n = parseFloat(s);
-  if (! isNaN(n)) {
-    return(n);
-  }
-};
-number_code63 = function (n) {
-  return(n > 47 && n < 58);
-};
-numeric63 = function (s) {
-  var n = _35(s);
-  var i = 0;
-  while (i < n) {
-    if (! number_code63(code(s, i))) {
-      return(false);
-    }
-    i = i + 1;
-  }
-  return(true);
-};
 var tostring = function (x) {
   return(x.toString());
 };
@@ -504,25 +536,25 @@ escape = function (s) {
   var i = 0;
   while (i < _35(s)) {
     var c = char(s, i);
-    var _e13;
+    var _e15;
     if (c === "\n") {
-      _e13 = "\\n";
+      _e15 = "\\n";
     } else {
-      var _e14;
+      var _e16;
       if (c === "\"") {
-        _e14 = "\\\"";
+        _e16 = "\\\"";
       } else {
-        var _e15;
+        var _e17;
         if (c === "\\") {
-          _e15 = "\\\\";
+          _e17 = "\\\\";
         } else {
-          _e15 = c;
+          _e17 = c;
         }
-        _e14 = _e15;
+        _e16 = _e17;
       }
-      _e13 = _e14;
+      _e15 = _e16;
     }
-    var c1 = _e13;
+    var c1 = _e15;
     s1 = s1 + c1;
     i = i + 1;
   }
@@ -565,35 +597,35 @@ str = function (x, depth) {
                     var xs = [];
                     var ks = [];
                     var d = (depth || 0) + 1;
-                    var _o10 = x;
+                    var _o11 = x;
                     var k = undefined;
-                    for (k in _o10) {
-                      var v = _o10[k];
-                      var _e16;
+                    for (k in _o11) {
+                      var v = _o11[k];
+                      var _e18;
                       if (numeric63(k)) {
-                        _e16 = parseInt(k);
+                        _e18 = parseInt(k);
                       } else {
-                        _e16 = k;
+                        _e18 = k;
                       }
-                      var _k8 = _e16;
-                      if (number63(_k8)) {
-                        xs[_k8] = str(v, d);
+                      var _k10 = _e18;
+                      if (number63(_k10)) {
+                        xs[_k10] = str(v, d);
                       } else {
-                        add(ks, _k8 + ":");
+                        add(ks, _k10 + ":");
                         add(ks, str(v, d));
                       }
                     }
-                    var _o11 = join(xs, ks);
-                    var _i13 = undefined;
-                    for (_i13 in _o11) {
-                      var v = _o11[_i13];
-                      var _e17;
-                      if (numeric63(_i13)) {
-                        _e17 = parseInt(_i13);
+                    var _o12 = join(xs, ks);
+                    var _i14 = undefined;
+                    for (_i14 in _o12) {
+                      var v = _o12[_i14];
+                      var _e19;
+                      if (numeric63(_i14)) {
+                        _e19 = parseInt(_i14);
                       } else {
-                        _e17 = _i13;
+                        _e19 = _i14;
                       }
-                      var __i13 = _e17;
+                      var __i14 = _e19;
                       s = s + sp + v;
                       sp = " ";
                     }
@@ -614,39 +646,6 @@ apply = function (f, args) {
 };
 call = function (f) {
   return(f());
-};
-toplevel63 = function () {
-  return(one63(environment));
-};
-setenv = function (k) {
-  var _r68 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _id1 = _r68;
-  var _keys = cut(_id1, 0);
-  if (string63(k)) {
-    var _e18;
-    if (_keys.toplevel) {
-      _e18 = hd(environment);
-    } else {
-      _e18 = last(environment);
-    }
-    var frame = _e18;
-    var entry = frame[k] || {};
-    var _o12 = _keys;
-    var _k9 = undefined;
-    for (_k9 in _o12) {
-      var v = _o12[_k9];
-      var _e19;
-      if (numeric63(_k9)) {
-        _e19 = parseInt(_k9);
-      } else {
-        _e19 = _k9;
-      }
-      var _k10 = _e19;
-      entry[_k10] = v;
-    }
-    frame[k] = entry;
-    return(frame[k]);
-  }
 };
 print = function (x) {
   return(console.log(x));

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -1,5 +1,31 @@
 environment = {{}}
 target = "lua"
+function toplevel63()
+  return(one63(environment))
+end
+function setenv(k, ...)
+  local _r1 = unstash({...})
+  local _id = _r1
+  local keys = cut(_id, 0)
+  if string63(k) then
+    local _e
+    if keys.toplevel then
+      _e = hd(environment)
+    else
+      _e = last(environment)
+    end
+    local frame = _e
+    local entry = frame[k] or {}
+    local _o = keys
+    local _k = nil
+    for _k in next, _o do
+      local v = _o[_k]
+      entry[_k] = v
+    end
+    frame[k] = entry
+    return(frame[k])
+  end
+end
 function nil63(x)
   return(x == nil)
 end
@@ -53,47 +79,104 @@ end
 function cut(x, from, upto)
   local l = {}
   local j = 0
-  local _e
-  if nil63(from) or from < 0 then
-    _e = 0
-  else
-    _e = from
-  end
-  local i = _e
-  local n = _35(x)
   local _e1
-  if nil63(upto) or upto > n then
-    _e1 = n
+  if nil63(from) or from < 0 then
+    _e1 = 0
   else
-    _e1 = upto
+    _e1 = from
   end
-  local _upto = _e1
+  local i = _e1
+  local n = _35(x)
+  local _e2
+  if nil63(upto) or upto > n then
+    _e2 = n
+  else
+    _e2 = upto
+  end
+  local _upto = _e2
   while i < _upto do
     l[j + 1] = x[i + 1]
     i = i + 1
     j = j + 1
   end
-  local _o = x
+  local _o1 = x
   local k = nil
-  for k in next, _o do
-    local v = _o[k]
+  for k in next, _o1 do
+    local v = _o1[k]
     if not number63(k) then
       l[k] = v
     end
   end
   return(l)
 end
+function empty63(t)
+  local _o2 = t
+  local _i2 = nil
+  for _i2 in next, _o2 do
+    local x = _o2[_i2]
+    return(false)
+  end
+  return(true)
+end
+function keys63(t)
+  local _o3 = t
+  local k = nil
+  for k in next, _o3 do
+    local v = _o3[k]
+    if not number63(k) then
+      return(true)
+    end
+  end
+  return(false)
+end
 function keys(x)
   local t = {}
-  local _o1 = x
+  local _o4 = x
   local k = nil
-  for k in next, _o1 do
-    local v = _o1[k]
+  for k in next, _o4 do
+    local v = _o4[k]
     if not number63(k) then
       t[k] = v
     end
   end
   return(t)
+end
+function stash(args)
+  if keys63(args) then
+    local p = {}
+    local _o5 = args
+    local k = nil
+    for k in next, _o5 do
+      local v = _o5[k]
+      if not number63(k) then
+        p[k] = v
+      end
+    end
+    p._stash = true
+    add(args, p)
+  end
+  return(args)
+end
+function unstash(args)
+  if none63(args) then
+    return({})
+  else
+    local l = last(args)
+    if not atom63(l) and l._stash then
+      local args1 = almost(args)
+      local _o6 = l
+      local k = nil
+      for k in next, _o6 do
+        local v = _o6[k]
+        if not( k == "_stash") then
+          args1[k] = v
+        end
+      end
+      return(args1)
+    else
+      return(args)
+    end
+  end
 end
 function edge(x)
   return(_35(x) - 1)
@@ -108,17 +191,34 @@ function char(s, n)
   return(clip(s, n, n + 1))
 end
 function code(s, n)
-  local _e2
+  local _e3
   if n then
-    _e2 = n + 1
+    _e3 = n + 1
   end
-  return(string.byte(s, _e2))
+  return(string.byte(s, _e3))
 end
 function string_literal63(x)
   return(string63(x) and char(x, 0) == "\"")
 end
 function id_literal63(x)
   return(string63(x) and char(x, 0) == "|")
+end
+function number(s)
+  return(tonumber(s))
+end
+function number_code63(n)
+  return(n > 47 and n < 58)
+end
+function numeric63(s)
+  local n = _35(s)
+  local i = 0
+  while i < n do
+    if not number_code63(code(s, i)) then
+      return(false)
+    end
+    i = i + 1
+  end
+  return(true)
 end
 function add(l, x)
   return(table.insert(l, x))
@@ -141,36 +241,48 @@ function reverse(l)
   end
   return(l1)
 end
-function reduce(f, x)
+function reduce(f, x, y)
   if none63(x) then
-    return(x)
-  else
-    if one63(x) then
-      return(hd(x))
+    if is63(y) then
+      return(y)
     else
-      return(f(hd(x), reduce(f, tl(x))))
+      return(x)
     end
+  else
+    local a = hd(x)
+    local _x2 = tl(x)
+    local _n7 = _35(_x2)
+    local _i7 = 0
+    while _i7 < _n7 do
+      local b = _x2[_i7 + 1]
+      a = f(a, b)
+      _i7 = _i7 + 1
+    end
+    return(a)
   end
 end
+setenv("reducing", {_stash = true, macro = function (f, x, y)
+  return({"reduce", {"fn", {"a", "b"}, {f, "a", "b"}}, x, y})
+end})
 function join(...)
   local ls = unstash({...})
   if two63(ls) then
-    local _id = ls
-    local a = _id[1]
-    local b = _id[2]
+    local _id1 = ls
+    local a = _id1[1]
+    local b = _id1[2]
     if a and b then
       local c = {}
       local o = _35(a)
-      local _o2 = a
+      local _o7 = a
       local k = nil
-      for k in next, _o2 do
-        local v = _o2[k]
+      for k in next, _o7 do
+        local v = _o7[k]
         c[k] = v
       end
-      local _o3 = b
+      local _o8 = b
       local k = nil
-      for k in next, _o3 do
-        local v = _o3[k]
+      for k in next, _o8 do
+        local v = _o8[k]
         if number63(k) then
           k = k + o
         end
@@ -185,10 +297,10 @@ function join(...)
   end
 end
 function find(f, t)
-  local _o4 = t
-  local _i4 = nil
-  for _i4 in next, _o4 do
-    local x = _o4[_i4]
+  local _o9 = t
+  local _i10 = nil
+  for _i10 in next, _o9 do
+    local x = _o9[_i10]
     local y = f(x)
     if y then
       return(y)
@@ -196,16 +308,16 @@ function find(f, t)
   end
 end
 function first(f, l)
-  local _x2 = l
-  local _n5 = _35(_x2)
-  local _i5 = 0
-  while _i5 < _n5 do
-    local x = _x2[_i5 + 1]
+  local _x12 = l
+  local _n11 = _35(_x12)
+  local _i11 = 0
+  while _i11 < _n11 do
+    local x = _x12[_i11 + 1]
     local y = f(x)
     if y then
       return(y)
     end
-    _i5 = _i5 + 1
+    _i11 = _i11 + 1
   end
 end
 function in63(x, t)
@@ -229,24 +341,15 @@ function sort(l, f)
 end
 function map(f, x)
   local t = {}
-  local _x4 = x
-  local _n6 = _35(_x4)
-  local _i6 = 0
-  while _i6 < _n6 do
-    local v = _x4[_i6 + 1]
+  local _o10 = x
+  local k = nil
+  for k in next, _o10 do
+    local v = _o10[k]
     local y = f(v)
     if is63(y) then
-      add(t, y)
-    end
-    _i6 = _i6 + 1
-  end
-  local _o5 = x
-  local k = nil
-  for k in next, _o5 do
-    local v = _o5[k]
-    if not number63(k) then
-      local y = f(v)
-      if is63(y) then
+      if number63(k) then
+        add(t, y)
+      else
         t[k] = y
       end
     end
@@ -260,69 +363,12 @@ function keep(f, x)
     end
   end, x))
 end
-function keys63(t)
-  local _o6 = t
-  local k = nil
-  for k in next, _o6 do
-    local v = _o6[k]
-    if not number63(k) then
-      return(true)
-    end
-  end
-  return(false)
-end
-function empty63(t)
-  local _o7 = t
-  local _i9 = nil
-  for _i9 in next, _o7 do
-    local x = _o7[_i9]
-    return(false)
-  end
-  return(true)
-end
-function stash(args)
-  if keys63(args) then
-    local p = {}
-    local _o8 = args
-    local k = nil
-    for k in next, _o8 do
-      local v = _o8[k]
-      if not number63(k) then
-        p[k] = v
-      end
-    end
-    p._stash = true
-    add(args, p)
-  end
-  return(args)
-end
-function unstash(args)
-  if none63(args) then
-    return({})
-  else
-    local l = last(args)
-    if not atom63(l) and l._stash then
-      local args1 = almost(args)
-      local _o9 = l
-      local k = nil
-      for k in next, _o9 do
-        local v = _o9[k]
-        if not( k == "_stash") then
-          args1[k] = v
-        end
-      end
-      return(args1)
-    else
-      return(args)
-    end
-  end
-end
 function search(s, pattern, start)
-  local _e3
+  local _e4
   if start then
-    _e3 = start + 1
+    _e4 = start + 1
   end
-  local _start = _e3
+  local _start = _e4
   local i = string.find(s, pattern, _start, true)
   return(i and i - 1)
 end
@@ -347,43 +393,39 @@ function split(s, sep)
 end
 function cat(...)
   local xs = unstash({...})
-  if none63(xs) then
-    return("")
-  else
-    return(reduce(function (a, b)
-      return(a .. b)
-    end, xs))
-  end
+  return(reduce(function (a, b)
+    return(a .. b)
+  end, xs, ""))
 end
 function _43(...)
   local xs = unstash({...})
   return(reduce(function (a, b)
     return(a + b)
-  end, xs))
+  end, xs, 0))
 end
 function _(...)
   local xs = unstash({...})
-  return(reduce(function (b, a)
+  return(reduce(function (a, b)
     return(a - b)
-  end, reverse(xs)))
+  end, xs, 0))
 end
 function _42(...)
   local xs = unstash({...})
   return(reduce(function (a, b)
     return(a * b)
-  end, xs))
+  end, xs, 1))
 end
 function _47(...)
   local xs = unstash({...})
-  return(reduce(function (b, a)
+  return(reduce(function (a, b)
     return(a / b)
-  end, reverse(xs)))
+  end, xs, 1))
 end
 function _37(...)
   local xs = unstash({...})
-  return(reduce(function (b, a)
+  return(reduce(function (a, b)
     return(a % b)
-  end, reverse(xs)))
+  end, xs, 1))
 end
 function _62(a, b)
   return(a > b)
@@ -400,47 +442,30 @@ end
 function _6061(a, b)
   return(a <= b)
 end
-function number(s)
-  return(tonumber(s))
-end
-function number_code63(n)
-  return(n > 47 and n < 58)
-end
-function numeric63(s)
-  local n = _35(s)
-  local i = 0
-  while i < n do
-    if not number_code63(code(s, i)) then
-      return(false)
-    end
-    i = i + 1
-  end
-  return(true)
-end
 function escape(s)
   local s1 = "\""
   local i = 0
   while i < _35(s) do
     local c = char(s, i)
-    local _e4
+    local _e5
     if c == "\n" then
-      _e4 = "\\n"
+      _e5 = "\\n"
     else
-      local _e5
+      local _e6
       if c == "\"" then
-        _e5 = "\\\""
+        _e6 = "\\\""
       else
-        local _e6
+        local _e7
         if c == "\\" then
-          _e6 = "\\\\"
+          _e7 = "\\\\"
         else
-          _e6 = c
+          _e7 = c
         end
-        _e5 = _e6
+        _e6 = _e7
       end
-      _e4 = _e5
+      _e5 = _e6
     end
-    local c1 = _e4
+    local c1 = _e5
     s1 = s1 .. c1
     i = i + 1
   end
@@ -483,10 +508,10 @@ function str(x, depth)
                     local xs = {}
                     local ks = {}
                     local d = (depth or 0) + 1
-                    local _o10 = x
+                    local _o11 = x
                     local k = nil
-                    for k in next, _o10 do
-                      local v = _o10[k]
+                    for k in next, _o11 do
+                      local v = _o11[k]
                       if number63(k) then
                         xs[k] = str(v, d)
                       else
@@ -494,10 +519,10 @@ function str(x, depth)
                         add(ks, str(v, d))
                       end
                     end
-                    local _o11 = join(xs, ks)
-                    local _i13 = nil
-                    for _i13 in next, _o11 do
-                      local v = _o11[_i13]
+                    local _o12 = join(xs, ks)
+                    local _i14 = nil
+                    for _i14 in next, _o12 do
+                      local v = _o12[_i14]
                       s = s .. sp .. v
                       sp = " "
                     end
@@ -519,32 +544,6 @@ function apply(f, args)
 end
 function call(f)
   return(f())
-end
-function toplevel63()
-  return(one63(environment))
-end
-function setenv(k, ...)
-  local _r65 = unstash({...})
-  local _id1 = _r65
-  local _keys = cut(_id1, 0)
-  if string63(k) then
-    local _e7
-    if _keys.toplevel then
-      _e7 = hd(environment)
-    else
-      _e7 = last(environment)
-    end
-    local frame = _e7
-    local entry = frame[k] or {}
-    local _o12 = _keys
-    local _k = nil
-    for _k in next, _o12 do
-      local v = _o12[_k]
-      entry[_k] = v
-    end
-    frame[k] = entry
-    return(frame[k])
-  end
 end
 local math = math
 abs = math.abs

--- a/bin/reader.js
+++ b/bin/reader.js
@@ -1,13 +1,13 @@
-var delimiters = {"(": true, "\n": true, ";": true, ")": true};
-var whitespace = {"\t": true, " ": true, "\n": true};
+var delimiters = {"(": true, ")": true, "\n": true, ";": true};
+var whitespace = {" ": true, "\n": true, "\t": true};
 var stream = function (str, more) {
-  return({more: more, pos: 0, string: str, len: _35(str)});
+  return({more: more, pos: 0, len: _35(str), string: str});
 };
 var peek_char = function (s) {
   var _id = s;
   var pos = _id.pos;
-  var string = _id.string;
   var len = _id.len;
+  var string = _id.string;
   if (pos < len) {
     return(char(string, pos));
   }

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -1,12 +1,12 @@
-local delimiters = {[";"] = true, ["\n"] = true, [")"] = true, ["("] = true}
-local whitespace = {[" "] = true, ["\t"] = true, ["\n"] = true}
+local delimiters = {["("] = true, [")"] = true, ["\n"] = true, [";"] = true}
+local whitespace = {[" "] = true, ["\n"] = true, ["\t"] = true}
 local function stream(str, more)
-  return({more = more, len = _35(str), pos = 0, string = str})
+  return({more = more, pos = 0, len = _35(str), string = str})
 end
 local function peek_char(s)
   local _id = s
-  local len = _id.len
   local pos = _id.pos
+  local len = _id.len
   local string = _id.string
   if pos < len then
     return(char(string, pos))
@@ -231,4 +231,4 @@ read_table[","] = function (s)
     return(wrap(s, "unquote"))
   end
 end
-return({["read-all"] = read_all, stream = stream, read = read, ["read-string"] = read_string, ["read-table"] = read_table})
+return({["read-string"] = read_string, ["read-all"] = read_all, read = read, ["read-table"] = read_table, stream = stream})

--- a/bin/system.lua
+++ b/bin/system.lua
@@ -43,4 +43,4 @@ local function exit(code)
   return(os.exit(code))
 end
 local argv = arg
-return({write = write, ["read-file"] = read_file, ["path-join"] = path_join, ["write-file"] = write_file, exit = exit, ["file-exists?"] = file_exists63, argv = argv, ["path-separator"] = path_separator, ["get-environment-variable"] = get_environment_variable})
+return({["write-file"] = write_file, write = write, ["read-file"] = read_file, argv = argv, ["path-join"] = path_join, ["get-environment-variable"] = get_environment_variable, exit = exit, ["file-exists?"] = file_exists63, ["path-separator"] = path_separator})

--- a/compiler.l
+++ b/compiler.l
@@ -501,8 +501,8 @@
 (define lower-infix (form hoist)
   (let ((x rest: args) form)
     (lower (reduce (fn (a b)
-                     (list x b a))
-                   (reverse args))
+                     (list x a b))
+                   args)
            hoist)))
 
 (define lower-special (form hoist)

--- a/runtime.l
+++ b/runtime.l
@@ -3,6 +3,19 @@
 (define-global environment (list (obj)))
 (define-global target (language))
 
+(define-global toplevel? ()
+  (one? environment))
+
+(define-global setenv (k rest: keys)
+  (when (string? k)
+    (let (frame (if (get keys 'toplevel)
+                    (hd environment)
+                  (last environment))
+          entry (or (get frame k) (obj)))
+      (each (k v) keys
+        (set (get entry k) v))
+      (set (get frame k) entry))))
+
 (define-global nil? (x)
   (target
     js: (or (= x nil) (= x null))
@@ -57,11 +70,42 @@
         (unless (number? k)
           (set (get l k) v))))))
 
+(define-global empty? (t)
+  (each x t
+    (return false))
+  true)
+
+(define-global keys? (t)
+  (each (k v) t
+    (unless (number? k)
+      (return true)))
+  false)
+
 (define-global keys (x)
   (with t ()
     (each (k v) x
       (unless (number? k)
         (set (get t k) v)))))
+
+(define-global stash (args)
+  (when (keys? args)
+    (let p ()
+      (each (k v) args
+        (unless (number? k)
+          (set (get p k) v)))
+      (set (get p '_stash) true)
+      (add args p)))
+  args)
+
+(define-global unstash (args)
+  (if (none? args) ()
+    (let l (last args)
+      (if (and (not (atom? l)) (get l '_stash))
+          (with args1 (almost args)
+            (each (k v) l
+              (unless (= k '_stash)
+                (set (get args1 k) v))))
+        args))))
 
 (define-global edge (x)
   (- (# x) 1))
@@ -85,6 +129,22 @@
 (define-global id-literal? (x)
   (and (string? x) (= (char x 0) "|")))
 
+(define-global number (s)
+  (target
+    js: (let n (parseFloat s)
+          (unless (isNaN n) n))
+    lua: (tonumber s)))
+
+(define-global number-code? (n)
+  (and (> n 47) (< n 58)))
+
+(define-global numeric? (s)
+  (let n (# s)
+    (for i n
+      (unless (number-code? (code s i))
+        (return false))))
+  true)
+
 (define-global add (l x)
   (target js: (do ((get l 'push) x) nil)
           lua: ((get table 'insert) l x)))
@@ -106,10 +166,14 @@
         (add l1 (at l i))
         (dec i)))))
 
-(define-global reduce (f x)
-  (if (none? x) x
-      (one? x) (hd x)
-    (f (hd x) (reduce f (tl x)))))
+(define-global reduce (f x y)
+  (if (none? x) (if (is? y) y x)
+    (with a (hd x)
+      (step b (tl x)
+        (set a (f a b))))))
+
+(define-macro reducing (f x y)
+  `(reduce (fn (a b) (,f a b)) ,x ,y))
 
 (define-global join ls
   (if (two? ls)
@@ -152,49 +216,14 @@
 
 (define-global map (f x)
   (with t ()
-    (step v x
-      (let y (f v)
-        (if (is? y)
-          (add t y))))
     (each (k v) x
-      (unless (number? k)
-        (let y (f v)
-          (when (is? y)
+      (let y (f v)
+        (when (is? y)
+          (if (number? k) (add t y)
             (set (get t k) y)))))))
 
 (define-global keep (f x)
   (map (fn (v) (when (f v) v)) x))
-
-(define-global keys? (t)
-  (each (k v) t
-    (unless (number? k)
-      (return true)))
-  false)
-
-(define-global empty? (t)
-  (each x t
-    (return false))
-  true)
-
-(define-global stash (args)
-  (when (keys? args)
-    (let p ()
-      (each (k v) args
-        (unless (number? k)
-          (set (get p k) v)))
-      (set (get p '_stash) true)
-      (add args p)))
-  args)
-
-(define-global unstash (args)
-  (if (none? args) ()
-    (let l (last args)
-      (if (and (not (atom? l)) (get l '_stash))
-          (with args1 (almost args)
-            (each (k v) l
-              (unless (= k '_stash)
-                (set (get args1 k) v))))
-        args))))
 
 (define-global search (s pattern start)
   (target
@@ -216,45 +245,28 @@
         (add l s)))))
 
 (define-global cat xs
-  (if (none? xs) ""
-    (reduce (fn (a b) (cat a b)) xs)))
+  (reducing cat xs ""))
 
 (define-global + xs
-  (reduce (fn (a b) (+ a b)) xs))
+  (reducing + xs 0))
 
 (define-global - xs
-  (reduce (fn (b a) (- a b)) (reverse xs)))
+  (reducing - xs 0))
 
 (define-global * xs
-  (reduce (fn (a b) (* a b)) xs))
+  (reducing * xs 1))
 
 (define-global / xs
-  (reduce (fn (b a) (/ a b)) (reverse xs)))
+  (reducing / xs 1))
 
 (define-global % xs
-  (reduce (fn (b a) (% a b)) (reverse xs)))
+  (reducing % xs 1))
 
 (define-global > (a b) (> a b))
 (define-global < (a b) (< a b))
 (define-global = (a b) (= a b))
 (define-global >= (a b) (>= a b))
 (define-global <= (a b) (<= a b))
-
-(define-global number (s)
-  (target
-    js: (let n (parseFloat s)
-          (unless (isNaN n) n))
-    lua: (tonumber s)))
-
-(define-global number-code? (n)
-  (and (> n 47) (< n 58)))
-
-(define-global numeric? (s)
-  (let n (# s)
-    (for i n
-      (unless (number-code? (code s i))
-        (return false))))
-  true)
 
 (target js: (define tostring (x) ((get x 'toString))))
 
@@ -301,19 +313,6 @@
             lua: (f (values args)))))
 
 (define-global call (f) (f))
-
-(define-global toplevel? ()
-  (one? environment))
-
-(define-global setenv (k rest: keys)
-  (when (string? k)
-    (let (frame (if (get keys 'toplevel)
-                    (hd environment)
-                  (last environment))
-          entry (or (get frame k) (obj)))
-      (each (k v) keys
-        (set (get entry k) v))
-      (set (get frame k) entry))))
 
 (target js:
   (define-global print (x)

--- a/test.l
+++ b/test.l
@@ -792,16 +792,10 @@ c"
   (test= (list "a" "b" "") (split "azzbzz" "zz")))
 
 (define-test reduce
-  (test= 'a (reduce (fn (a b) (+ a b)) '(a)))
-  (test= 6 (reduce (fn (a b) (+ a b)) '(1 2 3)))
-  (test= '(1 (2 3))
-         (reduce
-          (fn (a b) (list a b))
-          '(1 2 3)))
-  (test= '(1 2 3 4 5)
-         (reduce
-          (fn (a b) (join a b))
-          '((1) (2 3) (4 5)))))
+  (test= 'a (reducing + '(a)))
+  (test= 6 (reducing + '(1 2 3)))
+  (test= '((1 2) 3) (reducing list '(1 2 3)))
+  (test= '(1 2 3 4 5) (reducing join '((1) (2 3) (4 5)))))
 
 (define-test keep
   (test= () (keep (fn (x) x) ()))


### PR DESCRIPTION
Closes #40.

- Simplified the implementation of `map`.

- `reduce` now takes a value to be returned when the input list is empty.

- Applying `+` or `-` to an empty list gives `0`.
  * Previously gave `()`.

- Applying `*` `/` or `%` to an empty list gives `1`.
  * Previously gave `()`.

- `reduce` now processes left-to-right rather than right-to-left.
  * Removes the need to reverse a list before passing it to `reduce`.

- Shuffled a few definitions in `runtime.l`.
  * Enables simple macros to be defined in `runtime.l`.

- Added a macro: `reducing`.  These are equivalent:
  * `(reduce (fn (a b) (+ a b)) '(1 2 3))`
  * `(reducing + '(1 2 3))`
