### PR TITLE
Prevent "-" from being compiled to "_"

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -596,7 +596,7 @@ var id = function (id) {
     var c = char(id, i);
     var n = code(c);
     var _e24;
-    if (c === "-") {
+    if (c === "-" && !( id === "-")) {
       _e24 = "_";
     } else {
       var _e25;

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -542,7 +542,7 @@ local function id(id)
     local c = char(id, i)
     local n = code(c)
     local _e16
-    if c == "-" then
+    if c == "-" and not( id == "-") then
       _e16 = "_"
     else
       local _e17

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -445,7 +445,7 @@ _43 = function () {
     return(a + b);
   }, xs) || 0);
 };
-_ = function () {
+_45 = function () {
   var xs = unstash(Array.prototype.slice.call(arguments, 0));
   return(reduce(function (b, a) {
     return(a - b);

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -369,7 +369,7 @@ function _43(...)
     return(a + b)
   end, xs) or 0)
 end
-function _(...)
+function _45(...)
   local xs = unstash({...})
   return(reduce(function (b, a)
     return(a - b)

--- a/compiler.l
+++ b/compiler.l
@@ -312,7 +312,9 @@
     (for i (# id)
       (let (c (char id i)
             n (code c)
-            c1 (if (= c "-") "_"
+            c1 (if (and (= c "-")
+                        (not (= id "-")))
+                   "_"
                    (valid-code? n) c
                    (= i 0) (cat "_" n)
                  n))


### PR DESCRIPTION
`+` compiles to `_43`, so it follows that `-` should compile to `_45`.

Currently `-` compiles to `_`. I'd like to be able to use `_` as a variable name without conflicting with Lumen's `-` function.