### PR TITLE
Minor fix in NUMERIC?

### DIFF
--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -502,7 +502,7 @@ numeric63 = function (s) {
     }
     i = i + 1;
   }
-  return(true);
+  return(some63(s));
 };
 var tostring = function (x) {
   return(x.toString());

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -423,7 +423,7 @@ function numeric63(s)
     end
     i = i + 1
   end
-  return(true)
+  return(some63(s))
 end
 function escape(s)
   local s1 = "\""

--- a/runtime.l
+++ b/runtime.l
@@ -259,7 +259,7 @@
     (for i n
       (unless (number-code? (code s i))
         (return false))))
-  true)
+  (some? s))
 
 (target js: (define tostring (x) ((get x 'toString))))
 

--- a/test.l
+++ b/test.l
@@ -157,7 +157,8 @@
   (test= true (< 2e-3 0.0021))
   (test= false (< 2 2))
   (test= true (<= 2 2))
-  (test= -7 (- 7)))
+  (test= -7 (- 7))
+  (test= false (numeric? "")))
 
 (define-test math
   (test= 3 (max 1 3))


### PR DESCRIPTION
Prevent empty string keys from being converted to nan on JS.


Previously,

```
$ LUMEN_HOST=node bin/lumen
> (each (k v) (set-of "" "a")
    (print k))
NaN
a
> (each (k v) (get (require 'reader) 'read-table)
    (print (str (list k v))))
(nan function)
("(" function)
(")" function)
...
```
