### PR TITLE
Dot syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,22 @@ hi
 10
 ```
 
+It's common to access the values of a list variable where the position or key is known in advance, so there is a shorthand for that:		
+```		
+> (let x (list foo: 10 bar: 20)		
+    x.bar)		
+20		
+> (let x (list foo: 10 bar: 20)		
+    (get x "bar")) ; equivalent		
+20		
+> (let x (list 10 20 30)		
+    x.2)		
+30		
+> (let x (list 10 20 30)		
+    (at x 2)) ; equivalent		
+30		
+```		
+
 #### Assignment
 Variables and list values can be updated using `set`, which evaluates to the value that it updated:
 ```

--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -406,7 +406,7 @@ indentation = function () {
   }
   return(s);
 };
-var reserved = {"finally": true, "*": true, "for": true, "catch": true, "nil": true, "end": true, "local": true, "and": true, "break": true, "then": true, "/": true, "switch": true, "with": true, "==": true, ">": true, "=": true, "not": true, "+": true, "or": true, "-": true, "if": true, "%": true, "void": true, ">=": true, "do": true, "true": true, "instanceof": true, "continue": true, "false": true, "until": true, "else": true, "this": true, "var": true, "in": true, "try": true, "while": true, "debugger": true, "typeof": true, "elseif": true, "function": true, "new": true, "<=": true, "return": true, "case": true, "default": true, "repeat": true, "delete": true, "throw": true, "<": true};
+var reserved = {"else": true, "<": true, "true": true, "/": true, "end": true, "typeof": true, "function": true, "switch": true, "=": true, "or": true, "try": true, "catch": true, "until": true, "local": true, "repeat": true, "-": true, "false": true, "continue": true, "==": true, "and": true, "if": true, "for": true, ">=": true, "<=": true, "with": true, "return": true, "finally": true, "nil": true, "new": true, "do": true, "case": true, "break": true, "elseif": true, "+": true, "not": true, "void": true, "var": true, "%": true, "in": true, "delete": true, "throw": true, "debugger": true, "instanceof": true, "this": true, "while": true, "then": true, "default": true, "*": true, ">": true};
 reserved63 = function (x) {
   return(reserved[x]);
 };
@@ -466,12 +466,12 @@ _x58.lua = "not";
 _x58.js = "!";
 __x57["not"] = _x58;
 var __x59 = [];
-__x59["*"] = true;
 __x59["/"] = true;
+__x59["*"] = true;
 __x59["%"] = true;
 var __x60 = [];
-__x60["-"] = true;
 __x60["+"] = true;
+__x60["-"] = true;
 var __x61 = [];
 var _x62 = [];
 _x62.lua = "..";
@@ -479,8 +479,8 @@ _x62.js = "+";
 __x61.cat = _x62;
 var __x63 = [];
 __x63["<="] = true;
-__x63["<"] = true;
 __x63[">="] = true;
+__x63["<"] = true;
 __x63[">"] = true;
 var __x64 = [];
 var _x65 = [];
