### PR TITLE
SYSTEM features

### DIFF
--- a/bin/lumen
+++ b/bin/lumen
@@ -37,4 +37,10 @@ case $host in
         export LUA_PATH="$LUA_PATH;${home}/?.lua;${dir}/lib/?.lua;;";;
 esac
 
+t=""
+[ -t 0 ] && t="${t} 0"
+[ -t 1 ] && t="${t} 1"
+[ -t 2 ] && t="${t} 2"
+export LUMEN_TTY="${t}"
+
 exec ${host} "${home}/${code}" "$@"

--- a/bin/lumen
+++ b/bin/lumen
@@ -37,10 +37,4 @@ case $host in
         export LUA_PATH="$LUA_PATH;${home}/?.lua;${dir}/lib/?.lua;;";;
 esac
 
-t=""
-[ -t 0 ] && t="${t} 0"
-[ -t 1 ] && t="${t} 1"
-[ -t 2 ] && t="${t} 2"
-export LUMEN_TTY="${t}"
-
 exec ${host} "${home}/${code}" "$@"

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -909,7 +909,7 @@ setenv("define-global", {_stash: true, macro: function (name, x) {
   var _x148 = destash33(x, _r39);
   var _id31 = _r39;
   var body = cut(_id31, 0);
-  setenv(_name7, {_stash: true, variable: true, toplevel: true});
+  setenv(_name7, {_stash: true, toplevel: true, variable: true});
   if (some63(body)) {
     return(join(["%global-function", _name7], bind42(_x148, body)));
   } else {
@@ -998,8 +998,8 @@ setenv("guard", {_stash: true, macro: function (expr) {
     var msg = unique("msg");
     var trace = unique("trace");
     var _x257 = ["obj"];
-    _x257.stack = trace;
     _x257.message = msg;
+    _x257.stack = trace;
     return(["let", [x, "nil", msg, "nil", trace, "nil"], ["if", ["xpcall", ["fn", join(), ["set", x, expr]], ["fn", ["m"], ["set", msg, ["clip", "m", ["+", ["search", "m", "\": \""], 2]], trace, [["get", "debug", ["quote", "traceback"]]]]]], ["list", true, x], ["list", false, _x257]]]);
   }
 }});
@@ -1197,7 +1197,7 @@ var run_file = function (path) {
   return(compiler.run(system["read-file"](path)));
 };
 var script_file63 = function (path) {
-  return(!( "-" === char(path, 0) || ".js" === clip(path, _35(path) - 3) || ".lua" === clip(path, _35(path) - 4)));
+  return(path === "-" || !( "-" === char(path, 0) || ".js" === clip(path, _35(path) - 3) || ".lua" === clip(path, _35(path) - 4)));
 };
 var usage = function () {
   print("usage: lumen [<file> <arguments> | options <object files>]");

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -1085,7 +1085,7 @@ local function run_file(path)
   return(compiler.run(system["read-file"](path)))
 end
 local function script_file63(path)
-  return(not( "-" == char(path, 0) or ".js" == clip(path, _35(path) - 3) or ".lua" == clip(path, _35(path) - 4)))
+  return(path == "-" or not( "-" == char(path, 0) or ".js" == clip(path, _35(path) - 3) or ".lua" == clip(path, _35(path) - 4)))
 end
 local function usage()
   print("usage: lumen [<file> <arguments> | options <object files>]")

--- a/bin/system.js
+++ b/bin/system.js
@@ -21,7 +21,7 @@ var write_file = function (path, data) {
   return(fs.writeFileSync(_path1, data, "utf8"));
 };
 var file_exists63 = function (path) {
-  return(fs.existsSync(path, "utf8"));
+  return(path === "-" || fs.existsSync(path, "utf8"));
 };
 var path_separator = require("path").sep;
 var path_join = function () {

--- a/bin/system.js
+++ b/bin/system.js
@@ -61,7 +61,13 @@ var tty63 = function (fd) {
       if (fd === "stderr") {
         _e4 = 2;
       } else {
-        _e4 = fd;
+        var _e5;
+        if (number63(fd)) {
+          _e5 = fd;
+        } else {
+          return(false);
+        }
+        _e4 = _e5;
       }
       _e3 = _e4;
     }

--- a/bin/system.js
+++ b/bin/system.js
@@ -34,6 +34,29 @@ var reload = function (module) {
 var run = function (command) {
   return(child_process.execSync(command).toString());
 };
+var tty63 = function (fd) {
+  var _e;
+  if (fd === "stdin") {
+    _e = 0;
+  } else {
+    var _e1;
+    if (fd === "stdout") {
+      _e1 = 1;
+    } else {
+      var _e2;
+      if (fd === "stderr") {
+        _e2 = 2;
+      } else {
+        _e2 = fd;
+      }
+      _e1 = _e2;
+    }
+    _e = _e1;
+  }
+  var _fd = _e;
+  var s = get_environment_variable("LUMEN_TTY") || "";
+  return(yes(search(s, " " + _fd)));
+};
 exports["read-file"] = read_file;
 exports["write-file"] = write_file;
 exports["file-exists?"] = file_exists63;
@@ -45,3 +68,4 @@ exports.exit = exit;
 exports.argv = argv;
 exports.reload = reload;
 exports.run = run;
+exports["tty?"] = tty63;

--- a/bin/system.js
+++ b/bin/system.js
@@ -68,8 +68,7 @@ var tty63 = function (fd) {
     _e2 = _e3;
   }
   var _fd = _e2;
-  var s = get_environment_variable("LUMEN_TTY") || "";
-  return(yes(search(s, " " + _fd)));
+  return("1" === run("[ -t " + _fd + " ] && printf 1 || exit 0"));
 };
 exports["read-file"] = read_file;
 exports["write-file"] = write_file;

--- a/bin/system.js
+++ b/bin/system.js
@@ -1,10 +1,24 @@
 var fs = require("fs");
 var child_process = require("child_process");
 var read_file = function (path) {
-  return(fs.readFileSync(path, "utf8"));
+  var _e;
+  if (path === "-") {
+    _e = "/dev/stdin";
+  } else {
+    _e = path;
+  }
+  var _path = _e;
+  return(fs.readFileSync(_path, "utf8"));
 };
 var write_file = function (path, data) {
-  return(fs.writeFileSync(path, data, "utf8"));
+  var _e1;
+  if (path === "-") {
+    _e1 = "/dev/stdout";
+  } else {
+    _e1 = path;
+  }
+  var _path1 = _e1;
+  return(fs.writeFileSync(_path1, data, "utf8"));
 };
 var file_exists63 = function (path) {
   return(fs.existsSync(path, "utf8"));
@@ -35,25 +49,25 @@ var run = function (command) {
   return(child_process.execSync(command).toString());
 };
 var tty63 = function (fd) {
-  var _e;
+  var _e2;
   if (fd === "stdin") {
-    _e = 0;
+    _e2 = 0;
   } else {
-    var _e1;
+    var _e3;
     if (fd === "stdout") {
-      _e1 = 1;
+      _e3 = 1;
     } else {
-      var _e2;
+      var _e4;
       if (fd === "stderr") {
-        _e2 = 2;
+        _e4 = 2;
       } else {
-        _e2 = fd;
+        _e4 = fd;
       }
-      _e1 = _e2;
+      _e3 = _e4;
     }
-    _e = _e1;
+    _e2 = _e3;
   }
-  var _fd = _e;
+  var _fd = _e2;
   var s = get_environment_variable("LUMEN_TTY") || "";
   return(yes(search(s, " " + _fd)));
 };

--- a/bin/system.lua
+++ b/bin/system.lua
@@ -86,7 +86,13 @@ local function tty63(fd)
       if fd == "stderr" then
         _e7 = 2
       else
-        _e7 = fd
+        local _e8
+        if number63(fd) then
+          _e8 = fd
+        else
+          return(false)
+        end
+        _e7 = _e8
       end
       _e6 = _e7
     end
@@ -95,4 +101,4 @@ local function tty63(fd)
   local _fd = _e5
   return("1" == run("[ -t " .. _fd .. " ] && printf 1 || exit 0"))
 end
-return({["read-file"] = read_file, reload = reload, ["file-exists?"] = file_exists63, exit = exit, ["write-file"] = write_file, ["path-join"] = path_join, write = write, ["path-separator"] = path_separator, run = run, ["tty?"] = tty63, argv = argv, ["get-environment-variable"] = get_environment_variable})
+return({["read-file"] = read_file, ["write-file"] = write_file, argv = argv, ["file-exists?"] = file_exists63, exit = exit, write = write, ["tty?"] = tty63, ["path-separator"] = path_separator, run = run, ["path-join"] = path_join, ["get-environment-variable"] = get_environment_variable, reload = reload})

--- a/bin/system.lua
+++ b/bin/system.lua
@@ -93,7 +93,6 @@ local function tty63(fd)
     _e5 = _e6
   end
   local _fd = _e5
-  local s = get_environment_variable("LUMEN_TTY") or ""
-  return(yes(search(s, " " .. _fd)))
+  return("1" == run("[ -t " .. _fd .. " ] && printf 1 || exit 0"))
 end
-return({["path-join"] = path_join, ["read-file"] = read_file, exit = exit, reload = reload, run = run, ["path-separator"] = path_separator, ["file-exists?"] = file_exists63, ["tty?"] = tty63, ["write-file"] = write_file, ["get-environment-variable"] = get_environment_variable, write = write, argv = argv})
+return({["read-file"] = read_file, reload = reload, ["file-exists?"] = file_exists63, exit = exit, ["write-file"] = write_file, ["path-join"] = path_join, write = write, ["path-separator"] = path_separator, run = run, ["tty?"] = tty63, argv = argv, ["get-environment-variable"] = get_environment_variable})

--- a/bin/system.lua
+++ b/bin/system.lua
@@ -32,11 +32,19 @@ local function write_file(path, data)
   end, _path1, "w"))
 end
 local function file_exists63(path)
-  local f = io.open(path)
-  if f then
-    f.close(f)
+  local _id = path == "-"
+  local _e3
+  if _id then
+    _e3 = _id
+  else
+    local f = io.open(path)
+    local _e4
+    if f then
+      _e4 = f.close(f)
+    end
+    _e3 = is63(f)
   end
-  return(is63(f))
+  return(_e3)
 end
 local path_separator = char(_G.package.config, 0)
 local function path_join(...)
@@ -66,26 +74,26 @@ local function run(command)
   return(x)
 end
 local function tty63(fd)
-  local _e2
+  local _e5
   if fd == "stdin" then
-    _e2 = 0
+    _e5 = 0
   else
-    local _e3
+    local _e6
     if fd == "stdout" then
-      _e3 = 1
+      _e6 = 1
     else
-      local _e4
+      local _e7
       if fd == "stderr" then
-        _e4 = 2
+        _e7 = 2
       else
-        _e4 = fd
+        _e7 = fd
       end
-      _e3 = _e4
+      _e6 = _e7
     end
-    _e2 = _e3
+    _e5 = _e6
   end
-  local _fd = _e2
+  local _fd = _e5
   local s = get_environment_variable("LUMEN_TTY") or ""
   return(yes(search(s, " " .. _fd)))
 end
-return({write = write, ["write-file"] = write_file, exit = exit, ["tty?"] = tty63, ["path-separator"] = path_separator, reload = reload, ["get-environment-variable"] = get_environment_variable, argv = argv, ["file-exists?"] = file_exists63, ["read-file"] = read_file, run = run, ["path-join"] = path_join})
+return({["path-join"] = path_join, ["read-file"] = read_file, exit = exit, reload = reload, run = run, ["path-separator"] = path_separator, ["file-exists?"] = file_exists63, ["tty?"] = tty63, ["write-file"] = write_file, ["get-environment-variable"] = get_environment_variable, write = write, argv = argv})

--- a/bin/system.lua
+++ b/bin/system.lua
@@ -8,14 +8,28 @@ local function call_with_file(f, path, mode)
   return(x)
 end
 local function read_file(path)
+  local _e
+  if path == "-" then
+    _e = "/dev/stdin"
+  else
+    _e = path
+  end
+  local _path = _e
   return(call_with_file(function (f)
     return(f.read(f, "*a"))
-  end, path))
+  end, _path))
 end
 local function write_file(path, data)
+  local _e1
+  if path == "-" then
+    _e1 = "/dev/stdout"
+  else
+    _e1 = path
+  end
+  local _path1 = _e1
   return(call_with_file(function (f)
     return(f.write(f, data))
-  end, path, "w"))
+  end, _path1, "w"))
 end
 local function file_exists63(path)
   local f = io.open(path)
