### PR TITLE
Fix TOPLEVEL?

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -233,6 +233,7 @@ var expand_function = function (_x38) {
   var args = _id1[1];
   var body = cut(_id1, 2);
   add(environment, {});
+  setenv("%bindings", {_stash: true, variable: true});
   var _o3 = args;
   var _i3 = undefined;
   for (_i3 in _o3) {
@@ -257,6 +258,7 @@ var expand_definition = function (_x42) {
   var args = _id2[2];
   var body = cut(_id2, 3);
   add(environment, {});
+  setenv("%bindings", {_stash: true, variable: true});
   var _o4 = args;
   var _i4 = undefined;
   for (_i4 in _o4) {

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -212,6 +212,7 @@ local function expand_function(_x38)
   local args = _id1[2]
   local body = cut(_id1, 2)
   add(environment, {})
+  setenv("%bindings", {_stash = true, variable = true})
   local _o3 = args
   local _i3 = nil
   for _i3 in next, _o3 do
@@ -229,6 +230,7 @@ local function expand_definition(_x42)
   local args = _id2[3]
   local body = cut(_id2, 3)
   add(environment, {})
+  setenv("%bindings", {_stash = true, variable = true})
   local _o4 = args
   local _i4 = nil
   for _i4 in next, _o4 do

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -634,7 +634,7 @@ call = function (f) {
   return(apply(_f, args));
 };
 toplevel63 = function () {
-  return(one63(environment));
+  return(! bound63("%bindings"));
 };
 setenv = function (k) {
   var _r72 = unstash(Array.prototype.slice.call(arguments, 1));
@@ -933,6 +933,8 @@ setenv("with-bindings", {_stash: true, macro: function (_x169) {
   var _id35 = _r41;
   var body = cut(_id35, 0);
   var x = unique("x");
+  var _x171 = ["setenv", ["quote", "%bindings"]]
+  _x171.variable = true
   var _x172 = ["setenv", x];
   _x172.variable = true;
   return(join(["with-frame", ["each", x, names, _x172]], body));

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -539,7 +539,7 @@ function call(f, ...)
   return(apply(_f, args))
 end
 function toplevel63()
-  return(one63(environment))
+  return(not(bound63("%bindings")))
 end
 function setenv(k, ...)
   local _r69 = unstash({...})
@@ -821,6 +821,8 @@ setenv("with-bindings", {_stash = true, macro = function (_x185, ...)
   local _id35 = _r41
   local body = cut(_id35, 0)
   local x = unique("x")
+  local _x190 = {"setenv", {"quote", "%bindings"}}
+  _x190.variable = true
   local _x189 = {"setenv", x}
   _x189.variable = true
   return(join({"with-frame", {"each", x, names, _x189}}, body))

--- a/macros.l
+++ b/macros.l
@@ -117,6 +117,7 @@
 (define-macro with-bindings ((names) rest: body)
   (let-unique (x)
    `(with-frame
+      (setenv '%bindings :variable)
       (each ,x ,names
         (setenv ,x :variable))
       ,@body)))

--- a/runtime.l
+++ b/runtime.l
@@ -313,7 +313,7 @@
   (apply f args))
 
 (define-global toplevel? ()
-  (one? environment))
+  (not (bound? '%bindings)))
 
 (define-global setenv (k rest: keys)
   (when (string? k)


### PR DESCRIPTION
Closes #80.

```
$ bin/lumen -e "(print (compile (expand '(let (a 1 b 1 c 1) (list a b c)))))"
local _a = 1
local _b = 1
local _c = 1
{_a, _b, _c}
$ bin/lumen -e "(print (compile (expand '(let (a 1 b 1 c 1) (fn () (let (u 1 v 1) (list a b c u v)))))))"
local _a = 1
local _b = 1
local _c = 1
function ()
  local u = 1
  local v = 1
  return({_a, _b, _c, u, v})
end
```
