### PR TITLE
Update COMPILE-FILE; minor fix in LOAD

### DIFF
--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -1185,13 +1185,24 @@ var repl = function () {
   return(_in.on("data", rep1));
 };
 compile_file = function (path) {
-  var s = reader.stream(system["read-file"](path));
+  var _r5 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _path = destash33(path, _r5);
+  var _id1 = _r5;
+  var options = cut(_id1, 0);
+  var target1 = target;
+  var environment1 = environment;
+  target = options.target || target;
+  environment = options.environment || environment;
+  var s = reader.stream(system["read-file"](_path));
   var body = reader["read-all"](s);
   var form = compiler.expand(join(["do"], body));
-  return(compiler.compile(form, {_stash: true, stmt: true}));
+  var code = compiler.compile(form, {_stash: true, stmt: true});
+  target = target1;
+  environment = environment1;
+  return(code);
 };
 load = function (path) {
-  return(compiler.run(compile_file(path)));
+  return(compiler.run(compile_file(path, {_stash: true, target: "js"})));
 };
 var run_file = function (path) {
   return(compiler.run(system["read-file"](path)));
@@ -1221,7 +1232,7 @@ var main = function () {
       var pre = [];
       var input = undefined;
       var output = undefined;
-      var target1 = undefined;
+      var _target = undefined;
       var expr = undefined;
       var argv = system.argv;
       var i = 0;
@@ -1240,7 +1251,7 @@ var main = function () {
                 output = val;
               } else {
                 if (a === "-t") {
-                  target1 = val;
+                  _target = val;
                 } else {
                   if (a === "-e") {
                     expr = val;
@@ -1270,10 +1281,7 @@ var main = function () {
           return(repl());
         }
       } else {
-        if (target1) {
-          target = target1;
-        }
-        var code = compile_file(input);
+        var code = compile_file(input, {_stash: true, target: _target});
         if (nil63(output) || output === "-") {
           return(print(code));
         } else {

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -1084,14 +1084,25 @@ local function repl()
     end
   end
 end
-function compile_file(path)
-  local s = reader.stream(system["read-file"](path))
+function compile_file(path, ...)
+  local _r6 = unstash({...})
+  local _path = destash33(path, _r6)
+  local _id1 = _r6
+  local options = cut(_id1, 0)
+  local target1 = target
+  local environment1 = environment
+  target = options.target or target
+  environment = options.environment or environment
+  local s = reader.stream(system["read-file"](_path))
   local body = reader["read-all"](s)
   local form = compiler.expand(join({"do"}, body))
-  return(compiler.compile(form, {_stash = true, stmt = true}))
+  local code = compiler.compile(form, {_stash = true, stmt = true})
+  target = target1
+  environment = environment1
+  return(code)
 end
 function load(path)
-  return(compiler.run(compile_file(path)))
+  return(compiler.run(compile_file(path, {_stash = true, target = "lua"})))
 end
 local function run_file(path)
   return(compiler.run(system["read-file"](path)))
@@ -1121,7 +1132,7 @@ local function main()
       local pre = {}
       local input = nil
       local output = nil
-      local target1 = nil
+      local _target = nil
       local expr = nil
       local argv = system.argv
       local i = 0
@@ -1140,7 +1151,7 @@ local function main()
                 output = val
               else
                 if a == "-t" then
-                  target1 = val
+                  _target = val
                 else
                   if a == "-e" then
                     expr = val
@@ -1170,10 +1181,7 @@ local function main()
           return(repl())
         end
       else
-        if target1 then
-          target = target1
-        end
-        local code = compile_file(input)
+        local code = compile_file(input, {_stash = true, target = _target})
         if nil63(output) or output == "-" then
           return(print(code))
         else

--- a/main.l
+++ b/main.l
@@ -32,14 +32,19 @@
            (let s ((get io 'read))
              (if s (rep1 (cat s "\n")) (break))))))
 
-(define-global compile-file (path)
-  (let (s ((get reader 'stream) ((get system 'read-file) path))
-        body ((get reader 'read-all) s)
-        form ((get compiler 'expand) `(do ,@body)))
-    ((get compiler 'compile) form :stmt)))
+(define-global compile-file (path rest: options)
+  (let (target1 target environment1 environment)
+    (set target (or (get options 'target) target))
+    (set environment (or (get options 'environment) environment))
+    (let (s ((get reader 'stream) ((get system 'read-file) path))
+          body ((get reader 'read-all) s)
+          form ((get compiler 'expand) `(do ,@body)))
+      (with code ((get compiler 'compile) form :stmt)
+        (set target target1)
+        (set environment environment1)))))
 
 (define-global load (path)
-  ((get compiler 'run) (compile-file path)))
+  ((get compiler 'run) (compile-file path target: (language))))
 
 (define run-file (path)
   ((get compiler 'run) ((get system 'read-file) path)))
@@ -70,7 +75,7 @@
       (let (pre ()
             input nil
             output nil
-            target1 nil
+            target nil
             expr nil
             argv (get system 'argv))
         (for i (# argv)
@@ -82,16 +87,15 @@
                       (let val (at argv i)
                         (if (= a "-c") (set input val)
                             (= a "-o") (set output val)
-                            (= a "-t") (set target1 val)
+                            (= a "-t") (set target val)
                             (= a "-e") (set expr val)))))
                 (not (= "-" (char a 0))) (add pre a))))
         (step file pre
           (run-file file))
         (if (nil? input) (if expr (rep expr) (repl))
-          (do (if target1 (set target target1))
-              (let code (compile-file input)
-                (if (or (nil? output) (= output "-"))
-                    (print code)
-                  ((get system 'write-file) output code)))))))))
+          (let code (compile-file input target: target)
+            (if (or (nil? output) (= output "-"))
+              (print code)
+              ((get system 'write-file) output code))))))))
 
 (main)


### PR DESCRIPTION
- `compile-file` now takes keyword arguments `:target` and `:environment`
- `load` now uses the current language as the compilation target

Closes #77.