@@ -52,26 +66,26 @@ local function run(command)
   return(x)
 end
 local function tty63(fd)
-  local _e
+  local _e2
   if fd == "stdin" then
-    _e = 0
+    _e2 = 0
   else
-    local _e1
+    local _e3
     if fd == "stdout" then
-      _e1 = 1
+      _e3 = 1
     else
-      local _e2
+      local _e4
       if fd == "stderr" then
-        _e2 = 2
+        _e4 = 2
       else
-        _e2 = fd
+        _e4 = fd
       end
-      _e1 = _e2
+      _e3 = _e4
     end
-    _e = _e1
+    _e2 = _e3
   end
-  local _fd = _e
+  local _fd = _e2
   local s = get_environment_variable("LUMEN_TTY") or ""
   return(yes(search(s, " " .. _fd)))
 end
-return({["file-exists?"] = file_exists63, ["read-file"] = read_file, write = write, ["path-join"] = path_join, ["write-file"] = write_file, exit = exit, ["path-separator"] = path_separator, reload = reload, ["tty?"] = tty63, ["get-environment-variable"] = get_environment_variable, argv = argv, run = run})
+return({write = write, ["write-file"] = write_file, exit = exit, ["tty?"] = tty63, ["path-separator"] = path_separator, reload = reload, ["get-environment-variable"] = get_environment_variable, argv = argv, ["file-exists?"] = file_exists63, ["read-file"] = read_file, run = run, ["path-join"] = path_join})

