### PR TITLE
Minor fix in EXPORT for JS

### DIFF
--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -1135,7 +1135,9 @@ setenv("export", {_stash: true, macro: function () {
       var __i7 = _e12;
       x[k] = k;
     }
-    return(["return", join(["obj"], x)]);
+    return(["return", join(["%object"], mapo(function (x) {
+      return(x);
+    }, x))]);
   }
 }});
 setenv("when-compiling", {_stash: true, macro: function () {

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -1009,7 +1009,9 @@ setenv("export", {_stash = true, macro = function (...)
       local k = _o5[_i7]
       x[k] = k
     end
-    return({"return", join({"obj"}, x)})
+    return({"return", join({"%object"}, mapo(function (x)
+      return(x)
+    end, x))})
   end
 end})
 setenv("when-compiling", {_stash = true, macro = function (...)

--- a/macros.l
+++ b/macros.l
@@ -231,7 +231,7 @@
     (let x (obj)
       (each k names
         (set (get x k) k))
-      `(return (obj ,@x)))))
+      `(return (%object ,@(mapo (fn (x) x) x))))))
 
 (define-macro when-compiling body
   (eval `(do ,@body)))


### PR DESCRIPTION
This fixes an error when exporting "length" on JS when targeting Lua.

This allows JS hosts to export objects that contain a "length" property, such as Motor's buffer object.

Currently,
```
git clone https://github.com/sctb/motor
LUMEN_HOST=node lumen -c motor/buffer.l -t js
```
results in an error:
```
lumen/bin/lumen.js:201
        r[_k2] = v;
               ^
RangeError: Invalid array length
    at join (lumen/bin/lumen.js:201:16)
    at Function.setenv.macro (lumen/bin/lumen.js:1138:23)
    at apply (lumen/bin/lumen.js:627:12)
    at expand1 (lumen/bin/compiler.js:284:16)
    at expand_macro (lumen/bin/compiler.js:278:22)
    at macroexpand (lumen/bin/compiler.js:307:24)
    at map (lumen/bin/lumen.js:272:13)
    at macroexpand (lumen/bin/compiler.js:309:28)
    at Object.expand (lumen/bin/compiler.js:1051:16)
    at compile_file (lumen/bin/lumen.js:1190:23)
```

The problem is that in JS, `join` can't join an array (e.g. `(list "obj")`) with an object containing a `length` property (e.g. `(obj length: "length")`), so the quasisplice `(obj ,@x)` in EXPORT results in an error.

The most straightforward fix is to sidestep the problem by replacing `(obj ,@x)` with `(%object ,@(mapo (fn (x) x) x))` in EXPORT. 