### PR TITLE
Compile multiple IF statements to ELSE IF statements

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -5,13 +5,13 @@ var getenv = function (k, p) {
     while (i >= 0) {
       var b = environment[i][k];
       if (is63(b)) {
-        var _e9;
+        var _e10;
         if (p) {
-          _e9 = b[p];
+          _e10 = b[p];
         } else {
-          _e9 = b;
+          _e10 = b;
         }
-        return(_e9);
+        return(_e10);
       } else {
         i = i - 1;
       }
@@ -51,12 +51,10 @@ bound63 = function (x) {
 quoted = function (form) {
   if (string63(form)) {
     return(escape(form));
+  } else if (atom63(form)) {
+    return(form);
   } else {
-    if (atom63(form)) {
-      return(form);
-    } else {
-      return(join(["list"], map(quoted, form)));
-    }
+    return(join(["list"], map(quoted, form)));
   }
 };
 var literal = function (s) {
@@ -84,13 +82,13 @@ var stash42 = function (args) {
     var k = undefined;
     for (k in _o) {
       var v = _o[k];
-      var _e10;
+      var _e11;
       if (numeric63(k)) {
-        _e10 = parseInt(k);
+        _e11 = parseInt(k);
       } else {
-        _e10 = k;
+        _e11 = k;
       }
-      var _k = _e10;
+      var _k = _e11;
       if (! number63(_k)) {
         add(l, literal(_k));
         add(l, v);
@@ -121,28 +119,28 @@ bind = function (lh, rh) {
     var k = undefined;
     for (k in _o1) {
       var v = _o1[k];
-      var _e11;
-      if (numeric63(k)) {
-        _e11 = parseInt(k);
-      } else {
-        _e11 = k;
-      }
-      var _k1 = _e11;
       var _e12;
-      if (_k1 === "rest") {
-        _e12 = ["cut", id, _35(lh)];
+      if (numeric63(k)) {
+        _e12 = parseInt(k);
       } else {
-        _e12 = ["get", id, ["quote", bias(_k1)]];
+        _e12 = k;
       }
-      var x = _e12;
+      var _k1 = _e12;
+      var _e13;
+      if (_k1 === "rest") {
+        _e13 = ["cut", id, _35(lh)];
+      } else {
+        _e13 = ["get", id, ["quote", bias(_k1)]];
+      }
+      var x = _e13;
       if (is63(_k1)) {
-        var _e13;
+        var _e14;
         if (v === true) {
-          _e13 = _k1;
+          _e14 = _k1;
         } else {
-          _e13 = v;
+          _e14 = v;
         }
-        var _k2 = _e13;
+        var _k2 = _e14;
         bs = join(bs, bind(_k2, x));
       }
     }
@@ -171,13 +169,13 @@ bind42 = function (args, body) {
     var k = undefined;
     for (k in _o2) {
       var v = _o2[k];
-      var _e14;
+      var _e15;
       if (numeric63(k)) {
-        _e14 = parseInt(k);
+        _e15 = parseInt(k);
       } else {
-        _e14 = k;
+        _e15 = k;
       }
-      var _k3 = _e14;
+      var _k3 = _e15;
       if (number63(_k3)) {
         if (atom63(v)) {
           add(args1, v);
@@ -190,13 +188,13 @@ bind42 = function (args, body) {
     }
     if (keys63(args)) {
       bs = join(bs, [r, rest()]);
-      var _e15;
+      var _e16;
       if (target === "lua") {
-        _e15 = edge(args1);
+        _e16 = edge(args1);
       } else {
-        _e15 = _35(args1);
+        _e16 = _35(args1);
       }
-      var n = _e15;
+      var n = _e16;
       var i = 0;
       while (i < n) {
         var v = args1[i];
@@ -237,13 +235,13 @@ var expand_function = function (_x38) {
   var _i3 = undefined;
   for (_i3 in _o3) {
     var _x39 = _o3[_i3];
-    var _e16;
+    var _e17;
     if (numeric63(_i3)) {
-      _e16 = parseInt(_i3);
+      _e17 = parseInt(_i3);
     } else {
-      _e16 = _i3;
+      _e17 = _i3;
     }
-    var __i3 = _e16;
+    var __i3 = _e17;
     setenv(_x39, {_stash: true, variable: true});
   }
   var _x40 = join(["%function", args], macroexpand(body));
@@ -261,13 +259,13 @@ var expand_definition = function (_x42) {
   var _i4 = undefined;
   for (_i4 in _o4) {
     var _x43 = _o4[_i4];
-    var _e17;
+    var _e18;
     if (numeric63(_i4)) {
-      _e17 = parseInt(_i4);
+      _e18 = parseInt(_i4);
     } else {
-      _e17 = _i4;
+      _e18 = _i4;
     }
-    var __i4 = _e17;
+    var __i4 = _e18;
     setenv(_x43, {_stash: true, variable: true});
   }
   var _x44 = join([x, name, args], macroexpand(body));
@@ -286,32 +284,22 @@ expand1 = function (_x46) {
 macroexpand = function (form) {
   if (symbol63(form)) {
     return(macroexpand(symbol_expansion(form)));
+  } else if (atom63(form)) {
+    return(form);
   } else {
-    if (atom63(form)) {
-      return(form);
+    var x = hd(form);
+    if (x === "%local") {
+      return(expand_local(form));
+    } else if (x === "%function") {
+      return(expand_function(form));
+    } else if (x === "%global-function") {
+      return(expand_definition(form));
+    } else if (x === "%local-function") {
+      return(expand_definition(form));
+    } else if (macro63(x)) {
+      return(expand_macro(form));
     } else {
-      var x = hd(form);
-      if (x === "%local") {
-        return(expand_local(form));
-      } else {
-        if (x === "%function") {
-          return(expand_function(form));
-        } else {
-          if (x === "%global-function") {
-            return(expand_definition(form));
-          } else {
-            if (x === "%local-function") {
-              return(expand_definition(form));
-            } else {
-              if (macro63(x)) {
-                return(expand_macro(form));
-              } else {
-                return(map(macroexpand, form));
-              }
-            }
-          }
-        }
-      }
+      return(map(macroexpand, form));
     }
   }
 };
@@ -321,21 +309,21 @@ var quasiquote_list = function (form, depth) {
   var k = undefined;
   for (k in _o5) {
     var v = _o5[k];
-    var _e18;
+    var _e19;
     if (numeric63(k)) {
-      _e18 = parseInt(k);
+      _e19 = parseInt(k);
     } else {
-      _e18 = k;
+      _e19 = k;
     }
-    var _k4 = _e18;
+    var _k4 = _e19;
     if (! number63(_k4)) {
-      var _e19;
+      var _e20;
       if (quasisplice63(v, depth)) {
-        _e19 = quasiexpand(v[1]);
+        _e20 = quasiexpand(v[1]);
       } else {
-        _e19 = quasiexpand(v, depth);
+        _e20 = quasiexpand(v, depth);
       }
-      var _v = _e19;
+      var _v = _e20;
       last(xs)[_k4] = _v;
     }
   }
@@ -365,37 +353,25 @@ quasiexpand = function (form, depth) {
   if (quasiquoting63(depth)) {
     if (atom63(form)) {
       return(["quote", form]);
+    } else if (can_unquote63(depth) && hd(form) === "unquote") {
+      return(quasiexpand(form[1]));
+    } else if (hd(form) === "unquote" || hd(form) === "unquote-splicing") {
+      return(quasiquote_list(form, depth - 1));
+    } else if (hd(form) === "quasiquote") {
+      return(quasiquote_list(form, depth + 1));
     } else {
-      if (can_unquote63(depth) && hd(form) === "unquote") {
-        return(quasiexpand(form[1]));
-      } else {
-        if (hd(form) === "unquote" || hd(form) === "unquote-splicing") {
-          return(quasiquote_list(form, depth - 1));
-        } else {
-          if (hd(form) === "quasiquote") {
-            return(quasiquote_list(form, depth + 1));
-          } else {
-            return(quasiquote_list(form, depth));
-          }
-        }
-      }
+      return(quasiquote_list(form, depth));
     }
+  } else if (atom63(form)) {
+    return(form);
+  } else if (hd(form) === "quote") {
+    return(form);
+  } else if (hd(form) === "quasiquote") {
+    return(quasiexpand(form[1], 1));
   } else {
-    if (atom63(form)) {
-      return(form);
-    } else {
-      if (hd(form) === "quote") {
-        return(form);
-      } else {
-        if (hd(form) === "quasiquote") {
-          return(quasiexpand(form[1], 1));
-        } else {
-          return(map(function (x) {
-            return(quasiexpand(x, depth));
-          }, form));
-        }
-      }
-    }
+    return(map(function (x) {
+      return(quasiexpand(x, depth));
+    }, form));
   }
 };
 expand_if = function (_x54) {
@@ -405,10 +381,8 @@ expand_if = function (_x54) {
   var c = cut(_id4, 2);
   if (is63(b)) {
     return([join(["%if", a, b], expand_if(c))]);
-  } else {
-    if (is63(a)) {
-      return([a]);
-    }
+  } else if (is63(a)) {
+    return([a]);
   }
 };
 indent_level = 0;
@@ -421,7 +395,7 @@ indentation = function () {
   }
   return(s);
 };
-var reserved = {"try": true, "delete": true, "false": true, "function": true, "break": true, "repeat": true, "var": true, "throw": true, "%": true, "else": true, "with": true, "nil": true, "or": true, "do": true, "+": true, "/": true, "debugger": true, "until": true, "new": true, ">": true, "then": true, "-": true, "typeof": true, "=": true, "==": true, "local": true, "void": true, "continue": true, "<=": true, "catch": true, "while": true, "not": true, "default": true, ">=": true, "and": true, "elseif": true, "true": true, "<": true, "instanceof": true, "case": true, "in": true, "finally": true, "*": true, "end": true, "switch": true, "for": true, "if": true, "return": true};
+var reserved = {"throw": true, "or": true, "then": true, "in": true, "end": true, "while": true, "continue": true, "*": true, "not": true, "return": true, "repeat": true, "<": true, ">": true, "until": true, "and": true, "false": true, "with": true, "delete": true, "break": true, "new": true, "function": true, "if": true, "else": true, "nil": true, "instanceof": true, "switch": true, "var": true, "typeof": true, "for": true, "local": true, "try": true, "do": true, "default": true, "-": true, "void": true, "/": true, "elseif": true, "debugger": true, "+": true, "catch": true, "finally": true, "true": true, "<=": true, "==": true, "case": true, ">=": true, "=": true, "%": true};
 reserved63 = function (x) {
   return(reserved[x]);
 };
@@ -446,12 +420,10 @@ key = function (k) {
   var i = inner(k);
   if (valid_id63(i)) {
     return(i);
+  } else if (target === "js") {
+    return(k);
   } else {
-    if (target === "js") {
-      return(k);
-    } else {
-      return("[" + k + "]");
-    }
+    return("[" + k + "]");
   }
 };
 mapo = function (f, t) {
@@ -460,13 +432,13 @@ mapo = function (f, t) {
   var k = undefined;
   for (k in _o6) {
     var v = _o6[k];
-    var _e20;
+    var _e21;
     if (numeric63(k)) {
-      _e20 = parseInt(k);
+      _e21 = parseInt(k);
     } else {
-      _e20 = k;
+      _e21 = k;
     }
-    var _k5 = _e20;
+    var _k5 = _e21;
     var x = f(v);
     if (is63(x)) {
       add(o, literal(_k5));
@@ -477,40 +449,40 @@ mapo = function (f, t) {
 };
 var __x59 = [];
 var _x60 = [];
-_x60.lua = "not";
 _x60.js = "!";
+_x60.lua = "not";
 __x59["not"] = _x60;
 var __x61 = [];
 __x61["/"] = true;
-__x61["%"] = true;
 __x61["*"] = true;
+__x61["%"] = true;
 var __x62 = [];
 __x62["+"] = true;
 __x62["-"] = true;
 var __x63 = [];
 var _x64 = [];
-_x64.lua = "..";
 _x64.js = "+";
+_x64.lua = "..";
 __x63.cat = _x64;
 var __x65 = [];
-__x65[">="] = true;
 __x65["<"] = true;
-__x65["<="] = true;
 __x65[">"] = true;
+__x65[">="] = true;
+__x65["<="] = true;
 var __x66 = [];
 var _x67 = [];
-_x67.lua = "==";
 _x67.js = "===";
+_x67.lua = "==";
 __x66["="] = _x67;
 var __x68 = [];
 var _x69 = [];
-_x69.lua = "and";
 _x69.js = "&&";
+_x69.lua = "and";
 __x68["and"] = _x69;
 var __x70 = [];
 var _x71 = [];
-_x71.lua = "or";
 _x71.js = "||";
+_x71.lua = "or";
 __x70["or"] = _x71;
 var infix = [__x59, __x61, __x62, __x63, __x65, __x66, __x68, __x70];
 var unary63 = function (form) {
@@ -525,13 +497,13 @@ var precedence = function (form) {
     var k = undefined;
     for (k in _o7) {
       var v = _o7[k];
-      var _e21;
+      var _e22;
       if (numeric63(k)) {
-        _e21 = parseInt(k);
+        _e22 = parseInt(k);
       } else {
-        _e21 = k;
+        _e22 = k;
       }
-      var _k6 = _e21;
+      var _k6 = _e22;
       if (v[hd(form)]) {
         return(index(_k6));
       }
@@ -544,10 +516,8 @@ var getop = function (op) {
     var x = level[op];
     if (x === true) {
       return(op);
-    } else {
-      if (is63(x)) {
-        return(x[target]);
-      }
+    } else if (is63(x)) {
+      return(x[target]);
     }
   }, infix));
 };
@@ -572,48 +542,48 @@ var escape_newlines = function (s) {
   var i = 0;
   while (i < _35(s)) {
     var c = char(s, i);
-    var _e22;
+    var _e23;
     if (c === "\n") {
-      _e22 = "\\n";
+      _e23 = "\\n";
     } else {
-      _e22 = c;
+      _e23 = c;
     }
-    s1 = s1 + _e22;
+    s1 = s1 + _e23;
     i = i + 1;
   }
   return(s1);
 };
 var id = function (id) {
-  var _e23;
+  var _e24;
   if (number_code63(code(id, 0))) {
-    _e23 = "_";
+    _e24 = "_";
   } else {
-    _e23 = "";
+    _e24 = "";
   }
-  var id1 = _e23;
+  var id1 = _e24;
   var i = 0;
   while (i < _35(id)) {
     var c = char(id, i);
     var n = code(c);
-    var _e24;
+    var _e25;
     if (c === "-") {
-      _e24 = "_";
+      _e25 = "_";
     } else {
-      var _e25;
+      var _e26;
       if (valid_code63(n)) {
-        _e25 = c;
+        _e26 = c;
       } else {
-        var _e26;
+        var _e27;
         if (i === 0) {
-          _e26 = "_" + n;
+          _e27 = "_" + n;
         } else {
-          _e26 = n;
+          _e27 = n;
         }
-        _e25 = _e26;
+        _e26 = _e27;
       }
-      _e24 = _e25;
+      _e25 = _e26;
     }
-    var c1 = _e24;
+    var c1 = _e25;
     id1 = id1 + c1;
     i = i + 1;
   }
@@ -626,59 +596,39 @@ var id = function (id) {
 var compile_atom = function (x) {
   if (x === "nil" && target === "lua") {
     return(x);
-  } else {
-    if (x === "nil") {
-      return("undefined");
+  } else if (x === "nil") {
+    return("undefined");
+  } else if (id_literal63(x)) {
+    return(inner(x));
+  } else if (string_literal63(x)) {
+    return(escape_newlines(x));
+  } else if (string63(x)) {
+    return(id(x));
+  } else if (boolean63(x)) {
+    if (x) {
+      return("true");
     } else {
-      if (id_literal63(x)) {
-        return(inner(x));
-      } else {
-        if (string_literal63(x)) {
-          return(escape_newlines(x));
-        } else {
-          if (string63(x)) {
-            return(id(x));
-          } else {
-            if (boolean63(x)) {
-              if (x) {
-                return("true");
-              } else {
-                return("false");
-              }
-            } else {
-              if (nan63(x)) {
-                return("nan");
-              } else {
-                if (x === inf) {
-                  return("inf");
-                } else {
-                  if (x === -inf) {
-                    return("-inf");
-                  } else {
-                    if (number63(x)) {
-                      return(x + "");
-                    } else {
-                      throw new Error("Cannot compile atom: " + str(x));
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+      return("false");
     }
+  } else if (nan63(x)) {
+    return("nan");
+  } else if (x === inf) {
+    return("inf");
+  } else if (x === -inf) {
+    return("-inf");
+  } else if (number63(x)) {
+    return(x + "");
+  } else {
+    throw new Error("Cannot compile atom: " + str(x));
   }
 };
 var terminator = function (stmt63) {
   if (! stmt63) {
     return("");
+  } else if (target === "js") {
+    return(";\n");
   } else {
-    if (target === "js") {
-      return(";\n");
-    } else {
-      return("\n");
-    }
+    return("\n");
   }
 };
 var compile_special = function (form, stmt63) {
@@ -711,13 +661,13 @@ var op_delims = function (parent, child) {
   var _child = destash33(child, _r56);
   var _id7 = _r56;
   var right = _id7.right;
-  var _e27;
+  var _e28;
   if (right) {
-    _e27 = _6261;
+    _e28 = _6261;
   } else {
-    _e27 = _62;
+    _e28 = _62;
   }
-  if (_e27(precedence(_child), precedence(_parent))) {
+  if (_e28(precedence(_child), precedence(_parent))) {
     return(["(", ")"]);
   } else {
     return(["", ""]);
@@ -751,33 +701,33 @@ compile_function = function (args, body) {
   var _id12 = _r58;
   var name = _id12.name;
   var prefix = _id12.prefix;
-  var _e28;
+  var _e29;
   if (name) {
-    _e28 = compile(name);
+    _e29 = compile(name);
   } else {
-    _e28 = "";
+    _e29 = "";
   }
-  var _id13 = _e28;
+  var _id13 = _e29;
   var _args1 = compile_args(_args);
   indent_level = indent_level + 1;
   var _x76 = compile(_body, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
   var _body1 = _x76;
   var ind = indentation();
-  var _e29;
-  if (prefix) {
-    _e29 = prefix + " ";
-  } else {
-    _e29 = "";
-  }
-  var p = _e29;
   var _e30;
-  if (target === "js") {
-    _e30 = "";
+  if (prefix) {
+    _e30 = prefix + " ";
   } else {
-    _e30 = "end";
+    _e30 = "";
   }
-  var tr = _e30;
+  var p = _e30;
+  var _e31;
+  if (target === "js") {
+    _e31 = "";
+  } else {
+    _e31 = "end";
+  }
+  var tr = _e31;
   if (name) {
     tr = tr + "\n";
   }
@@ -797,33 +747,31 @@ compile = function (form) {
   var stmt = _id14.stmt;
   if (nil63(_form)) {
     return("");
+  } else if (special_form63(_form)) {
+    return(compile_special(_form, stmt));
   } else {
-    if (special_form63(_form)) {
-      return(compile_special(_form, stmt));
+    var tr = terminator(stmt);
+    var _e32;
+    if (stmt) {
+      _e32 = indentation();
     } else {
-      var tr = terminator(stmt);
-      var _e31;
-      if (stmt) {
-        _e31 = indentation();
-      } else {
-        _e31 = "";
-      }
-      var ind = _e31;
-      var _e32;
-      if (atom63(_form)) {
-        _e32 = compile_atom(_form);
-      } else {
-        var _e33;
-        if (infix63(hd(_form))) {
-          _e33 = compile_infix(_form);
-        } else {
-          _e33 = compile_call(_form);
-        }
-        _e32 = _e33;
-      }
-      var _form1 = _e32;
-      return(ind + _form1 + tr);
+      _e32 = "";
     }
+    var ind = _e32;
+    var _e33;
+    if (atom63(_form)) {
+      _e33 = compile_atom(_form);
+    } else {
+      var _e34;
+      if (infix63(hd(_form))) {
+        _e34 = compile_infix(_form);
+      } else {
+        _e34 = compile_call(_form);
+      }
+      _e33 = _e34;
+    }
+    var _form1 = _e33;
+    return(ind + _form1 + tr);
   }
 };
 var lower_statement = function (form, tail63) {
@@ -831,16 +779,12 @@ var lower_statement = function (form, tail63) {
   var e = lower(form, hoist, true, tail63);
   if (some63(hoist) && is63(e)) {
     return(join(["do"], hoist, [e]));
+  } else if (is63(e)) {
+    return(e);
+  } else if (_35(hoist) > 1) {
+    return(join(["do"], hoist));
   } else {
-    if (is63(e)) {
-      return(e);
-    } else {
-      if (_35(hoist) > 1) {
-        return(join(["do"], hoist));
-      } else {
-        return(hd(hoist));
-      }
-    }
+    return(hd(hoist));
   }
 };
 var lower_body = function (body, tail63) {
@@ -888,19 +832,19 @@ var lower_if = function (args, hoist, stmt63, tail63) {
   var _then = _id16[1];
   var _else = _id16[2];
   if (stmt63) {
-    var _e35;
+    var _e36;
     if (is63(_else)) {
-      _e35 = [lower_body([_else], tail63)];
+      _e36 = [lower_body([_else], tail63)];
     }
-    return(add(hoist, join(["%if", lower(cond, hoist), lower_body([_then], tail63)], _e35)));
+    return(add(hoist, join(["%if", lower(cond, hoist), lower_body([_then], tail63)], _e36)));
   } else {
     var e = unique("e");
     add(hoist, ["%local", e]);
-    var _e34;
+    var _e35;
     if (is63(_else)) {
-      _e34 = [lower(["%set", e, _else])];
+      _e35 = [lower(["%set", e, _else])];
     }
-    add(hoist, join(["%if", lower(cond, hoist), lower(["%set", e, _then])], _e34));
+    add(hoist, join(["%if", lower(cond, hoist), lower(["%set", e, _then])], _e35));
     return(e);
   }
 };
@@ -912,13 +856,13 @@ var lower_short = function (x, args, hoist) {
   var b1 = lower(b, hoist1);
   if (some63(hoist1)) {
     var _id18 = unique("id");
-    var _e36;
+    var _e37;
     if (x === "and") {
-      _e36 = ["%if", _id18, b, _id18];
+      _e37 = ["%if", _id18, b, _id18];
     } else {
-      _e36 = ["%if", _id18, _id18, b];
+      _e37 = ["%if", _id18, _id18, b];
     }
-    return(lower(["do", ["%local", _id18, a], _e36], hoist));
+    return(lower(["do", ["%local", _id18, a], _e37], hoist));
   } else {
     return([x, lower(a, hoist), b1]);
   }
@@ -932,13 +876,13 @@ var lower_while = function (args, hoist) {
   var body = cut(_id19, 1);
   var pre = [];
   var _c = lower(c, pre);
-  var _e37;
+  var _e38;
   if (none63(pre)) {
-    _e37 = ["while", _c, lower_body(body)];
+    _e38 = ["while", _c, lower_body(body)];
   } else {
-    _e37 = ["while", true, join(["do"], pre, [["%if", ["not", _c], ["break"]], lower_body(body)])];
+    _e38 = ["while", true, join(["do"], pre, [["%if", ["not", _c], ["break"]], lower_body(body)])];
   }
-  return(add(hoist, _e37));
+  return(add(hoist, _e38));
 };
 var lower_for = function (args, hoist) {
   var _id20 = args;
@@ -988,62 +932,38 @@ var lower_special = function (form, hoist) {
 lower = function (form, hoist, stmt63, tail63) {
   if (atom63(form)) {
     return(form);
+  } else if (empty63(form)) {
+    return(["%array"]);
+  } else if (nil63(hoist)) {
+    return(lower_statement(form));
+  } else if (lower_infix63(form)) {
+    return(lower_infix(form, hoist));
   } else {
-    if (empty63(form)) {
-      return(["%array"]);
+    var _id24 = form;
+    var x = _id24[0];
+    var args = cut(_id24, 1);
+    if (x === "do") {
+      return(lower_do(args, hoist, stmt63, tail63));
+    } else if (x === "%set") {
+      return(lower_set(args, hoist, stmt63, tail63));
+    } else if (x === "%if") {
+      return(lower_if(args, hoist, stmt63, tail63));
+    } else if (x === "%try") {
+      return(lower_try(args, hoist, tail63));
+    } else if (x === "while") {
+      return(lower_while(args, hoist));
+    } else if (x === "%for") {
+      return(lower_for(args, hoist));
+    } else if (x === "%function") {
+      return(lower_function(args));
+    } else if (x === "%local-function" || x === "%global-function") {
+      return(lower_definition(x, args, hoist));
+    } else if (in63(x, ["and", "or"])) {
+      return(lower_short(x, args, hoist));
+    } else if (statement63(x)) {
+      return(lower_special(form, hoist));
     } else {
-      if (nil63(hoist)) {
-        return(lower_statement(form));
-      } else {
-        if (lower_infix63(form)) {
-          return(lower_infix(form, hoist));
-        } else {
-          var _id24 = form;
-          var x = _id24[0];
-          var args = cut(_id24, 1);
-          if (x === "do") {
-            return(lower_do(args, hoist, stmt63, tail63));
-          } else {
-            if (x === "%set") {
-              return(lower_set(args, hoist, stmt63, tail63));
-            } else {
-              if (x === "%if") {
-                return(lower_if(args, hoist, stmt63, tail63));
-              } else {
-                if (x === "%try") {
-                  return(lower_try(args, hoist, tail63));
-                } else {
-                  if (x === "while") {
-                    return(lower_while(args, hoist));
-                  } else {
-                    if (x === "%for") {
-                      return(lower_for(args, hoist));
-                    } else {
-                      if (x === "%function") {
-                        return(lower_function(args));
-                      } else {
-                        if (x === "%local-function" || x === "%global-function") {
-                          return(lower_definition(x, args, hoist));
-                        } else {
-                          if (in63(x, ["and", "or"])) {
-                            return(lower_short(x, args, hoist));
-                          } else {
-                            if (statement63(x)) {
-                              return(lower_special(form, hoist));
-                            } else {
-                              return(lower_call(form, hoist));
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+      return(lower_call(form, hoist));
     }
   }
 };
@@ -1061,7 +981,7 @@ eval = function (form) {
   run(code);
   return(_37result);
 };
-setenv("do", {_stash: true, special: function () {
+setenv("do", {_stash: true, tr: true, special: function () {
   var forms = unstash(Array.prototype.slice.call(arguments, 0));
   var s = "";
   var _x115 = forms;
@@ -1077,42 +997,57 @@ setenv("do", {_stash: true, special: function () {
     _i12 = _i12 + 1;
   }
   return(s);
-}, tr: true, stmt: true});
-setenv("%if", {_stash: true, special: function (cond, cons, alt) {
+}, stmt: true});
+setenv("%if", {_stash: true, tr: true, special: function (cond, cons, alt) {
+  var ind = indentation();
   var _cond1 = compile(cond);
   indent_level = indent_level + 1;
   var _x118 = compile(cons, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
   var _cons1 = _x118;
-  var _e38;
-  if (alt) {
-    indent_level = indent_level + 1;
-    var _x119 = compile(alt, {_stash: true, stmt: true});
-    indent_level = indent_level - 1;
-    _e38 = _x119;
+  var elif = obj63(alt) && hd(alt) === "%if";
+  var _e39;
+  if (elif) {
+    _e39 = clip(compile(alt, {_stash: true, stmt: true}), _35(ind));
+  } else {
+    var _e40;
+    if (alt) {
+      indent_level = indent_level + 1;
+      var _x119 = compile(alt, {_stash: true, stmt: true});
+      indent_level = indent_level - 1;
+      _e40 = _x119;
+    }
+    _e39 = _e40;
   }
-  var _alt1 = _e38;
-  var ind = indentation();
+  var _alt1 = _e39;
   var s = "";
   if (target === "js") {
     s = s + ind + "if (" + _cond1 + ") {\n" + _cons1 + ind + "}";
   } else {
     s = s + ind + "if " + _cond1 + " then\n" + _cons1;
   }
-  if (_alt1 && target === "js") {
-    s = s + " else {\n" + _alt1 + ind + "}";
-  } else {
-    if (_alt1) {
+  if (elif) {
+    if (target === "js") {
+      s = s + " else " + _alt1;
+    } else {
+      s = s + ind + "else" + _alt1;
+    }
+  } else if (_alt1) {
+    if (target === "js") {
+      s = s + " else {\n" + _alt1 + ind + "}";
+    } else {
       s = s + ind + "else\n" + _alt1;
     }
   }
-  if (target === "lua") {
+  if (elif) {
+    return(s);
+  } else if (target === "lua") {
     return(s + ind + "end\n");
   } else {
     return(s + "\n");
   }
-}, tr: true, stmt: true});
-setenv("while", {_stash: true, special: function (cond, form) {
+}, stmt: true});
+setenv("while", {_stash: true, tr: true, special: function (cond, form) {
   var _cond3 = compile(cond);
   indent_level = indent_level + 1;
   var _x121 = compile(form, {_stash: true, stmt: true});
@@ -1124,8 +1059,8 @@ setenv("while", {_stash: true, special: function (cond, form) {
   } else {
     return(ind + "while " + _cond3 + " do\n" + body + ind + "end\n");
   }
-}, tr: true, stmt: true});
-setenv("%for", {_stash: true, special: function (t, k, form) {
+}, stmt: true});
+setenv("%for", {_stash: true, tr: true, special: function (t, k, form) {
   var _t1 = compile(t);
   var ind = indentation();
   indent_level = indent_level + 1;
@@ -1137,8 +1072,8 @@ setenv("%for", {_stash: true, special: function (t, k, form) {
   } else {
     return(ind + "for (" + k + " in " + _t1 + ") {\n" + body + ind + "}\n");
   }
-}, tr: true, stmt: true});
-setenv("%try", {_stash: true, special: function (form) {
+}, stmt: true});
+setenv("%try", {_stash: true, tr: true, special: function (form) {
   var e = unique("e");
   var ind = indentation();
   indent_level = indent_level + 1;
@@ -1151,7 +1086,7 @@ setenv("%try", {_stash: true, special: function (form) {
   indent_level = indent_level - 1;
   var h = _x131;
   return(ind + "try {\n" + body + ind + "}\n" + ind + "catch (" + e + ") {\n" + h + ind + "}\n");
-}, tr: true, stmt: true});
+}, stmt: true});
 setenv("%delete", {_stash: true, special: function (place) {
   return(indentation() + "delete " + compile(place));
 }, stmt: true});
@@ -1161,30 +1096,30 @@ setenv("break", {_stash: true, special: function () {
 setenv("%function", {_stash: true, special: function (args, body) {
   return(compile_function(args, body));
 }});
-setenv("%global-function", {_stash: true, special: function (name, args, body) {
+setenv("%global-function", {_stash: true, tr: true, special: function (name, args, body) {
   if (target === "lua") {
     var x = compile_function(args, body, {_stash: true, name: name});
     return(indentation() + x);
   } else {
     return(compile(["%set", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}, tr: true, stmt: true});
-setenv("%local-function", {_stash: true, special: function (name, args, body) {
+}, stmt: true});
+setenv("%local-function", {_stash: true, tr: true, special: function (name, args, body) {
   if (target === "lua") {
     var x = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
     return(indentation() + x);
   } else {
     return(compile(["%local", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
-}, tr: true, stmt: true});
+}, stmt: true});
 setenv("return", {_stash: true, special: function (x) {
-  var _e39;
+  var _e41;
   if (nil63(x)) {
-    _e39 = "return";
+    _e41 = "return";
   } else {
-    _e39 = "return(" + compile(x) + ")";
+    _e41 = "return(" + compile(x) + ")";
   }
-  var _x141 = _e39;
+  var _x141 = _e41;
   return(indentation() + _x141);
 }, stmt: true});
 setenv("new", {_stash: true, special: function (x) {
@@ -1194,44 +1129,44 @@ setenv("typeof", {_stash: true, special: function (x) {
   return("typeof(" + compile(x) + ")");
 }});
 setenv("error", {_stash: true, special: function (x) {
-  var _e40;
+  var _e42;
   if (target === "js") {
-    _e40 = "throw " + compile(["new", ["Error", x]]);
+    _e42 = "throw " + compile(["new", ["Error", x]]);
   } else {
-    _e40 = "error(" + compile(x) + ")";
+    _e42 = "error(" + compile(x) + ")";
   }
-  var e = _e40;
+  var e = _e42;
   return(indentation() + e);
 }, stmt: true});
 setenv("%local", {_stash: true, special: function (name, value) {
   var _id26 = compile(name);
   var value1 = compile(value);
-  var _e41;
+  var _e43;
   if (is63(value)) {
-    _e41 = " = " + value1;
+    _e43 = " = " + value1;
   } else {
-    _e41 = "";
+    _e43 = "";
   }
-  var rh = _e41;
-  var _e42;
+  var rh = _e43;
+  var _e44;
   if (target === "js") {
-    _e42 = "var ";
+    _e44 = "var ";
   } else {
-    _e42 = "local ";
+    _e44 = "local ";
   }
-  var keyword = _e42;
+  var keyword = _e44;
   var ind = indentation();
   return(ind + keyword + _id26 + rh);
 }, stmt: true});
 setenv("%set", {_stash: true, special: function (lh, rh) {
   var _lh1 = compile(lh);
-  var _e43;
+  var _e45;
   if (nil63(rh)) {
-    _e43 = "nil";
+    _e45 = "nil";
   } else {
-    _e43 = rh;
+    _e45 = rh;
   }
-  var _rh1 = compile(_e43);
+  var _rh1 = compile(_e45);
   return(indentation() + _lh1 + " = " + _rh1);
 }, stmt: true});
 setenv("get", {_stash: true, special: function (t, k) {
@@ -1248,33 +1183,33 @@ setenv("get", {_stash: true, special: function (t, k) {
 }});
 setenv("%array", {_stash: true, special: function () {
   var forms = unstash(Array.prototype.slice.call(arguments, 0));
-  var _e44;
+  var _e46;
   if (target === "lua") {
-    _e44 = "{";
+    _e46 = "{";
   } else {
-    _e44 = "[";
+    _e46 = "[";
   }
-  var open = _e44;
-  var _e45;
+  var open = _e46;
+  var _e47;
   if (target === "lua") {
-    _e45 = "}";
+    _e47 = "}";
   } else {
-    _e45 = "]";
+    _e47 = "]";
   }
-  var close = _e45;
+  var close = _e47;
   var s = "";
   var c = "";
   var _o9 = forms;
   var k = undefined;
   for (k in _o9) {
     var v = _o9[k];
-    var _e46;
+    var _e48;
     if (numeric63(k)) {
-      _e46 = parseInt(k);
+      _e48 = parseInt(k);
     } else {
-      _e46 = k;
+      _e48 = k;
     }
-    var _k7 = _e46;
+    var _k7 = _e48;
     if (number63(_k7)) {
       s = s + c + compile(v);
       c = ", ";
@@ -1286,24 +1221,24 @@ setenv("%object", {_stash: true, special: function () {
   var forms = unstash(Array.prototype.slice.call(arguments, 0));
   var s = "{";
   var c = "";
-  var _e47;
+  var _e49;
   if (target === "lua") {
-    _e47 = " = ";
+    _e49 = " = ";
   } else {
-    _e47 = ": ";
+    _e49 = ": ";
   }
-  var sep = _e47;
+  var sep = _e49;
   var _o11 = pair(forms);
   var k = undefined;
   for (k in _o11) {
     var v = _o11[k];
-    var _e48;
+    var _e50;
     if (numeric63(k)) {
-      _e48 = parseInt(k);
+      _e50 = parseInt(k);
     } else {
-      _e48 = k;
+      _e50 = k;
     }
-    var _k9 = _e48;
+    var _k9 = _e50;
     if (number63(_k9)) {
       var _id28 = v;
       var _k10 = _id28[0];

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -167,12 +167,10 @@ reverse = function (l) {
 reduce = function (f, x) {
   if (none63(x)) {
     return(undefined);
+  } else if (one63(x)) {
+    return(hd(x));
   } else {
-    if (one63(x)) {
-      return(hd(x));
-    } else {
-      return(f(hd(x), reduce(f, tl(x))));
-    }
+    return(f(hd(x), reduce(f, tl(x))));
   }
 };
 join = function () {
@@ -539,87 +537,69 @@ escape = function (s) {
 str = function (x, stack) {
   if (nil63(x)) {
     return("nil");
-  } else {
-    if (nan63(x)) {
-      return("nan");
+  } else if (nan63(x)) {
+    return("nan");
+  } else if (x === inf) {
+    return("inf");
+  } else if (x === -inf) {
+    return("-inf");
+  } else if (boolean63(x)) {
+    if (x) {
+      return("true");
     } else {
-      if (x === inf) {
-        return("inf");
+      return("false");
+    }
+  } else if (string63(x)) {
+    return(escape(x));
+  } else if (atom63(x)) {
+    return(tostring(x));
+  } else if (function63(x)) {
+    return("function");
+  } else if (stack && in63(x, stack)) {
+    return("circular");
+  } else if (false) {
+    return(escape(tostring(x)));
+  } else {
+    var s = "(";
+    var sp = "";
+    var xs = [];
+    var ks = [];
+    var l = stack || [];
+    add(l, x);
+    var _o10 = x;
+    var k = undefined;
+    for (k in _o10) {
+      var v = _o10[k];
+      var _e16;
+      if (numeric63(k)) {
+        _e16 = parseInt(k);
       } else {
-        if (x === -inf) {
-          return("-inf");
-        } else {
-          if (boolean63(x)) {
-            if (x) {
-              return("true");
-            } else {
-              return("false");
-            }
-          } else {
-            if (string63(x)) {
-              return(escape(x));
-            } else {
-              if (atom63(x)) {
-                return(tostring(x));
-              } else {
-                if (function63(x)) {
-                  return("function");
-                } else {
-                  if (stack && in63(x, stack)) {
-                    return("circular");
-                  } else {
-                    if (false) {
-                      return(escape(tostring(x)));
-                    } else {
-                      var s = "(";
-                      var sp = "";
-                      var xs = [];
-                      var ks = [];
-                      var l = stack || [];
-                      add(l, x);
-                      var _o10 = x;
-                      var k = undefined;
-                      for (k in _o10) {
-                        var v = _o10[k];
-                        var _e16;
-                        if (numeric63(k)) {
-                          _e16 = parseInt(k);
-                        } else {
-                          _e16 = k;
-                        }
-                        var _k8 = _e16;
-                        if (number63(_k8)) {
-                          xs[_k8] = str(v, l);
-                        } else {
-                          add(ks, _k8 + ":");
-                          add(ks, str(v, l));
-                        }
-                      }
-                      drop(l);
-                      var _o11 = join(xs, ks);
-                      var _i14 = undefined;
-                      for (_i14 in _o11) {
-                        var v = _o11[_i14];
-                        var _e17;
-                        if (numeric63(_i14)) {
-                          _e17 = parseInt(_i14);
-                        } else {
-                          _e17 = _i14;
-                        }
-                        var __i14 = _e17;
-                        s = s + sp + v;
-                        sp = " ";
-                      }
-                      return(s + ")");
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+        _e16 = k;
+      }
+      var _k8 = _e16;
+      if (number63(_k8)) {
+        xs[_k8] = str(v, l);
+      } else {
+        add(ks, _k8 + ":");
+        add(ks, str(v, l));
       }
     }
+    drop(l);
+    var _o11 = join(xs, ks);
+    var _i14 = undefined;
+    for (_i14 in _o11) {
+      var v = _o11[_i14];
+      var _e17;
+      if (numeric63(_i14)) {
+        _e17 = parseInt(_i14);
+      } else {
+        _e17 = _i14;
+      }
+      var __i14 = _e17;
+      s = s + sp + v;
+      sp = " ";
+    }
+    return(s + ")");
   }
 };
 apply = function (f, args) {
@@ -705,10 +685,8 @@ setenv("set", {_stash: true, macro: function () {
 setenv("at", {_stash: true, macro: function (l, i) {
   if (target === "lua" && number63(i)) {
     i = i + 1;
-  } else {
-    if (target === "lua") {
-      i = ["+", i, 1];
-    }
+  } else if (target === "lua") {
+    i = ["+", i, 1];
   }
   return(["get", l, i]);
 }});
@@ -766,18 +744,12 @@ setenv("case", {_stash: true, macro: function (expr) {
     var b = _id5[1];
     if (nil63(b)) {
       return([a]);
-    } else {
-      if (string63(a) || number63(a)) {
-        return([eq(a), b]);
-      } else {
-        if (one63(a)) {
-          return([eq(hd(a)), b]);
-        } else {
-          if (_35(a) > 1) {
-            return([join(["or"], map(eq, a)), b]);
-          }
-        }
-      }
+    } else if (string63(a) || number63(a)) {
+      return([eq(a), b]);
+    } else if (one63(a)) {
+      return([eq(hd(a)), b]);
+    } else if (_35(a) > 1) {
+      return([join(["or"], map(eq, a)), b]);
     }
   };
   return(["let", x, _expr1, join(["if"], apply(join, map(cl, pair(clauses))))]);
@@ -809,28 +781,26 @@ setenv("let", {_stash: true, macro: function (bs) {
   var body = cut(_id13, 0);
   if (atom63(_bs1)) {
     return(join(["let", [_bs1, hd(body)]], tl(body)));
+  } else if (none63(_bs1)) {
+    return(join(["do"], body));
   } else {
-    if (none63(_bs1)) {
-      return(join(["do"], body));
+    var _id14 = _bs1;
+    var lh = _id14[0];
+    var rh = _id14[1];
+    var bs2 = cut(_id14, 2);
+    var _id15 = bind(lh, rh);
+    var id = _id15[0];
+    var val = _id15[1];
+    var bs1 = cut(_id15, 2);
+    var renames = [];
+    if (bound63(id) || toplevel63()) {
+      var id1 = unique(id);
+      renames = [id, id1];
+      id = id1;
     } else {
-      var _id14 = _bs1;
-      var lh = _id14[0];
-      var rh = _id14[1];
-      var bs2 = cut(_id14, 2);
-      var _id15 = bind(lh, rh);
-      var id = _id15[0];
-      var val = _id15[1];
-      var bs1 = cut(_id15, 2);
-      var renames = [];
-      if (bound63(id) || toplevel63()) {
-        var id1 = unique(id);
-        renames = [id, id1];
-        id = id1;
-      } else {
-        setenv(id, {_stash: true, variable: true});
-      }
-      return(["do", ["%local", id, val], ["let-symbol", renames, join(["let", join(bs1, bs2)], body)]]);
+      setenv(id, {_stash: true, variable: true});
     }
+    return(["do", ["%local", id, val], ["let-symbol", renames, join(["let", join(bs1, bs2)], body)]]);
   }
 }});
 setenv("with", {_stash: true, macro: function (x, v) {
@@ -909,7 +879,7 @@ setenv("define-global", {_stash: true, macro: function (name, x) {
   var _x148 = destash33(x, _r39);
   var _id31 = _r39;
   var body = cut(_id31, 0);
-  setenv(_name7, {_stash: true, variable: true, toplevel: true});
+  setenv(_name7, {_stash: true, toplevel: true, variable: true});
   if (some63(body)) {
     return(join(["%global-function", _name7], bind42(_x148, body)));
   } else {
@@ -998,8 +968,8 @@ setenv("guard", {_stash: true, macro: function (expr) {
     var msg = unique("msg");
     var trace = unique("trace");
     var _x265 = ["obj"];
-    _x265.stack = trace;
     _x265.message = msg;
+    _x265.stack = trace;
     return(["let", [x, "nil", msg, "nil", trace, "nil"], ["if", ["xpcall", ["fn", join(), ["set", x, expr]], ["fn", ["m"], ["set", trace, [["get", "debug", ["quote", "traceback"]]], msg, ["if", ["string?", "m"], ["clip", "m", ["+", ["search", "m", "\": \""], 2]], ["nil?", "m"], "\"\"", ["str", "m"]]]]], ["list", true, x], ["list", false, _x265]]]);
   }
 }});
@@ -1158,10 +1128,8 @@ var eval_print = function (form) {
   var v = _id[1];
   if (! ok) {
     return(print(v.stack));
-  } else {
-    if (is63(v)) {
-      return(print(str(v)));
-    }
+  } else if (is63(v)) {
+    return(print(str(v)));
   }
 };
 var rep = function (s) {
@@ -1218,71 +1186,61 @@ var main = function () {
   var arg = hd(system.argv);
   if (arg && script_file63(arg)) {
     return(load(arg));
+  } else if (arg === "-h" || arg === "--help") {
+    return(usage());
   } else {
-    if (arg === "-h" || arg === "--help") {
-      return(usage());
-    } else {
-      var pre = [];
-      var input = undefined;
-      var output = undefined;
-      var target1 = undefined;
-      var expr = undefined;
-      var argv = system.argv;
-      var i = 0;
-      while (i < _35(argv)) {
-        var a = argv[i];
-        if (a === "-c" || a === "-o" || a === "-t" || a === "-e") {
-          if (i === edge(argv)) {
-            print("missing argument for " + a);
-          } else {
-            i = i + 1;
-            var val = argv[i];
-            if (a === "-c") {
-              input = val;
-            } else {
-              if (a === "-o") {
-                output = val;
-              } else {
-                if (a === "-t") {
-                  target1 = val;
-                } else {
-                  if (a === "-e") {
-                    expr = val;
-                  }
-                }
-              }
-            }
-          }
+    var pre = [];
+    var input = undefined;
+    var output = undefined;
+    var target1 = undefined;
+    var expr = undefined;
+    var argv = system.argv;
+    var i = 0;
+    while (i < _35(argv)) {
+      var a = argv[i];
+      if (a === "-c" || a === "-o" || a === "-t" || a === "-e") {
+        if (i === edge(argv)) {
+          print("missing argument for " + a);
         } else {
-          if (!( "-" === char(a, 0))) {
-            add(pre, a);
+          i = i + 1;
+          var val = argv[i];
+          if (a === "-c") {
+            input = val;
+          } else if (a === "-o") {
+            output = val;
+          } else if (a === "-t") {
+            target1 = val;
+          } else if (a === "-e") {
+            expr = val;
           }
         }
-        i = i + 1;
+      } else if (!( "-" === char(a, 0))) {
+        add(pre, a);
       }
-      var _x2 = pre;
-      var _i = 0;
-      while (_i < _35(_x2)) {
-        var file = _x2[_i];
-        run_file(file);
-        _i = _i + 1;
-      }
-      if (nil63(input)) {
-        if (expr) {
-          return(rep(expr));
-        } else {
-          return(repl());
-        }
+      i = i + 1;
+    }
+    var _x2 = pre;
+    var _i = 0;
+    while (_i < _35(_x2)) {
+      var file = _x2[_i];
+      run_file(file);
+      _i = _i + 1;
+    }
+    if (nil63(input)) {
+      if (expr) {
+        return(rep(expr));
       } else {
-        if (target1) {
-          target = target1;
-        }
-        var code = compile_file(input);
-        if (nil63(output) || output === "-") {
-          return(print(code));
-        } else {
-          return(system["write-file"](output, code));
-        }
+        return(repl());
+      }
+    } else {
+      if (target1) {
+        target = target1;
+      }
+      var code = compile_file(input);
+      if (nil63(output) || output === "-") {
+        return(print(code));
+      } else {
+        return(system["write-file"](output, code));
       }
     }
   }

--- a/bin/reader.js
+++ b/bin/reader.js
@@ -1,12 +1,12 @@
-var delimiters = {"\n": true, "(": true, ";": true, ")": true};
-var whitespace = {"\t": true, " ": true, "\n": true};
+var delimiters = {")": true, "\n": true, ";": true, "(": true};
+var whitespace = {"\t": true, "\n": true, " ": true};
 var stream = function (str, more) {
-  return({more: more, len: _35(str), pos: 0, string: str});
+  return({len: _35(str), string: str, more: more, pos: 0});
 };
 var peek_char = function (s) {
   var _id = s;
-  var pos = _id.pos;
   var len = _id.len;
+  var pos = _id.pos;
   var string = _id.string;
   if (pos < len) {
     return(char(string, pos));
@@ -24,19 +24,15 @@ var skip_non_code = function (s) {
     var c = peek_char(s);
     if (nil63(c)) {
       break;
-    } else {
-      if (whitespace[c]) {
-        read_char(s);
-      } else {
-        if (c === ";") {
-          while (c && !( c === "\n")) {
-            c = read_char(s);
-          }
-          skip_non_code(s);
-        } else {
-          break;
-        }
+    } else if (whitespace[c]) {
+      read_char(s);
+    } else if (c === ";") {
+      while (c && !( c === "\n")) {
+        c = read_char(s);
       }
+      skip_non_code(s);
+    } else {
+      break;
     }
   }
 };
@@ -76,8 +72,8 @@ var flag63 = function (atom) {
 };
 var expected = function (s, c) {
   var _id1 = s;
-  var more = _id1.more;
   var pos = _id1.pos;
+  var more = _id1.more;
   var _id2 = more;
   var _e;
   if (_id2) {
@@ -133,36 +129,24 @@ read_table[""] = function (s) {
   }
   if (str === "true") {
     return(true);
+  } else if (str === "false") {
+    return(false);
+  } else if (str === "nan") {
+    return(nan);
+  } else if (str === "-nan") {
+    return(nan);
+  } else if (str === "inf") {
+    return(inf);
+  } else if (str === "-inf") {
+    return(-inf);
   } else {
-    if (str === "false") {
-      return(false);
+    var n = maybe_number(str);
+    if (real63(n)) {
+      return(n);
+    } else if (dot63 && valid_access63(str)) {
+      return(parse_access(str));
     } else {
-      if (str === "nan") {
-        return(nan);
-      } else {
-        if (str === "-nan") {
-          return(nan);
-        } else {
-          if (str === "inf") {
-            return(inf);
-          } else {
-            if (str === "-inf") {
-              return(-inf);
-            } else {
-              var n = maybe_number(str);
-              if (real63(n)) {
-                return(n);
-              } else {
-                if (dot63 && valid_access63(str)) {
-                  return(parse_access(str));
-                } else {
-                  return(str);
-                }
-              }
-            }
-          }
-        }
-      }
+      return(str);
     }
   }
 };
@@ -176,22 +160,18 @@ read_table["("] = function (s) {
     if (c === ")") {
       read_char(s);
       r = l;
+    } else if (nil63(c)) {
+      r = expected(s, ")");
     } else {
-      if (nil63(c)) {
-        r = expected(s, ")");
+      var x = read(s);
+      if (key63(x)) {
+        var k = clip(x, 0, edge(x));
+        var v = read(s);
+        l[k] = v;
+      } else if (flag63(x)) {
+        l[clip(x, 1)] = true;
       } else {
-        var x = read(s);
-        if (key63(x)) {
-          var k = clip(x, 0, edge(x));
-          var v = read(s);
-          l[k] = v;
-        } else {
-          if (flag63(x)) {
-            l[clip(x, 1)] = true;
-          } else {
-            add(l, x);
-          }
-        }
+        add(l, x);
       }
     }
   }
@@ -208,15 +188,13 @@ read_table["\""] = function (s) {
     var c = peek_char(s);
     if (c === "\"") {
       r = str + read_char(s);
+    } else if (nil63(c)) {
+      r = expected(s, "\"");
     } else {
-      if (nil63(c)) {
-        r = expected(s, "\"");
-      } else {
-        if (c === "\\") {
-          str = str + read_char(s);
-        }
+      if (c === "\\") {
         str = str + read_char(s);
       }
+      str = str + read_char(s);
     }
   }
   return(r);
@@ -229,12 +207,10 @@ read_table["|"] = function (s) {
     var c = peek_char(s);
     if (c === "|") {
       r = str + read_char(s);
+    } else if (nil63(c)) {
+      r = expected(s, "|");
     } else {
-      if (nil63(c)) {
-        r = expected(s, "|");
-      } else {
-        str = str + read_char(s);
-      }
+      str = str + read_char(s);
     }
   }
   return(r);

--- a/bin/system.lua
+++ b/bin/system.lua
@@ -70,4 +70,4 @@ local function run(command)
   f.close(f)
   return(x)
 end
-return({["path-separator"] = path_separator, ["read-file"] = read_file, write = write, ["write-file"] = write_file, ["get-environment-variable"] = get_environment_variable, run = run, reload = reload, argv = argv, exit = exit, ["directory-exists?"] = directory_exists63, ["file-exists?"] = file_exists63, ["path-join"] = path_join})
+return({argv = argv, ["get-environment-variable"] = get_environment_variable, ["path-join"] = path_join, ["path-separator"] = path_separator, ["read-file"] = read_file, exit = exit, ["file-exists?"] = file_exists63, write = write, run = run, reload = reload, ["write-file"] = write_file, ["directory-exists?"] = directory_exists63})

--- a/compiler.l
+++ b/compiler.l
@@ -574,18 +574,26 @@
             (break))))))
 
 (define-special %if (cond cons alt) :stmt :tr
-  (let (cond (compile cond)
+  (let (ind (indentation)
+        cond (compile cond)
         cons (with-indent (compile cons :stmt))
-        alt (if alt (with-indent (compile alt :stmt)))
-        ind (indentation)
+        elif (and (obj? alt) (= (hd alt) '%if))
+        alt (if elif (clip (compile alt :stmt) (# ind))
+                alt (with-indent (compile alt :stmt)))
         s "")
     (if (= target 'js)
         (cat! s ind "if (" cond ") {\n" cons ind "}")
       (cat! s ind "if " cond " then\n" cons))
-    (if (and alt (= target 'js))
-        (cat! s " else {\n" alt ind "}")
-        alt (cat! s ind "else\n" alt))
-    (if (= target 'lua)
+    (if elif
+        (if (= target 'js)
+            (cat! s " else " alt)
+          (cat! s ind "else" alt))
+        alt
+        (if (= target 'js)
+            (cat! s " else {\n" alt ind "}")
+          (cat! s ind "else\n" alt)))
+    (if elif s
+        (= target 'lua)
         (cat s ind "end\n")
       (cat s "\n"))))
 


### PR DESCRIPTION
This PR compiles chained %IF statements to if-elseif-elseif-else, rather than to nested IF statements.

Lumen's total compiled output is now 254 lines shorter.

In other words, the compiled output of e.g. `str` now looks like this:

```
function str(x, stack)
  if nil63(x) then
    return("nil")
  elseif nan63(x) then
    return("nan")
  elseif x == inf then
    return("inf")
  elseif x == -inf then
    return("-inf")
  elseif boolean63(x) then
    if x then
      return("true")
    else
      return("false")
    end
  elseif string63(x) then
    return(escape(x))
  elseif atom63(x) then
    return(tostring(x))
  elseif function63(x) then
    return("function")
  ...
  end
end
```

Instead of this:

```
function str(x, stack)
  if nil63(x) then
    return("nil")
  else
    if nan63(x) then
      return("nan")
    else
      if x == inf then
        return("inf")
      else
        if x == -inf then
          return("-inf")
        else
          if boolean63(x) then
            if x then
              return("true")
            else
              return("false")
            end
          else
            if string63(x) then
              return(escape(x))
            else
              if atom63(x) then
                return(tostring(x))
              else
                if function63(x) then
                  return("function")
                ...
                end
              end
            end
          end
        end
      end
    end
  end
end
```