### PR TITLE
Don't call MAIN during a require

### DIFF
--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -1291,4 +1291,6 @@ var main = function () {
     }
   }
 };
-main();
+if (global.require.main === module) {
+  main();
+}

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -1191,4 +1191,6 @@ local function main()
     end
   end
 end
-main()
+if _G.debug.getinfo(3) == nil then
+  main()
+end

--- a/main.l
+++ b/main.l
@@ -98,4 +98,6 @@
                     (print code)
                   ((get system 'write-file) output code)))))))))
 
-(main)
+(if (target js: (= (get (get global 'require) 'main) module)
+            lua: (= ((get (get _G 'debug) 'getinfo) 3) nil))
+  (main))


### PR DESCRIPTION
This PR allows the runtime to be reloaded. Additionally, other programs can `(require 'lumen)` without triggering Lumen's `main` function.

I tested this on the following hosts:

- node v0.12.7 (the OS X default)
- node v7.6.0
- lua 5.1
- lua 5.2
- lua 5.3
- luaJIT 2.1.0-beta2