--- a/bin/system.lua
+++ b/bin/system.lua
@@ -51,4 +51,27 @@ local function run(command)
   f.close(f)
   return(x)
 end
-return({["file-exists?"] = file_exists63, ["path-separator"] = path_separator, ["write-file"] = write_file, ["get-environment-variable"] = get_environment_variable, ["read-file"] = read_file, ["path-join"] = path_join, write = write, run = run, exit = exit, argv = argv, reload = reload})
+local function tty63(fd)
+  local _e
+  if fd == "stdin" then
+    _e = 0
+  else
+    local _e1
+    if fd == "stdout" then
+      _e1 = 1
+    else
+      local _e2
+      if fd == "stderr" then
+        _e2 = 2
+      else
+        _e2 = fd
+      end
+      _e1 = _e2
+    end
+    _e = _e1
+  end
+  local _fd = _e
+  local s = get_environment_variable("LUMEN_TTY") or ""
+  return(yes(search(s, " " .. _fd)))
+end
+return({["file-exists?"] = file_exists63, ["read-file"] = read_file, write = write, ["path-join"] = path_join, ["write-file"] = write_file, exit = exit, ["path-separator"] = path_separator, reload = reload, ["tty?"] = tty63, ["get-environment-variable"] = get_environment_variable, argv = argv, run = run})

