### PR TITLE
Support hex literals

### DIFF
--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -484,10 +484,19 @@ _6261 = function (a, b) {
 _6061 = function (a, b) {
   return(a <= b);
 };
-number = function (s) {
-  var n = parseFloat(s);
-  if (! isNaN(n)) {
-    return(n);
+var _num63 = new RegExp("^[+-]?(([0-9]+)|([0-9]*[.][0-9]+))([eE][+-]?[0-9]+)?$");
+var hex63 = new RegExp("^0[xX][0-9a-fA-F]+$");
+number = function (str, base) {
+  if (base) {
+    return(parseInt(str, base));
+  } else {
+    if (_num63.test(str)) {
+      return(parseFloat(str));
+    } else {
+      if (hex63.test(str)) {
+        return(parseInt(str));
+      }
+    }
   }
 };
 number_code63 = function (n) {

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -408,9 +408,7 @@ end
 function _6061(a, b)
   return(a <= b)
 end
-function number(s)
-  return(tonumber(s))
-end
+number = tonumber
 function number_code63(n)
   return(n > 47 and n < 58)
 end

--- a/bin/reader.js
+++ b/bin/reader.js
@@ -96,11 +96,6 @@ var wrap = function (s, x) {
     return([x, y]);
   }
 };
-var maybe_number = function (str) {
-  if (number_code63(code(str, edge(str)))) {
-    return(number(str));
-  }
-};
 var real63 = function (x) {
   return(number63(x) && ! nan63(x) && ! inf63(x));
 };
@@ -149,7 +144,7 @@ read_table[""] = function (s) {
             if (str === "-inf") {
               return(-inf);
             } else {
-              var n = maybe_number(str);
+              var n = number(str);
               if (real63(n)) {
                 return(n);
               } else {

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -96,11 +96,6 @@ local function wrap(s, x)
     return({x, y})
   end
 end
-local function maybe_number(str)
-  if number_code63(code(str, edge(str))) then
-    return(number(str))
-  end
-end
 local function real63(x)
   return(number63(x) and not nan63(x) and not inf63(x))
 end
@@ -149,7 +144,7 @@ read_table[""] = function (s)
             if str == "-inf" then
               return(-inf)
             else
-              local n = maybe_number(str)
+              local n = number(str)
               if real63(n) then
                 return(n)
               else

--- a/reader.l
+++ b/reader.l
@@ -66,10 +66,6 @@
     (if (= y (get s 'more)) y
       (list x y))))
 
-(define maybe-number (str)
-  (when (number-code? (code str (edge str)))
-    (number str)))
-
 (define real? (x)
   (and (number? x) (not (nan? x)) (not (inf? x))))
 
@@ -102,7 +98,7 @@
       (= str "-nan") nan
       (= str "inf") inf
       (= str "-inf") -inf
-    (let n (maybe-number str)
+    (let n (number str)
       (if (real? n) n
           (and dot? (valid-access? str))
           (parse-access str)

--- a/runtime.l
+++ b/runtime.l
@@ -245,11 +245,15 @@
 (define-global >= (a b) (>= a b))
 (define-global <= (a b) (<= a b))
 
-(define-global number (s)
-  (target
-    js: (let n (parseFloat s)
-          (unless (isNaN n) n))
-    lua: (tonumber s)))
+(target lua: (define-global number tonumber))
+
+(target js:
+  (let (num? (new (RegExp "^[+-]?(([0-9]+)|([0-9]*[.][0-9]+))([eE][+-]?[0-9]+)?$"))
+        hex? (new (RegExp "^0[xX][0-9a-fA-F]+$")))
+    (define-global number (str base)
+      (if base (parseInt str base)
+          ((get num? 'test) str) (parseFloat str)
+          ((get hex? 'test) str) (parseInt str)))))
 
 (define-global number-code? (n)
   (and (> n 47) (< n 58)))

--- a/test.l
+++ b/test.l
@@ -39,6 +39,7 @@
     (test= "nil" (read "nil"))
     (test= 17 (read "17"))
     (test= 0.015 (read "1.5e-2"))
+    (test= 65535 (read "0xffff"))
     (test= true (read "true"))
     (test= (not true) (read "false"))
     (test= 'hi (read "hi"))
@@ -59,8 +60,7 @@
     (test= true (inf? (read "inf")))
     (test= true (inf? (read "-inf")))
     (test= "0?" (read "0?"))
-    (test= "0!" (read "0!"))
-    (test= "0." (read "0."))))
+    (test= "0!" (read "0!"))))
 
 (define-test read-more
   (let read (get reader 'read-string)


### PR DESCRIPTION
This PR re-introduces support for hex literals. (See https://github.com/sctb/motor/pull/3)

It updates `number` to reject non-numeric strings.

