### PR TITLE
Add install/uninstall commands to the makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -53,3 +53,13 @@ test: all
 	@LUMEN_HOST=$(LUMEN_NODE) ./test.l
 	@echo lua:
 	@LUMEN_HOST=$(LUMEN_LUA) ./test.l
+
+PREFIX     ?= /usr/local/bin
+LUMEN_NAME ?= lumen
+
+install: all
+	@mkdir -p "$(PREFIX)"
+	@ln -sf "$(shell pwd)/bin/lumen" "$(PREFIX)/$(LUMEN_NAME)"
+
+uninstall:
+	@rm -f "$(PREFIX)/$(LUMEN_NAME)"


### PR DESCRIPTION
This PR introduces support for `make install` and `make uninstall`.

1. Running `make install` will symlink `/usr/local/bin/lumen -> $(pwd)/bin/lumen`

2. Running `LUMEN_NAME=sctb-lumen make install` will symlink `/usr/local/bin/sctb-lumen -> $(pwd)/bin/lumen`

3. Running `PREFIX=~/bin LUMEN_NAME=sctb-lumen make install` will symlink `~/bin/sctb-lumen -> $(pwd)/bin/lumen`

In the above examples, replacing `make install` with `make uninstall` would delete the corresponding symlink.

This PR makes it much easier to have several different versions of Lumen installed simultaneously. Personally, I have `sctb-lumen` which points to the latest commit in your repository, `lumen-experimental` which points to my work-in-progress version of lumen, and `lumen-old` which points to a version of lumen from last year (to measure whether any slowdowns have been introduced since then).