### PR TITLE
Fix expansion of symbols resolving to macros

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -274,11 +274,39 @@ var expand_definition = function (_x42) {
   drop(environment);
   return(_x44);
 };
-var expand_macro = function (form) {
-  return(macroexpand(expand1(form)));
+var expand_form = function (form) {
+  var x = macroexpand(hd(form));
+  if (macro63(x)) {
+    return(macroexpand(apply(macro_function(x), tl(form))));
+  } else {
+    var l = [x];
+    var i = 0;
+    while (i < _35(form)) {
+      if (!( i === 0)) {
+        add(l, macroexpand(form[i]));
+      }
+      i = i + 1;
+    }
+    var _o5 = form;
+    var k = undefined;
+    for (k in _o5) {
+      var v = _o5[k];
+      var _e18;
+      if (numeric63(k)) {
+        _e18 = parseInt(k);
+      } else {
+        _e18 = k;
+      }
+      var _k4 = _e18;
+      if (! number63(_k4)) {
+        l[_k4] = macroexpand(v);
+      }
+    }
+    return(l);
+  }
 };
-expand1 = function (_x46) {
-  var _id3 = _x46;
+expand1 = function (_x47) {
+  var _id3 = _x47;
   var name = _id3[0];
   var body = cut(_id3, 1);
   return(apply(macro_function(name), body));
@@ -290,23 +318,23 @@ macroexpand = function (form) {
     if (atom63(form)) {
       return(form);
     } else {
-      var x = hd(form);
-      if (x === "%local") {
-        return(expand_local(form));
+      if (none63(form)) {
+        return(form);
       } else {
-        if (x === "%function") {
-          return(expand_function(form));
+        var x = hd(form);
+        if (x === "%local") {
+          return(expand_local(form));
         } else {
-          if (x === "%global-function") {
-            return(expand_definition(form));
+          if (x === "%function") {
+            return(expand_function(form));
           } else {
-            if (x === "%local-function") {
+            if (x === "%global-function") {
               return(expand_definition(form));
             } else {
-              if (macro63(x)) {
-                return(expand_macro(form));
+              if (x === "%local-function") {
+                return(expand_definition(form));
               } else {
-                return(map(macroexpand, form));
+                return(expand_form(form));
               }
             }
           }

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -239,11 +239,32 @@ local function expand_definition(_x42)
   drop(environment)
   return(_x44)
 end
-local function expand_macro(form)
-  return(macroexpand(expand1(form)))
+local function expand_form(form)
+  local x = macroexpand(hd(form))
+  if macro63(x) then
+    return(macroexpand(apply(macro_function(x), tl(form))))
+  else
+    local l = {x}
+    local i = 0
+    while i < _35(form) do
+      if not( i == 0) then
+        add(l, macroexpand(form[i + 1]))
+      end
+      i = i + 1
+    end
+    local _o5 = form
+    local k = nil
+    for k in next, _o5 do
+      local v = _o5[k]
+      if not number63(k) then
+        l[k] = macroexpand(v)
+      end
+    end
+    return(l)
+  end
 end
-function expand1(_x46)
-  local _id3 = _x46
+function expand1(_x47)
+  local _id3 = _x47
   local name = _id3[1]
   local body = cut(_id3, 1)
   return(apply(macro_function(name), body))
@@ -255,23 +276,23 @@ function macroexpand(form)
     if atom63(form) then
       return(form)
     else
-      local x = hd(form)
-      if x == "%local" then
-        return(expand_local(form))
+      if none63(form) then
+        return(form)
       else
-        if x == "%function" then
-          return(expand_function(form))
+        local x = hd(form)
+        if x == "%local" then
+          return(expand_local(form))
         else
-          if x == "%global-function" then
-            return(expand_definition(form))
+          if x == "%function" then
+            return(expand_function(form))
           else
-            if x == "%local-function" then
+            if x == "%global-function" then
               return(expand_definition(form))
             else
-              if macro63(x) then
-                return(expand_macro(form))
+              if x == "%local-function" then
+                return(expand_definition(form))
               else
-                return(map(macroexpand, form))
+                return(expand_form(form))
               end
             end
           end

--- a/compiler.l
+++ b/compiler.l
@@ -142,8 +142,17 @@
   (with-bindings (args)
     `(,x ,name ,args ,@(macroexpand body))))
 
-(define expand-macro (form)
-  (macroexpand (expand1 form)))
+(define expand-form (form)
+  (let x (macroexpand (hd form))
+    (if (macro? x)
+        (macroexpand (apply (macro-function x) (tl form)))
+      (with l (list x)
+        (for i (# form)
+          (unless (= i 0)
+            (add l (macroexpand (at form i)))))
+        (each (k v) form
+          (unless (number? k)
+            (set (get l k) (macroexpand v))))))))
 
 (define-global expand1 ((name rest: body))
   (apply (macro-function name) body))
@@ -152,13 +161,13 @@
   (if (symbol? form)
       (macroexpand (symbol-expansion form))
       (atom? form) form
+      (none? form) form
     (let x (hd form)
       (if (= x '%local) (expand-local form)
           (= x '%function) (expand-function form)
           (= x '%global-function) (expand-definition form)
           (= x '%local-function) (expand-definition form)
-          (macro? x) (expand-macro form)
-        (map macroexpand form)))))
+        (expand-form form)))))
 
 (define quasiquote-list (form depth)
   (let xs (list '(list))

--- a/test.l
+++ b/test.l
@@ -740,13 +740,21 @@ c"
   (let-symbol (a 18)
     (let (b 20)
       (test= 18 a)
-      (test= 20 b))))
+      (test= 20 b)))
+  (let-symbol (def define)
+    (def f (x) (+ x 10))
+    (test= 20 (f 10))))
 
 (define-test define-symbol
   (define-symbol zzz 42)
   (test= zzz 42))
 
 (define-test macros-and-symbols
+  (define-symbol zzz1 define)
+  (define-macro zzz2 () 'zzz1)
+  (define-symbol zzz3 zzz2)
+  ((zzz3) f (x) (+ x 10))
+  (test= 20 (f 10))
   (let-symbol (a 1)
     (let-macro ((a () 2))
       (test= 2 (a)))


### PR DESCRIPTION
This PR fixes expansion of symbols whose value is a macro:

```
> (define-symbol def define-global)
(symbol: "define-global")
> (def foo 42)
error: attempt to call global 'define_global' (a nil value)
```

To achieve this, `macroexpand` was changed to the following algorithm:

- Call `macroexpand` on the first element of an expression

- If the first element expanded to a `macro?`, then apply its `macro-function` to the rest of the expression

- Otherwise, call `macroexpand` on each element of the expression except the first

On my machine, this PR has identical performance on `node` and `lua` hosts, and improves performance by ~2.5% on `luajit`.
