### PR TITLE
Fix RESERVED? on JS

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -423,7 +423,7 @@ indentation = function () {
 };
 var reserved = {"try": true, "delete": true, "false": true, "function": true, "break": true, "repeat": true, "var": true, "throw": true, "%": true, "else": true, "with": true, "nil": true, "or": true, "do": true, "+": true, "/": true, "debugger": true, "until": true, "new": true, ">": true, "then": true, "-": true, "typeof": true, "=": true, "==": true, "local": true, "void": true, "continue": true, "<=": true, "catch": true, "while": true, "not": true, "default": true, ">=": true, "and": true, "elseif": true, "true": true, "<": true, "instanceof": true, "case": true, "in": true, "finally": true, "*": true, "end": true, "switch": true, "for": true, "if": true, "return": true};
 reserved63 = function (x) {
-  return(reserved[x]);
+  return(reserved.hasOwnProperty(x));
 };
 var valid_code63 = function (n) {
   return(number_code63(n) || n > 64 && n < 91 || n > 96 && n < 123 || n === 95);

--- a/compiler.l
+++ b/compiler.l
@@ -232,7 +232,9 @@
           "function" "not" "true" "elseif" "if" "or" "until"))
 
 (define-global reserved? (x)
-  (get reserved x))
+  (target
+    lua: (get reserved x)
+    js: ((get reserved 'hasOwnProperty) x)))
 
 (define valid-code? (n)
   (or (number-code? n)         ; 0-9


### PR DESCRIPTION
`"toString"`, `"valueOf"`, etc were incorrectly being classified as reserved words on JS.

E.g. this was incorrect behavior:
```
$ LUMEN_HOST=node lumen -e "(compile 'toString)"
"_toString"
```
Correct behavior:
```
$ LUMEN_HOST=node lumen -e "(compile 'toString)"
"toString"
```

A more general fix would be to change the `set-of` macro to return an object without a prototype chain. Then `(let o (set-of "foo") (get o 'toString))` would return nil. (It currently returns a function.)