@@ -725,8 +725,8 @@ var compile_infix = function (form) {
 compile_function = function (args, body) {
   var _r57 = unstash(Array.prototype.slice.call(arguments, 2));
   var _id12 = _r57;
-  var prefix = _id12.prefix;
   var name = _id12.name;
+  var prefix = _id12.prefix;
   var _e26;
   if (name) {
     _e26 = compile(name);
@@ -1029,7 +1029,7 @@ eval = function (form) {
   run(code);
   return(_37result);
 };
-setenv("do", {_stash: true, tr: true, stmt: true, special: function () {
+setenv("do", {_stash: true, tr: true, special: function () {
   var forms = unstash(Array.prototype.slice.call(arguments, 0));
   var s = "";
   var _x107 = forms;
@@ -1041,8 +1041,8 @@ setenv("do", {_stash: true, tr: true, stmt: true, special: function () {
     _i12 = _i12 + 1;
   }
   return(s);
-}});
-setenv("%if", {_stash: true, tr: true, stmt: true, special: function (cond, cons, alt) {
+}, stmt: true});
+setenv("%if", {_stash: true, tr: true, special: function (cond, cons, alt) {
   var _cond1 = compile(cond);
   indent_level = indent_level + 1;
   var _x110 = compile(cons, {_stash: true, stmt: true});
@@ -1075,8 +1075,8 @@ setenv("%if", {_stash: true, tr: true, stmt: true, special: function (cond, cons
   } else {
     return(s + "\n");
   }
-}});
-setenv("while", {_stash: true, tr: true, stmt: true, special: function (cond, form) {
+}, stmt: true});
+setenv("while", {_stash: true, tr: true, special: function (cond, form) {
   var _cond3 = compile(cond);
   indent_level = indent_level + 1;
   var _x113 = compile(form, {_stash: true, stmt: true});
@@ -1088,8 +1088,8 @@ setenv("while", {_stash: true, tr: true, stmt: true, special: function (cond, fo
   } else {
     return(ind + "while " + _cond3 + " do\n" + body + ind + "end\n");
   }
-}});
-setenv("%for", {_stash: true, tr: true, stmt: true, special: function (t, k, form) {
+}, stmt: true});
+setenv("%for", {_stash: true, tr: true, special: function (t, k, form) {
   var _t1 = compile(t);
   var ind = indentation();
   indent_level = indent_level + 1;
@@ -1101,8 +1101,8 @@ setenv("%for", {_stash: true, tr: true, stmt: true, special: function (t, k, for
   } else {
     return(ind + "for (" + k + " in " + _t1 + ") {\n" + body + ind + "}\n");
   }
-}});
-setenv("%try", {_stash: true, tr: true, stmt: true, special: function (form) {
+}, stmt: true});
+setenv("%try", {_stash: true, tr: true, special: function (form) {
   var e = unique("e");
   var ind = indentation();
   indent_level = indent_level + 1;
@@ -1115,7 +1115,7 @@ setenv("%try", {_stash: true, tr: true, stmt: true, special: function (form) {
   indent_level = indent_level - 1;
   var h = _x127;
   return(ind + "try {\n" + body + ind + "}\n" + ind + "catch (" + e + ") {\n" + h + ind + "}\n");
-}});
+}, stmt: true});
 setenv("%delete", {_stash: true, special: function (place) {
   return(indentation() + "delete " + compile(place));
 }, stmt: true});
@@ -1125,22 +1125,22 @@ setenv("break", {_stash: true, special: function () {
 setenv("%function", {_stash: true, special: function (args, body) {
   return(compile_function(args, body));
 }});
-setenv("%global-function", {_stash: true, tr: true, stmt: true, special: function (name, args, body) {
+setenv("%global-function", {_stash: true, tr: true, special: function (name, args, body) {
   if (target === "lua") {
     var x = compile_function(args, body, {_stash: true, name: name});
     return(indentation() + x);
   } else {
     return(compile(["set", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}});
-setenv("%local-function", {_stash: true, tr: true, stmt: true, special: function (name, args, body) {
+}, stmt: true});
+setenv("%local-function", {_stash: true, tr: true, special: function (name, args, body) {
   if (target === "lua") {
-    var x = compile_function(args, body, {_stash: true, prefix: "local", name: name});
+    var x = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
     return(indentation() + x);
   } else {
     return(compile(["%local", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}});
+}, stmt: true});
 setenv("return", {_stash: true, special: function (x) {
   var _e36;
   if (nil63(x)) {

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -364,7 +364,7 @@ function indentation()
   end
   return(s)
 end
-local reserved = {["until"] = true, ["this"] = true, ["break"] = true, ["try"] = true, ["then"] = true, ["*"] = true, ["if"] = true, ["case"] = true, ["switch"] = true, ["in"] = true, ["else"] = true, ["=="] = true, ["function"] = true, [">"] = true, ["typeof"] = true, ["<"] = true, ["nil"] = true, ["catch"] = true, ["repeat"] = true, ["throw"] = true, ["continue"] = true, ["delete"] = true, ["elseif"] = true, ["or"] = true, ["debugger"] = true, ["return"] = true, ["-"] = true, ["while"] = true, ["+"] = true, ["void"] = true, ["do"] = true, ["local"] = true, ["false"] = true, ["and"] = true, ["var"] = true, ["finally"] = true, ["true"] = true, ["/"] = true, ["end"] = true, ["for"] = true, ["default"] = true, [">="] = true, ["with"] = true, ["<="] = true, ["new"] = true, ["instanceof"] = true, ["="] = true, ["not"] = true, ["%"] = true}
+local reserved = {["else"] = true, ["<"] = true, ["true"] = true, ["/"] = true, ["end"] = true, ["typeof"] = true, ["function"] = true, ["switch"] = true, ["="] = true, ["or"] = true, ["try"] = true, ["catch"] = true, ["until"] = true, ["local"] = true, ["repeat"] = true, ["-"] = true, ["false"] = true, ["continue"] = true, ["=="] = true, ["and"] = true, ["if"] = true, ["for"] = true, [">="] = true, ["<="] = true, ["with"] = true, ["return"] = true, ["finally"] = true, ["nil"] = true, ["new"] = true, ["do"] = true, ["case"] = true, ["break"] = true, ["elseif"] = true, ["+"] = true, ["not"] = true, ["void"] = true, ["var"] = true, ["%"] = true, ["in"] = true, ["delete"] = true, ["throw"] = true, ["debugger"] = true, ["instanceof"] = true, ["this"] = true, ["while"] = true, ["then"] = true, ["default"] = true, ["*"] = true, [">"] = true}
 function reserved63(x)
   return(reserved[x])
 end
@@ -413,8 +413,8 @@ function mapo(f, t)
 end
 local __x57 = {}
 local _x58 = {}
-_x58.js = "!"
 _x58.lua = "not"
+_x58.js = "!"
 __x57["not"] = _x58
 local __x59 = {}
 __x59["/"] = true
@@ -425,28 +425,28 @@ __x60["+"] = true
 __x60["-"] = true
 local __x61 = {}
 local _x62 = {}
-_x62.js = "+"
 _x62.lua = ".."
+_x62.js = "+"
 __x61.cat = _x62
 local __x63 = {}
-__x63[">="] = true
-__x63[">"] = true
 __x63["<="] = true
+__x63[">="] = true
 __x63["<"] = true
+__x63[">"] = true
 local __x64 = {}
 local _x65 = {}
-_x65.js = "==="
 _x65.lua = "=="
+_x65.js = "==="
 __x64["="] = _x65
 local __x66 = {}
 local _x67 = {}
-_x67.js = "&&"
 _x67.lua = "and"
+_x67.js = "&&"
 __x66["and"] = _x67
 local __x68 = {}
 local _x69 = {}
-_x69.js = "||"
 _x69.lua = "or"
+_x69.js = "||"
 __x68["or"] = _x69
 local infix = {__x57, __x59, __x60, __x61, __x63, __x64, __x66, __x68}
 local function unary63(form)
@@ -612,9 +612,9 @@ local function compile_special(form, stmt63)
   local x = _id5[1]
   local args = cut(_id5, 1)
   local _id6 = getenv(x)
-  local special = _id6.special
-  local stmt = _id6.stmt
   local self_tr63 = _id6.tr
+  local stmt = _id6.stmt
+  local special = _id6.special
   local tr = terminator(stmt63 and not self_tr63)
   return(apply(special, args) .. tr)
 end
@@ -982,7 +982,7 @@ function eval(form)
   run(code)
   return(_37result)
 end
-setenv("do", {_stash = true, special = function (...)
+setenv("do", {_stash = true, tr = true, special = function (...)
   local forms = unstash({...})
   local s = ""
   local _x111 = forms
@@ -994,8 +994,8 @@ setenv("do", {_stash = true, special = function (...)
     _i12 = _i12 + 1
   end
   return(s)
-end, stmt = true, tr = true})
-setenv("%if", {_stash = true, special = function (cond, cons, alt)
+end, stmt = true})
+setenv("%if", {_stash = true, tr = true, special = function (cond, cons, alt)
   local _cond1 = compile(cond)
   indent_level = indent_level + 1
   local _x114 = compile(cons, {_stash = true, stmt = true})
@@ -1028,8 +1028,8 @@ setenv("%if", {_stash = true, special = function (cond, cons, alt)
   else
     return(s .. "\n")
   end
-end, stmt = true, tr = true})
-setenv("while", {_stash = true, special = function (cond, form)
+end, stmt = true})
+setenv("while", {_stash = true, tr = true, special = function (cond, form)
   local _cond3 = compile(cond)
   indent_level = indent_level + 1
   local _x117 = compile(form, {_stash = true, stmt = true})
@@ -1041,8 +1041,8 @@ setenv("while", {_stash = true, special = function (cond, form)
   else
     return(ind .. "while " .. _cond3 .. " do\n" .. body .. ind .. "end\n")
   end
-end, stmt = true, tr = true})
-setenv("%for", {_stash = true, special = function (t, k, form)
+end, stmt = true})
+setenv("%for", {_stash = true, tr = true, special = function (t, k, form)
   local _t1 = compile(t)
   local ind = indentation()
   indent_level = indent_level + 1
@@ -1054,8 +1054,8 @@ setenv("%for", {_stash = true, special = function (t, k, form)
   else
     return(ind .. "for (" .. k .. " in " .. _t1 .. ") {\n" .. body .. ind .. "}\n")
   end
-end, stmt = true, tr = true})
-setenv("%try", {_stash = true, special = function (form)
+end, stmt = true})
+setenv("%try", {_stash = true, tr = true, special = function (form)
   local e = unique("e")
   local ind = indentation()
   indent_level = indent_level + 1
@@ -1068,7 +1068,7 @@ setenv("%try", {_stash = true, special = function (form)
   indent_level = indent_level - 1
   local h = _x131
   return(ind .. "try {\n" .. body .. ind .. "}\n" .. ind .. "catch (" .. e .. ") {\n" .. h .. ind .. "}\n")
-end, stmt = true, tr = true})
+end, stmt = true})
 setenv("%delete", {_stash = true, special = function (place)
   return(indentation() .. "delete " .. compile(place))
 end, stmt = true})
@@ -1078,22 +1078,22 @@ end, stmt = true})
 setenv("%function", {_stash = true, special = function (args, body)
   return(compile_function(args, body))
 end})
-setenv("%global-function", {_stash = true, special = function (name, args, body)
+setenv("%global-function", {_stash = true, tr = true, special = function (name, args, body)
   if target == "lua" then
     local x = compile_function(args, body, {_stash = true, name = name})
     return(indentation() .. x)
   else
     return(compile({"set", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
-end, stmt = true, tr = true})
-setenv("%local-function", {_stash = true, special = function (name, args, body)
+end, stmt = true})
+setenv("%local-function", {_stash = true, tr = true, special = function (name, args, body)
   if target == "lua" then
     local x = compile_function(args, body, {_stash = true, name = name, prefix = "local"})
     return(indentation() .. x)
   else
     return(compile({"%local", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
-end, stmt = true, tr = true})
+end, stmt = true})
 setenv("return", {_stash = true, special = function (x)
   local _e28
   if nil63(x) then
@@ -1220,4 +1220,4 @@ setenv("%object", {_stash = true, special = function (...)
   end
   return(s .. "}")
 end})
-return({expand = expand, eval = eval, run = run, compile = compile})
+return({run = run, expand = expand, compile = compile, eval = eval})

--- a/bin/reader.js
+++ b/bin/reader.js
@@ -1,13 +1,13 @@
-var delimiters = {"\n": true, ";": true, "(": true, ")": true};
-var whitespace = {" ": true, "\t": true, "\n": true};
+var delimiters = {"(": true, ")": true, "\n": true, ";": true};
+var whitespace = {" ": true, "\n": true, "\t": true};
 var stream = function (str, more) {
-  return({string: str, more: more, len: _35(str), pos: 0});
+  return({more: more, pos: 0, len: _35(str), string: str});
 };
 var peek_char = function (s) {
   var _id = s;
-  var string = _id.string;
-  var len = _id.len;
   var pos = _id.pos;
+  var len = _id.len;
+  var string = _id.string;
   if (pos < len) {
     return(char(string, pos));
   }
@@ -76,8 +76,8 @@ var flag63 = function (atom) {
 };
 var expected = function (s, c) {
   var _id1 = s;
-  var pos = _id1.pos;
   var more = _id1.more;
+  var pos = _id1.pos;
   var _id2 = more;
   var _e;
   if (_id2) {
@@ -96,6 +96,20 @@ var wrap = function (s, x) {
     return([x, y]);
   }
 };
+var dot_syntax = function (x) {
+  if (string63(x) && ! string_literal63(x) && !( "." === char(x, 0)) && !( "." === char(x, edge(x))) && search(x, ".") && ! search(x, "..")) {
+    return(reduce(function (a, b) {
+      var n = number(a);
+      if (is63(n)) {
+        return(["at", b, n]);
+      } else {
+        return(["get", b, ["quote", a]]);
+      }
+    }, reverse(split(x, "."))));
+  } else {
+    return(x);
+  }
+};
 read_table[""] = function (s) {
   var str = "";
   while (true) {
@@ -106,40 +120,56 @@ read_table[""] = function (s) {
       break;
     }
   }
+  var _e1;
   if (str === "true") {
-    return(true);
+    _e1 = true;
   } else {
+    var _e2;
     if (str === "false") {
-      return(false);
+      _e2 = false;
     } else {
+      var _e3;
       if (str === "nan") {
-        return(nan);
+        _e3 = nan;
       } else {
+        var _e4;
         if (str === "-nan") {
-          return(nan);
+          _e4 = nan;
         } else {
+          var _e5;
           if (str === "inf") {
-            return(inf);
+            _e5 = inf;
           } else {
+            var _e6;
             if (str === "-inf") {
-              return(-inf);
+              _e6 = -inf;
             } else {
+              var _e7;
               if (! number_code63(code(str, edge(str)))) {
-                return(str);
+                _e7 = str;
               } else {
                 var n = number(str);
+                var _e8;
                 if (nil63(n) || nan63(n) || inf63(n)) {
-                  return(str);
+                  _e8 = str;
                 } else {
-                  return(n);
+                  _e8 = n;
                 }
+                _e7 = _e8;
               }
+              _e6 = _e7;
             }
+            _e5 = _e6;
           }
+          _e4 = _e5;
         }
+        _e3 = _e4;
       }
+      _e2 = _e3;
     }
+    _e1 = _e2;
   }
+  return(dot_syntax(_e1));
 };
 read_table["("] = function (s) {
   read_char(s);

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -1,12 +1,12 @@
-local delimiters = {["("] = true, ["\n"] = true, [";"] = true, [")"] = true}
+local delimiters = {["("] = true, [")"] = true, ["\n"] = true, [";"] = true}
 local whitespace = {[" "] = true, ["\n"] = true, ["\t"] = true}
 local function stream(str, more)
-  return({len = _35(str), pos = 0, more = more, string = str})
+  return({more = more, pos = 0, len = _35(str), string = str})
 end
 local function peek_char(s)
   local _id = s
-  local len = _id.len
   local pos = _id.pos
+  local len = _id.len
   local string = _id.string
   if pos < len then
     return(char(string, pos))
@@ -96,6 +96,20 @@ local function wrap(s, x)
     return({x, y})
   end
 end
+local function dot_syntax(x)
+  if string63(x) and not string_literal63(x) and not( "." == char(x, 0)) and not( "." == char(x, edge(x))) and search(x, ".") and not search(x, "..") then
+    return(reduce(function (a, b)
+      local n = number(a)
+      if is63(n) then
+        return({"at", b, n})
+      else
+        return({"get", b, {"quote", a}})
+      end
+    end, reverse(split(x, "."))))
+  else
+    return(x)
+  end
+end
 read_table[""] = function (s)
   local str = ""
   while true do
@@ -106,40 +120,56 @@ read_table[""] = function (s)
       break
     end
   end
+  local _e1
   if str == "true" then
-    return(true)
+    _e1 = true
   else
+    local _e2
     if str == "false" then
-      return(false)
+      _e2 = false
     else
+      local _e3
       if str == "nan" then
-        return(nan)
+        _e3 = nan
       else
+        local _e4
         if str == "-nan" then
-          return(nan)
+          _e4 = nan
         else
+          local _e5
           if str == "inf" then
-            return(inf)
+            _e5 = inf
           else
+            local _e6
             if str == "-inf" then
-              return(-inf)
+              _e6 = -inf
             else
+              local _e7
               if not number_code63(code(str, edge(str))) then
-                return(str)
+                _e7 = str
               else
                 local n = number(str)
+                local _e8
                 if nil63(n) or nan63(n) or inf63(n) then
-                  return(str)
+                  _e8 = str
                 else
-                  return(n)
+                  _e8 = n
                 end
+                _e7 = _e8
               end
+              _e6 = _e7
             end
+            _e5 = _e6
           end
+          _e4 = _e5
         end
+        _e3 = _e4
       end
+      _e2 = _e3
     end
+    _e1 = _e2
   end
+  return(dot_syntax(_e1))
 end
 read_table["("] = function (s)
   read_char(s)
@@ -231,4 +261,4 @@ read_table[","] = function (s)
     return(wrap(s, "unquote"))
   end
 end
-return({["read-table"] = read_table, ["read-string"] = read_string, stream = stream, ["read-all"] = read_all, read = read})
+return({["read-string"] = read_string, ["read-all"] = read_all, read = read, ["read-table"] = read_table, stream = stream})

--- a/bin/system.lua
+++ b/bin/system.lua
@@ -39,4 +39,4 @@ local function exit(code)
   return(os.exit(code))
 end
 local argv = arg
-return({["get-environment-variable"] = get_environment_variable, write = write, ["write-file"] = write_file, ["path-join"] = path_join, argv = argv, ["file-exists?"] = file_exists63, ["read-file"] = read_file, ["path-separator"] = path_separator, exit = exit})
+return({["write-file"] = write_file, write = write, ["read-file"] = read_file, argv = argv, ["path-join"] = path_join, ["get-environment-variable"] = get_environment_variable, exit = exit, ["file-exists?"] = file_exists63, ["path-separator"] = path_separator})

--- a/reader.l
+++ b/reader.l
@@ -68,6 +68,21 @@
     (if (= y (get s 'more)) y
       (list x y))))
 
+(define dot-syntax (x)
+  (if (and (string? x)
+           (not (string-literal? x))
+           (not (= "." (char x 0)))
+           (not (= "." (char x (edge x))))
+           (search x ".")
+           (not (search x "..")))
+      (reduce (fn (a b)
+                  (let n (number a)
+                    (if (is? n)
+                      `(at ,b ,n)
+                      `(get ,b (quote ,a)))))
+                (reverse (split x ".")))
+    x))
+
 (define-reader ("" s) ; atom
   (let (str "")
     (while true
@@ -76,6 +91,7 @@
 			(not (get delimiters c))))
 	    (cat! str (read-char s))
 	  (break))))
+  (dot-syntax
     (if (= str "true") true
         (= str "false") false
         (= str "nan") nan
@@ -84,7 +100,7 @@
         (= str "-inf") -inf
         (not (number-code? (code str (edge str)))) str
       (let n (number str)
-        (if (or (nil? n) (nan? n) (inf? n)) str n)))))
+        (if (or (nil? n) (nan? n) (inf? n)) str n))))))
 
 (define-reader ("(" s)
   (read-char s)
@@ -148,3 +164,4 @@
         read-all
         read-string
         read-table)
+


### PR DESCRIPTION
This PR restores Lumen's old dot syntax, which was previously removed in commit 6410c8cc2de.  It's an a minimalistic alternative to PR #51, and is intended to strictly restore the old dot syntax rather than provide additional flexibility.

String atoms that contain `.` but begin or end with `.` or contain `..` are ignored.

According to tests, this PR introduces no measurable slowdowns.