--- a/main.l
+++ b/main.l
@@ -45,9 +45,10 @@
   ((get compiler 'run) ((get system 'read-file) path)))
 
 (define script-file? (path)
-  (not (or (= "-" (char path 0))
-           (= ".js" (clip path (- (# path) 3)))
-           (= ".lua" (clip path (- (# path) 4))))))
+  (or (= path "-")
+      (not (or (= "-" (char path 0))
+               (= ".js" (clip path (- (# path) 3)))
+               (= ".lua" (clip path (- (# path) 4)))))))
 
 (define usage ()
   (print "usage: lumen [<file> <arguments> | options <object files>]")

--- a/system.l
+++ b/system.l
@@ -68,6 +68,14 @@
            (with x ((get f 'read) f '*all)
              ((get f 'close) f)))))
 
+(define tty? (fd)
+  (let (fd (if (= fd 'stdin) 0
+               (= fd 'stdout) 1
+               (= fd 'stderr) 2
+             fd)
+        s (or (get-environment-variable "LUMEN_TTY") ""))
+    (yes (search s (cat " " fd)))))
+
 (export read-file
         write-file
         file-exists?
@@ -78,4 +86,5 @@
         exit
         argv
         reload
-        run)
+        run
+        tty?)

--- a/system.l
+++ b/system.l
@@ -26,11 +26,12 @@
             path 'w))))
 
 (define file-exists? (path)
-  (target
-    js: ((get fs 'existsSync) path 'utf8)
-    lua: (let f ((get io 'open) path)
-           (if f ((get f 'close) f))
-           (is? f))))
+  (or (= path "-")
+      (target
+        js: ((get fs 'existsSync) path 'utf8)
+        lua: (let f ((get io 'open) path)
+               (if f ((get f 'close) f))
+               (is? f)))))
 
 (define path-separator
   (target

--- a/system.l
+++ b/system.l
@@ -72,12 +72,11 @@
              ((get f 'close) f)))))
 
 (define tty? (fd)
-  (let (fd (if (= fd 'stdin) 0
-               (= fd 'stdout) 1
-               (= fd 'stderr) 2
-             fd)
-        s (or (get-environment-variable "LUMEN_TTY") ""))
-    (yes (search s (cat " " fd)))))
+  (let fd (if (= fd 'stdin) 0
+              (= fd 'stdout) 1
+              (= fd 'stderr) 2
+            fd)
+    (= "1" (run (cat "[ -t " fd " ] && printf 1 || exit 0")))))
 
 (export read-file
         write-file

--- a/system.l
+++ b/system.l
@@ -10,18 +10,20 @@
         ((get h 'close) h)))))
 
 (define read-file (path)
-  (target
-    js: ((get fs 'readFileSync) path 'utf8)
-    lua: (call-with-file
-          (fn (f) ((get f 'read) f '*a))
-          path)))
+  (let path (if (= path "-") "/dev/stdin" path)
+    (target
+      js: ((get fs 'readFileSync) path 'utf8)
+      lua: (call-with-file
+            (fn (f) ((get f 'read) f '*a))
+            path))))
 
 (define write-file (path data)
-  (target
-    js: ((get fs 'writeFileSync) path data 'utf8)
-    lua: (call-with-file
-          (fn (f) ((get f 'write) f data))
-          path 'w)))
+  (let path (if (= path "-") "/dev/stdout" path)
+    (target
+      js: ((get fs 'writeFileSync) path data 'utf8)
+      lua: (call-with-file
+            (fn (f) ((get f 'write) f data))
+            path 'w))))
 
 (define file-exists? (path)
   (target

--- a/system.l
+++ b/system.l
@@ -75,7 +75,8 @@
   (let fd (if (= fd 'stdin) 0
               (= fd 'stdout) 1
               (= fd 'stderr) 2
-            fd)
+              (number? fd) fd
+            (return false))
     (= "1" (run (cat "[ -t " fd " ] && printf 1 || exit 0")))))
 
 (export read-file


### PR DESCRIPTION
- Define `system.tty?`

```sh
$ bin/lumen -e '(do (define system (require "system")) (system.tty? "stdin"))'
true
$ echo 1 | bin/lumen -e '(do (define system (require "system")) (system.tty? "stdin"))'
false
$ echo 1 | bin/lumen -e '(do (define system (require "system")) (system.tty? "stdout"))'
true
$ echo 1 | bin/lumen -e '(do (define system (require "system")) (system.tty? "stdout"))' | cat
false
$ echo 1 | bin/lumen -e '(do (define system (require "system")) (system.tty? "stderr"))' | cat
true
$ echo 1 | bin/lumen -e '(do (define system (require "system")) (system.tty? "stderr"))' 2>&1 | cat
false
```

---

- A file path equal to "-" is now treated as "/dev/stdin" by `system.read-file` and "/dev/stdout" by `system.write-file`.

```sh
$ cat test.l | bin/lumen -
 609 passed, 0 failed
```
```sh
$ cat test.l | bin/lumen -c -
local passed = 0
local failed = 0
local tests = {}
local reader = require("reader")
local compiler = require("compiler")
setenv("test", {_stash = true, macro = function (x, msg)
...
```
```sh
$ echo '(print 1)' | bin/lumen -c - -o -
print(1)
```
---

As always, let me know if you have any feedback or if you think of anything else you'd like.

My next goal is to extend `system` with the remaining target-specific functionality in `main.l`: reading lines from stdin and formatting error messages. It might also be a good idea to add some simple argument parsing facilities similar to Python's `argparse`, since almost every Lumen script will be parsing arguments.

I'll also look into fixing a bug with `load` on Node hosts. `(define reader (load "reader.l"))` works on Lua, but it fails for Node since scripts aren't loaded as modules:

```sh
$ echo '(define reader (load "reader.l"))' | LUMEN_HOST=node bin/lumen -
undefined:259
exports.stream = stream;
^
ReferenceError: exports is not defined
```

One long-term goal is to strategize with you about how `load` should work. It seems like a good idea to add some sort of load-path functionality, i.e. a list of dirs that `load` tries to load from. Right now `(load "foo.l")` will only try to load relative to the current working directory instead of the directory of the script that called it. If we had a load-path, we could fix that by pushing the script's directory onto the load-path just before running it.

There are a bunch of open questions, too: Should `load` try to detect circular loads? Should we cache the result of calling `load`, making its behavior more like `require`? Etc. For now I'll just try to write some scripts and libraries and see what problems turn up in practice.