### PR TITLE
Support symlinks to bin/lumen

### DIFF
--- a/bin/lumen
+++ b/bin/lumen
@@ -1,7 +1,14 @@
 #!/bin/sh
 
 dir="$(pwd)"
-cd "$(dirname "$0")"
+bin="$0"
+while [ -L "${bin}" ]
+do
+  x="$(readlink "${bin}")"
+  cd "$(dirname "${bin}")"
+  bin="${x}"
+done
+cd "$(dirname "${bin}")"
 home="$(pwd)"
 cd "${dir}"
 

--- a/bin/lumen
+++ b/bin/lumen
@@ -4,9 +4,9 @@ dir="$(pwd)"
 bin="$0"
 while [ -L "${bin}" ]
 do
-  x="$(readlink "${bin}")"
-  cd "$(dirname "${bin}")"
-  bin="${x}"
+    x="$(readlink "${bin}")"
+    cd "$(dirname "${bin}")"
+    bin="${x}"
 done
 cd "$(dirname "${bin}")"
 home="$(pwd)"


### PR DESCRIPTION
This PR introduces support for creating symlinks to `bin/lumen`. Here are a few situations where this might be useful: 

- Installing `lumen` globally

```sh
$ git clone https://github.com/sctb/lumen
$ ln -s "$(pwd)/lumen/bin/lumen" /usr/local/bin/lumen
$ lumen -e 1
1
```

- Adding a `make install` target to Lumen's makefile

```make
PREFIX?=/usr/local

install: all
	@mkdir -p "$(PREFIX)/bin"
	@ln -sf "$(shell pwd)/bin/lumen" "$(PREFIX)/bin/lumen"

uninstall:
	@rm -f "$(PREFIX)/bin/lumen"
```

```sh
$ make test && make install && lumen -e 1
js:
 609 passed, 0 failed
lua:
 609 passed, 0 failed
1
```

- Making Lumen available through Homebrew. `brew install lumen` could be pretty convenient.

Features:

1.  Symlinks containing relative paths are supported. E.g. Homebrew would install Lumen by creating a symlink like `/usr/local/bin/lumen -> ../Cellar/lumen/0/bin/lumen`

2. Chains of symlinks are supported.

I tried to keep the implementation as small as possible. I think it would be hard to make it any smaller without dropping support for relative paths or symlink chains.