### PR TITLE
Fix`(apply * '(0 0)) and friends

### DIFF
--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -164,9 +164,9 @@ reverse = function (l) {
   }
   return(l1);
 };
-reduce = function (f, x) {
+reduce = function (f, x, none) {
   if (none63(x)) {
-    return(undefined);
+    return(none);
   } else {
     if (one63(x)) {
       return(hd(x));
@@ -437,37 +437,37 @@ cat = function () {
   var xs = unstash(Array.prototype.slice.call(arguments, 0));
   return(reduce(function (a, b) {
     return(a + b);
-  }, xs) || "");
+  }, xs, ""));
 };
 _43 = function () {
   var xs = unstash(Array.prototype.slice.call(arguments, 0));
   return(reduce(function (a, b) {
     return(a + b);
-  }, xs) || 0);
+  }, xs, 0));
 };
 _45 = function () {
   var xs = unstash(Array.prototype.slice.call(arguments, 0));
   return(reduce(function (b, a) {
     return(a - b);
-  }, reverse(xs)) || 0);
+  }, reverse(xs), 0));
 };
 _42 = function () {
   var xs = unstash(Array.prototype.slice.call(arguments, 0));
   return(reduce(function (a, b) {
     return(a * b);
-  }, xs) || 1);
+  }, xs, 1));
 };
 _47 = function () {
   var xs = unstash(Array.prototype.slice.call(arguments, 0));
   return(reduce(function (b, a) {
     return(a / b);
-  }, reverse(xs)) || 1);
+  }, reverse(xs), 1));
 };
 _37 = function () {
   var xs = unstash(Array.prototype.slice.call(arguments, 0));
   return(reduce(function (b, a) {
     return(a % b);
-  }, reverse(xs)) || 0);
+  }, reverse(xs), 0));
 };
 _62 = function (a, b) {
   return(a > b);

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -150,9 +150,9 @@ function reverse(l)
   end
   return(l1)
 end
-function reduce(f, x)
+function reduce(f, x, none)
   if none63(x) then
-    return(nil)
+    return(none)
   else
     if one63(x) then
       return(hd(x))
@@ -361,37 +361,37 @@ function cat(...)
   local xs = unstash({...})
   return(reduce(function (a, b)
     return(a .. b)
-  end, xs) or "")
+  end, xs, ""))
 end
 function _43(...)
   local xs = unstash({...})
   return(reduce(function (a, b)
     return(a + b)
-  end, xs) or 0)
+  end, xs, 0))
 end
 function _45(...)
   local xs = unstash({...})
   return(reduce(function (b, a)
     return(a - b)
-  end, reverse(xs)) or 0)
+  end, reverse(xs), 0))
 end
 function _42(...)
   local xs = unstash({...})
   return(reduce(function (a, b)
     return(a * b)
-  end, xs) or 1)
+  end, xs, 1))
 end
 function _47(...)
   local xs = unstash({...})
   return(reduce(function (b, a)
     return(a / b)
-  end, reverse(xs)) or 1)
+  end, reverse(xs), 1))
 end
 function _37(...)
   local xs = unstash({...})
   return(reduce(function (b, a)
     return(a % b)
-  end, reverse(xs)) or 0)
+  end, reverse(xs), 0))
 end
 function _62(a, b)
   return(a > b)

--- a/runtime.l
+++ b/runtime.l
@@ -111,8 +111,8 @@
         (add l1 (at l i))
         (dec i)))))
 
-(define-global reduce (f x)
-  (if (none? x) nil
+(define-global reduce (f x none)
+  (if (none? x) none
       (one? x) (hd x)
     (f (hd x) (reduce f (tl x)))))
 
@@ -222,22 +222,22 @@
         (add l s)))))
 
 (define-global cat xs
-  (or (reduce (fn (a b) (cat a b)) xs) ""))
+  (reduce (fn (a b) (cat a b)) xs ""))
 
 (define-global + xs
-  (or (reduce (fn (a b) (+ a b)) xs) 0))
+  (reduce (fn (a b) (+ a b)) xs 0))
 
 (define-global - xs
-  (or (reduce (fn (b a) (- a b)) (reverse xs)) 0))
+  (reduce (fn (b a) (- a b)) (reverse xs) 0))
 
 (define-global * xs
-  (or (reduce (fn (a b) (* a b)) xs) 1))
+  (reduce (fn (a b) (* a b)) xs 1))
 
 (define-global / xs
-  (or (reduce (fn (b a) (/ a b)) (reverse xs)) 1))
+  (reduce (fn (b a) (/ a b)) (reverse xs) 1))
 
 (define-global % xs
-  (or (reduce (fn (b a) (% a b)) (reverse xs)) 0))
+  (reduce (fn (b a) (% a b)) (reverse xs) 0))
 
 (define-global > (a b) (> a b))
 (define-global < (a b) (< a b))

--- a/test.l
+++ b/test.l
@@ -139,6 +139,7 @@
 
 (define-test numeric
   (test= 4 (+ 2 2))
+  (test= 0 (apply * '(0 0)))
   (test= 4 (apply + '(2 2)))
   (test= 0 (apply + ()))
   (test= 18 18.00)
@@ -902,6 +903,7 @@ c"
   (test= (list "a" "b" "") (split "azzbzz" "zz")))
 
 (define-test reduce
+  (test= 'a (reduce (fn (a b) (+ a b)) '() 'a))
   (test= 'a (reduce (fn (a b) (+ a b)) '(a)))
   (test= 6 (reduce (fn (a b) (+ a b)) '(1 2 3)))
   (test= '(1 (2 3))


### PR DESCRIPTION
Additionally, REDUCE now accepts an argument to be returned when given
an empty list.

cf. fe98c902