### PR TITLE
Minor fix for npm

### DIFF
--- a/bin/lumen
+++ b/bin/lumen
@@ -31,7 +31,7 @@ fi
 case $host in
     node*)
         code=lumen.js
-        export NODE_PATH="$NODE_PATH:${home}:${dir}/lib";;
+        export NODE_PATH="$NODE_PATH:${home}:${dir}/lib:${dir}/node_modules";;
     *)
         code=lumen.lua
         export LUA_PATH="$LUA_PATH;${home}/?.lua;${dir}/lib/?.lua;;";;


### PR DESCRIPTION
This PR adds `$(pwd)/node_modules` to NODE_PATH, allowing users to install a library from npm, then `require` it using Lumen.

This matches the expected behavior of Node. For example, using Node, try the following:

```
$ npm install leftpad
leftpad@0.0.0 node_modules/leftpad
$ node -e 'console.log(require("leftpad"))'
[Function]
```

Currently, Lumen doesn't support this:

```
$ LUMEN_HOST=node lumen -e '(require "leftpad")'
Error: Cannot find module 'leftpad'
```

Users would expect this to work, because it's the very basis of the Node ecosystem. It's also in line with Lumen's goal of matching the target runtime environment as closely as possible.

Initially I was confused why this wasn't working. Node's `require` algorithm should already be doing this. But it turns out that `require` tries to load `node_modules` relative to Lumen's `bin/compiler.js` file, because that's where the `eval` function is stored as `(define run eval)`.
