### PR TITLE
Fix STR for tables with non-atom keys in Lua

### DIFF
--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -502,6 +502,9 @@ function str(x, stack)
                         if number63(k) then
                           xs[k] = str(v, l)
                         else
+                          if not string63(k) then
+                            k = str(k, l)
+                          end
                           add(ks, k .. ":")
                           add(ks, str(v, l))
                         end

--- a/runtime.l
+++ b/runtime.l
@@ -293,7 +293,10 @@
       (each (k v) x
         (if (number? k)
             (set (get xs k) (str v l))
-          (do (add ks (cat k ":"))
+          (do (target lua:
+                (unless (string? k)
+                  (set k (str k l))))
+              (add ks (cat k ":"))
               (add ks (str v l)))))
       (drop l)
       (each v (join xs ks)

--- a/test.l
+++ b/test.l
@@ -976,6 +976,15 @@ c"
   (test= false (obj? 'zz))
   (test= false (obj? (fn ()))))
 
+(define-test str
+  (define f (x) x)
+  (let (l () l2 ())
+    (set (get l f) true)
+    (set (get l2 (target js: (str l) lua: l)) true)
+    (let k (target js: f lua: 'function)
+      (test= (cat "(" k ": true)") (str l))
+      (test= (cat "((" k ": true): true)") (str l2)))))
+
 (define-test apply
   (test= 4 (apply (fn (a b) (+ a b)) '(2 2)))
   (test= '(2 2) (apply (fn a a) '(2 2)))


### PR DESCRIPTION
This PR fixes the following bug:

```sh
$ lumen -e "(str (with l () (set (get l (fn ())) true)))"
error: attempt to concatenate local 'k' (a function value)
```

