### PR TITLE
Define WITH-COMPILATION

### DIFF
--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -860,11 +860,9 @@ setenv("define-macro", {_stash: true, macro: function (name, args) {
   var _args1 = destash33(args, _r29);
   var _id21 = _r29;
   var body = cut(_id21, 0);
-  var _x110 = ["setenv", ["quote", _name1]];
-  _x110.macro = join(["fn", _args1], body);
-  var form = _x110;
-  eval(form);
-  return(form);
+  var _x112 = ["setenv", ["quote", _name1]];
+  _x112.macro = join(["fn", _args1], body);
+  return(["with-compilation", _x112]);
 }});
 setenv("define-special", {_stash: true, macro: function (name, args) {
   var _r31 = unstash(Array.prototype.slice.call(arguments, 2));
@@ -872,11 +870,9 @@ setenv("define-special", {_stash: true, macro: function (name, args) {
   var _args3 = destash33(args, _r31);
   var _id23 = _r31;
   var body = cut(_id23, 0);
-  var _x117 = ["setenv", ["quote", _name3]];
-  _x117.special = join(["fn", _args3], body);
-  var form = join(_x117, keys(body));
-  eval(form);
-  return(form);
+  var _x121 = ["setenv", ["quote", _name3]];
+  _x121.special = join(["fn", _args3], body);
+  return(["with-compilation", join(_x121, keys(body))]);
 }});
 setenv("define-symbol", {_stash: true, macro: function (name, expansion) {
   setenv(name, {_stash: true, symbol: expansion});
@@ -1145,6 +1141,18 @@ setenv("export", {_stash: true, macro: function () {
 setenv("when-compiling", {_stash: true, macro: function () {
   var body = unstash(Array.prototype.slice.call(arguments, 0));
   return(eval(join(["do"], body)));
+}});
+setenv("with-compilation", {_stash: true, macro: function () {
+  var body = unstash(Array.prototype.slice.call(arguments, 0));
+  var form = join(["do"], body);
+  var entry = setenv("with-compilation", {_stash: true, toplevel: true});
+  if (! entry.skip) {
+    entry.skip = true;
+    eval(form);
+    form = expand(form);
+    delete entry.skip;
+  }
+  return(form);
 }});
 var reader = require("reader");
 var compiler = require("compiler");

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -748,11 +748,9 @@ setenv("define-macro", {_stash = true, macro = function (name, args, ...)
   local _args1 = destash33(args, _r29)
   local _id21 = _r29
   local body = cut(_id21, 0)
-  local _x121 = {"setenv", {"quote", _name1}}
-  _x121.macro = join({"fn", _args1}, body)
-  local form = _x121
-  eval(form)
-  return(form)
+  local _x123 = {"setenv", {"quote", _name1}}
+  _x123.macro = join({"fn", _args1}, body)
+  return({"with-compilation", _x123})
 end})
 setenv("define-special", {_stash = true, macro = function (name, args, ...)
   local _r31 = unstash({...})
@@ -760,11 +758,9 @@ setenv("define-special", {_stash = true, macro = function (name, args, ...)
   local _args3 = destash33(args, _r31)
   local _id23 = _r31
   local body = cut(_id23, 0)
-  local _x129 = {"setenv", {"quote", _name3}}
-  _x129.special = join({"fn", _args3}, body)
-  local form = join(_x129, keys(body))
-  eval(form)
-  return(form)
+  local _x133 = {"setenv", {"quote", _name3}}
+  _x133.special = join({"fn", _args3}, body)
+  return({"with-compilation", join(_x133, keys(body))})
 end})
 setenv("define-symbol", {_stash = true, macro = function (name, expansion)
   setenv(name, {_stash = true, symbol = expansion})
@@ -1019,6 +1015,18 @@ end})
 setenv("when-compiling", {_stash = true, macro = function (...)
   local body = unstash({...})
   return(eval(join({"do"}, body)))
+end})
+setenv("with-compilation", {_stash = true, macro = function (...)
+  local body = unstash({...})
+  local form = join({"do"}, body)
+  local entry = setenv("with-compilation", {_stash = true, toplevel = true})
+  if not entry.skip then
+    entry.skip = true
+    eval(form)
+    form = expand(form)
+    entry.skip = nil
+  end
+  return(form)
 end})
 local reader = require("reader")
 local compiler = require("compiler")

--- a/macros.l
+++ b/macros.l
@@ -80,14 +80,12 @@
            ,@body)))))
 
 (define-macro define-macro (name args rest: body)
-  (let form `(setenv ',name macro: (fn ,args ,@body))
-    (eval form)
-    form))
+  `(with-compilation
+     (setenv ',name macro: (fn ,args ,@body))))
 
 (define-macro define-special (name args rest: body)
-  (let form `(setenv ',name special: (fn ,args ,@body) ,@(keys body))
-    (eval form)
-    form))
+  `(with-compilation
+     (setenv ',name special: (fn ,args ,@body) ,@(keys body))))
 
 (define-macro define-symbol (name expansion)
   (setenv name symbol: expansion)
@@ -235,3 +233,12 @@
 
 (define-macro when-compiling body
   (eval `(do ,@body)))
+
+(define-macro with-compilation body
+  (with form `(do ,@body)
+    (let entry (setenv 'with-compilation :toplevel)
+      (unless (get entry 'skip)
+        (set (get entry 'skip) true)
+        (eval form)
+        (set form (expand form))
+        (wipe (get entry 'skip))))))


### PR DESCRIPTION
This PR introduces `with-compilation`, which is similar to `eval-and-compile` in other lisps.

It allows macros and specials to use local helper functions.

For example, the `if` macro could be refactored to use a local `expand-if` function:

```
(with-compilation
  (define expand-if ((a b rest: c))
    (if (is? b) `((%if ,a ,b ,@(expand-if c)))
        (is? a) (list a)))

  (define-macro if branches
    (hd (expand-if branches))))
```

The outer-most `with-compilation` form is evaluated at compile time. Any nested `with-compilation` forms are simply expanded.


