### PR TITLE
Fix standalone test

### DIFF
--- a/test.l
+++ b/test.l
@@ -180,7 +180,7 @@
   (test= 12 (do (get but zz) 12))
   (let y nil
     (let ignore (do |y = 10;| 42)
-      (test= 10 x))))
+      (test= 10 y))))
 
 (define-test string
   (test= 3 (# "foo"))


### PR DESCRIPTION
It seems like the original intent of this test was to verify that `(let y nil |y = 10| 42)` correctly mutates `y`.

If so, then `(test= 10 x)` was a typo, and this PR fixes it.

