### PR TITLE
Minor fix for Lua 5.1

### DIFF
--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -996,7 +996,7 @@ end
 function expand(form)
   return(lower(macroexpand(form)))
 end
-local load1 = load
+local load1 = loadstring or load
 local function run(code)
   local f,e = load1(code)
   if f then

--- a/compiler.l
+++ b/compiler.l
@@ -548,7 +548,7 @@
 (target js: (set (get global 'require) require))
 (target js: (define run eval))
 
-(target lua: (define load1 load))
+(target lua: (define load1 (or loadstring load)))
 (target lua:
   (define run (code)
     (let |f,e| (load1 code)


### PR DESCRIPTION
This PR allows lua5.1 to be used as a `LUMEN_HOST`.

Currently `LUMEN_HOST=lua5.1` results in an error:

```
$ LUMEN_HOST=lua5.1 lumen -e 1
error: bad argument #1 to 'load1' (function expected, got string)
```