### PR TITLE
Update LET to always bind to unique names

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -1,19 +1,19 @@
 var reader = require("reader");
 var getenv = function (k, p) {
   if (string63(k)) {
-    var i = edge(environment);
-    while (i >= 0) {
-      var b = environment[i][k];
-      if (is63(b)) {
-        var _e10;
+    var _i = edge(environment);
+    while (_i >= 0) {
+      var _b = environment[_i][k];
+      if (is63(_b)) {
+        var _e21;
         if (p) {
-          _e10 = b[p];
+          _e21 = _b[p];
         } else {
-          _e10 = b;
+          _e21 = _b;
         }
-        return(_e10);
+        return(_e21);
       } else {
-        i = i - 1;
+        _i = _i - 1;
       }
     }
   }
@@ -40,10 +40,10 @@ var symbol63 = function (k) {
   return(is63(symbol_expansion(k)));
 };
 var variable63 = function (k) {
-  var b = first(function (frame) {
+  var _b1 = first(function (frame) {
     return(frame[k]);
   }, reverse(environment));
-  return(! atom63(b) && is63(b.variable));
+  return(! atom63(_b1) && is63(_b1.variable));
 };
 bound63 = function (x) {
   return(macro63(x) || special63(x) || symbol63(x) || variable63(x));
@@ -69,9 +69,9 @@ var literal = function (s) {
 var _names = {};
 unique = function (x) {
   if (_names[x]) {
-    var i = _names[x];
+    var _i1 = _names[x];
     _names[x] = _names[x] + 1;
-    return(unique(x + i));
+    return(unique(x + _i1));
   } else {
     _names[x] = 1;
     return("_" + x);
@@ -79,24 +79,24 @@ unique = function (x) {
 };
 var stash42 = function (args) {
   if (keys63(args)) {
-    var l = ["%object", "\"_stash\"", true];
-    var _o = args;
-    var k = undefined;
-    for (k in _o) {
-      var v = _o[k];
-      var _e11;
-      if (numeric63(k)) {
-        _e11 = parseInt(k);
+    var _l = ["%object", "\"_stash\"", true];
+    var __o = args;
+    var _k = undefined;
+    for (_k in __o) {
+      var _v = __o[_k];
+      var _e22;
+      if (numeric63(_k)) {
+        _e22 = parseInt(_k);
       } else {
-        _e11 = k;
+        _e22 = _k;
       }
-      var _k = _e11;
-      if (! number63(_k)) {
-        add(l, literal(_k));
-        add(l, v);
+      var _k1 = _e22;
+      if (! number63(_k1)) {
+        add(_l, literal(_k1));
+        add(_l, _v);
       }
     }
-    return(join(args, [l]));
+    return(join(args, [_l]));
   } else {
     return(args);
   }
@@ -115,97 +115,97 @@ bind = function (lh, rh) {
   if (atom63(lh)) {
     return([lh, rh]);
   } else {
-    var id = unique("id");
-    var bs = [id, rh];
-    var _o1 = lh;
-    var k = undefined;
-    for (k in _o1) {
-      var v = _o1[k];
-      var _e12;
-      if (numeric63(k)) {
-        _e12 = parseInt(k);
+    var _id = unique("id");
+    var _bs = [_id, rh];
+    var __o1 = lh;
+    var _k2 = undefined;
+    for (_k2 in __o1) {
+      var _v1 = __o1[_k2];
+      var _e23;
+      if (numeric63(_k2)) {
+        _e23 = parseInt(_k2);
       } else {
-        _e12 = k;
+        _e23 = _k2;
       }
-      var _k1 = _e12;
-      var _e13;
-      if (_k1 === "rest") {
-        _e13 = ["cut", id, _35(lh)];
+      var _k3 = _e23;
+      var _e24;
+      if (_k3 === "rest") {
+        _e24 = ["cut", _id, _35(lh)];
       } else {
-        _e13 = ["get", id, ["quote", bias(_k1)]];
+        _e24 = ["get", _id, ["quote", bias(_k3)]];
       }
-      var x = _e13;
-      if (is63(_k1)) {
-        var _e14;
-        if (v === true) {
-          _e14 = _k1;
+      var _x5 = _e24;
+      if (is63(_k3)) {
+        var _e25;
+        if (_v1 === true) {
+          _e25 = _k3;
         } else {
-          _e14 = v;
+          _e25 = _v1;
         }
-        var _k2 = _e14;
-        bs = join(bs, bind(_k2, x));
+        var _k4 = _e25;
+        _bs = join(_bs, bind(_k4, _x5));
       }
     }
-    return(bs);
+    return(_bs);
   }
 };
 setenv("arguments%", {_stash: true, macro: function (from) {
   return([["get", ["get", ["get", "Array", ["quote", "prototype"]], ["quote", "slice"]], ["quote", "call"]], "arguments", from]);
 }});
 bind42 = function (args, body) {
-  var args1 = [];
+  var _args1 = [];
   var rest = function () {
     if (target === "js") {
-      return(["unstash", ["arguments%", _35(args1)]]);
+      return(["unstash", ["arguments%", _35(_args1)]]);
     } else {
-      add(args1, "|...|");
+      add(_args1, "|...|");
       return(["unstash", ["list", "|...|"]]);
     }
   };
   if (atom63(args)) {
-    return([args1, join(["let", [args, rest()]], body)]);
+    return([_args1, join(["let", [args, rest()]], body)]);
   } else {
-    var bs = [];
-    var r = unique("r");
-    var _o2 = args;
-    var k = undefined;
-    for (k in _o2) {
-      var v = _o2[k];
-      var _e15;
-      if (numeric63(k)) {
-        _e15 = parseInt(k);
+    var _bs1 = [];
+    var _r21 = unique("r");
+    var __o2 = args;
+    var _k5 = undefined;
+    for (_k5 in __o2) {
+      var _v2 = __o2[_k5];
+      var _e26;
+      if (numeric63(_k5)) {
+        _e26 = parseInt(_k5);
       } else {
-        _e15 = k;
+        _e26 = _k5;
       }
-      var _k3 = _e15;
-      if (number63(_k3)) {
-        if (atom63(v)) {
-          add(args1, v);
+      var _k6 = _e26;
+      if (number63(_k6)) {
+        if (atom63(_v2)) {
+          add(_args1, _v2);
         } else {
-          var x = unique("x");
-          add(args1, x);
-          bs = join(bs, [v, x]);
+          var _x30 = unique("x");
+          add(_args1, _x30);
+          _bs1 = join(_bs1, [_v2, _x30]);
         }
       }
     }
     if (keys63(args)) {
-      bs = join(bs, [r, rest()]);
-      var _e16;
+      _bs1 = join(_bs1, [_r21, rest()]);
+      var _e27;
       if (target === "lua") {
-        _e16 = edge(args1);
+        _e27 = edge(_args1);
       } else {
-        _e16 = _35(args1);
+        _e27 = _35(_args1);
       }
-      var n = _e16;
-      var i = 0;
-      while (i < n) {
-        var _v = args1[i];
-        bs = join(bs, [_v, ["destash!", _v, r]]);
-        i = i + 1;
+      var _n3 = _e27;
+      var _i5 = 0;
+      while (_i5 < _n3) {
+        var _v3 = _args1[_i5];
+        _bs1 = join(_bs1, [_v3, ["destash!", _v3, _r21]]);
+        _i5 = _i5 + 1;
       }
-      bs = join(bs, [keys(args), r]);
+      _bs1 = join(_bs1, [keys(args), _r21]);
     }
-    return([args1, join(["let", bs], body)]);
+    return([_args1, join(["let", _bs1], body)]);
   }
 };
 var quoting63 = function (depth) {
@@ -220,69 +220,69 @@ var can_unquote63 = function (depth) {
 var quasisplice63 = function (x, depth) {
   return(can_unquote63(depth) && ! atom63(x) && hd(x) === "unquote-splicing");
 };
-var expand_local = function (_x36) {
-  var _id = _x36;
-  var x = _id[0];
-  var name = _id[1];
-  var value = _id[2];
-  setenv(name, {_stash: true, variable: true});
-  return(["%local", name, macroexpand(value)]);
+var expand_local = function (_x38) {
+  var __id1 = _x38;
+  var _x39 = __id1[0];
+  var _name = __id1[1];
+  var _value = __id1[2];
+  setenv(_name, {_stash: true, variable: true});
+  return(["%local", _name, macroexpand(_value)]);
 };
-var expand_function = function (_x38) {
-  var _id1 = _x38;
-  var x = _id1[0];
-  var args = _id1[1];
-  var body = cut(_id1, 2);
+var expand_function = function (_x41) {
+  var __id2 = _x41;
+  var _x42 = __id2[0];
+  var _args = __id2[1];
+  var _body = cut(__id2, 2);
   add(environment, {});
-  var _o3 = args;
-  var _i3 = undefined;
-  for (_i3 in _o3) {
-    var _x39 = _o3[_i3];
-    var _e17;
-    if (numeric63(_i3)) {
-      _e17 = parseInt(_i3);
+  var __o3 = _args;
+  var __i6 = undefined;
+  for (__i6 in __o3) {
+    var __x43 = __o3[__i6];
+    var _e28;
+    if (numeric63(__i6)) {
+      _e28 = parseInt(__i6);
     } else {
-      _e17 = _i3;
+      _e28 = __i6;
     }
-    var __i3 = _e17;
-    setenv(_x39, {_stash: true, variable: true});
+    var __i61 = _e28;
+    setenv(__x43, {_stash: true, variable: true});
   }
-  var _x40 = join(["%function", args], macroexpand(body));
+  var __x44 = join(["%function", _args], macroexpand(_body));
   drop(environment);
-  return(_x40);
+  return(__x44);
 };
-var expand_definition = function (_x42) {
-  var _id2 = _x42;
-  var x = _id2[0];
-  var name = _id2[1];
-  var args = _id2[2];
-  var body = cut(_id2, 3);
+var expand_definition = function (_x46) {
+  var __id3 = _x46;
+  var _x47 = __id3[0];
+  var _name1 = __id3[1];
+  var _args11 = __id3[2];
+  var _body1 = cut(__id3, 3);
   add(environment, {});
-  var _o4 = args;
-  var _i4 = undefined;
-  for (_i4 in _o4) {
-    var _x43 = _o4[_i4];
-    var _e18;
-    if (numeric63(_i4)) {
-      _e18 = parseInt(_i4);
+  var __o4 = _args11;
+  var __i7 = undefined;
+  for (__i7 in __o4) {
+    var __x48 = __o4[__i7];
+    var _e29;
+    if (numeric63(__i7)) {
+      _e29 = parseInt(__i7);
     } else {
-      _e18 = _i4;
+      _e29 = __i7;
     }
-    var __i4 = _e18;
-    setenv(_x43, {_stash: true, variable: true});
+    var __i71 = _e29;
+    setenv(__x48, {_stash: true, variable: true});
   }
-  var _x44 = join([x, name, args], macroexpand(body));
+  var __x49 = join([_x47, _name1, _args11], macroexpand(_body1));
   drop(environment);
-  return(_x44);
+  return(__x49);
 };
 var expand_macro = function (form) {
   return(macroexpand(expand1(form)));
 };
-expand1 = function (_x46) {
-  var _id3 = _x46;
-  var name = _id3[0];
-  var body = cut(_id3, 1);
-  return(apply(macro_function(name), body));
+expand1 = function (_x51) {
+  var __id4 = _x51;
+  var _name2 = __id4[0];
+  var _body2 = cut(__id4, 1);
+  return(apply(macro_function(_name2), _body2));
 };
 macroexpand = function (form) {
   if (symbol63(form)) {
@@ -291,20 +291,20 @@ macroexpand = function (form) {
     if (atom63(form)) {
       return(form);
     } else {
-      var x = hd(form);
-      if (x === "%local") {
+      var _x52 = hd(form);
+      if (_x52 === "%local") {
         return(expand_local(form));
       } else {
-        if (x === "%function") {
+        if (_x52 === "%function") {
           return(expand_function(form));
         } else {
-          if (x === "%global-function") {
+          if (_x52 === "%global-function") {
             return(expand_definition(form));
           } else {
-            if (x === "%local-function") {
+            if (_x52 === "%local-function") {
               return(expand_definition(form));
             } else {
-              if (macro63(x)) {
+              if (macro63(_x52)) {
                 return(expand_macro(form));
               } else {
                 return(map(macroexpand, form));
@@ -317,49 +317,49 @@ macroexpand = function (form) {
   }
 };
 var quasiquote_list = function (form, depth) {
-  var xs = [["list"]];
-  var _o5 = form;
-  var k = undefined;
-  for (k in _o5) {
-    var v = _o5[k];
-    var _e19;
-    if (numeric63(k)) {
-      _e19 = parseInt(k);
+  var _xs = [["list"]];
+  var __o5 = form;
+  var _k7 = undefined;
+  for (_k7 in __o5) {
+    var _v4 = __o5[_k7];
+    var _e30;
+    if (numeric63(_k7)) {
+      _e30 = parseInt(_k7);
     } else {
-      _e19 = k;
+      _e30 = _k7;
     }
-    var _k4 = _e19;
-    if (! number63(_k4)) {
-      var _e20;
-      if (quasisplice63(v, depth)) {
-        _e20 = quasiexpand(v[1]);
+    var _k8 = _e30;
+    if (! number63(_k8)) {
+      var _e31;
+      if (quasisplice63(_v4, depth)) {
+        _e31 = quasiexpand(_v4[1]);
       } else {
-        _e20 = quasiexpand(v, depth);
+        _e31 = quasiexpand(_v4, depth);
       }
-      var _v1 = _e20;
-      last(xs)[_k4] = _v1;
+      var _v5 = _e31;
+      last(_xs)[_k8] = _v5;
     }
   }
-  var _x49 = form;
-  var _i6 = 0;
-  while (_i6 < _35(_x49)) {
-    var x = _x49[_i6];
-    if (quasisplice63(x, depth)) {
-      var _x50 = quasiexpand(x[1]);
-      add(xs, _x50);
-      add(xs, ["list"]);
+  var __x55 = form;
+  var __i9 = 0;
+  while (__i9 < _35(__x55)) {
+    var _x56 = __x55[__i9];
+    if (quasisplice63(_x56, depth)) {
+      var _x57 = quasiexpand(_x56[1]);
+      add(_xs, _x57);
+      add(_xs, ["list"]);
     } else {
-      add(last(xs), quasiexpand(x, depth));
+      add(last(_xs), quasiexpand(_x56, depth));
     }
-    _i6 = _i6 + 1;
+    __i9 = __i9 + 1;
   }
-  var pruned = keep(function (x) {
+  var _pruned = keep(function (x) {
     return(_35(x) > 1 || !( hd(x) === "list") || keys63(x));
-  }, xs);
-  if (one63(pruned)) {
-    return(hd(pruned));
+  }, _xs);
+  if (one63(_pruned)) {
+    return(hd(_pruned));
   } else {
-    return(join(["join"], pruned));
+    return(join(["join"], _pruned));
   }
 };
 quasiexpand = function (form, depth) {
@@ -399,30 +399,30 @@ quasiexpand = function (form, depth) {
     }
   }
 };
-expand_if = function (_x54) {
-  var _id4 = _x54;
-  var a = _id4[0];
-  var b = _id4[1];
-  var c = cut(_id4, 2);
-  if (is63(b)) {
-    return([join(["%if", a, b], expand_if(c))]);
+expand_if = function (_x61) {
+  var __id5 = _x61;
+  var _a = __id5[0];
+  var _b2 = __id5[1];
+  var _c = cut(__id5, 2);
+  if (is63(_b2)) {
+    return([join(["%if", _a, _b2], expand_if(_c))]);
   } else {
-    if (is63(a)) {
-      return([a]);
+    if (is63(_a)) {
+      return([_a]);
     }
   }
 };
 indent_level = 0;
 indentation = function () {
-  var s = "";
-  var i = 0;
-  while (i < indent_level) {
-    s = s + "  ";
-    i = i + 1;
+  var _s = "";
+  var _i10 = 0;
+  while (_i10 < indent_level) {
+    _s = _s + "  ";
+    _i10 = _i10 + 1;
   }
-  return(s);
+  return(_s);
 };
-var reserved = {"else": true, "finally": true, "instanceof": true, "with": true, ">=": true, "elseif": true, "new": true, "delete": true, "end": true, "then": true, "in": true, "=": true, "or": true, "+": true, "var": true, "repeat": true, "-": true, "throw": true, "while": true, "debugger": true, "and": true, "if": true, "for": true, "nil": true, "until": true, "function": true, "false": true, "break": true, "==": true, "do": true, "/": true, "continue": true, "true": true, "typeof": true, "not": true, ">": true, "return": true, "<=": true, "catch": true, "local": true, "void": true, "try": true, "<": true, "switch": true, "*": true, "%": true, "default": true, "case": true};
+var reserved = {"=": true, "==": true, "+": true, "-": true, "%": true, "*": true, "/": true, "<": true, ">": true, "<=": true, ">=": true, "break": true, "case": true, "catch": true, "continue": true, "debugger": true, "default": true, "delete": true, "do": true, "else": true, "finally": true, "for": true, "function": true, "if": true, "in": true, "instanceof": true, "new": true, "return": true, "switch": true, "throw": true, "try": true, "typeof": true, "var": true, "void": true, "with": true, "and": true, "end": true, "repeat": true, "while": true, "false": true, "local": true, "nil": true, "then": true, "not": true, "true": true, "elseif": true, "or": true, "until": true};
 reserved63 = function (x) {
   return(reserved[x]);
 };
@@ -433,20 +433,20 @@ valid_id63 = function (id) {
   if (none63(id) || reserved63(id)) {
     return(false);
   } else {
-    var i = 0;
-    while (i < _35(id)) {
-      if (! valid_code63(code(id, i))) {
+    var _i11 = 0;
+    while (_i11 < _35(id)) {
+      if (! valid_code63(code(id, _i11))) {
         return(false);
       }
-      i = i + 1;
+      _i11 = _i11 + 1;
     }
     return(true);
   }
 };
 key = function (k) {
-  var i = inner(k);
-  if (valid_id63(i)) {
-    return(i);
+  var _i12 = inner(k);
+  if (valid_id63(_i12)) {
+    return(_i12);
   } else {
     if (target === "js") {
       return(k);
@@ -456,64 +456,64 @@ key = function (k) {
   }
 };
 mapo = function (f, t) {
-  var o = [];
-  var _o6 = t;
-  var k = undefined;
-  for (k in _o6) {
-    var v = _o6[k];
-    var _e21;
-    if (numeric63(k)) {
-      _e21 = parseInt(k);
+  var _o6 = [];
+  var __o7 = t;
+  var _k9 = undefined;
+  for (_k9 in __o7) {
+    var _v6 = __o7[_k9];
+    var _e32;
+    if (numeric63(_k9)) {
+      _e32 = parseInt(_k9);
     } else {
-      _e21 = k;
+      _e32 = _k9;
     }
-    var _k5 = _e21;
-    var x = f(v);
-    if (is63(x)) {
-      add(o, literal(_k5));
-      add(o, x);
+    var _k10 = _e32;
+    var _x65 = f(_v6);
+    if (is63(_x65)) {
+      add(_o6, literal(_k10));
+      add(_o6, _x65);
     }
   }
-  return(o);
+  return(_o6);
 };
-var __x59 = [];
-var _x60 = [];
-_x60.lua = "not";
-_x60.js = "!";
-__x59["not"] = _x60;
-var __x61 = [];
-__x61["%"] = true;
-__x61["/"] = true;
-__x61["*"] = true;
-var __x62 = [];
-__x62["-"] = true;
-__x62["+"] = true;
-var __x63 = [];
-var _x64 = [];
-_x64.lua = "..";
-_x64.js = "+";
-__x63.cat = _x64;
-var __x65 = [];
-__x65[">="] = true;
-__x65["<"] = true;
-__x65["<="] = true;
-__x65[">"] = true;
-var __x66 = [];
-var _x67 = [];
-_x67.lua = "==";
-_x67.js = "===";
-__x66["="] = _x67;
+var __x67 = [];
 var __x68 = [];
-var _x69 = [];
-_x69.lua = "and";
-_x69.js = "&&";
-__x68["and"] = _x69;
+__x68.js = "!";
+__x68.lua = "not";
+__x67["not"] = __x68;
+var __x69 = [];
+__x69["*"] = true;
+__x69["/"] = true;
+__x69["%"] = true;
 var __x70 = [];
-var _x71 = [];
-_x71.lua = "or";
-_x71.js = "||";
-__x70["or"] = _x71;
-var infix = [__x59, __x61, __x62, __x63, __x65, __x66, __x68, __x70];
+__x70["+"] = true;
+__x70["-"] = true;
+var __x71 = [];
+var __x72 = [];
+__x72.js = "+";
+__x72.lua = "..";
+__x71.cat = __x72;
+var __x73 = [];
+__x73["<"] = true;
+__x73[">"] = true;
+__x73["<="] = true;
+__x73[">="] = true;
+var __x74 = [];
+var __x75 = [];
+__x75.js = "===";
+__x75.lua = "==";
+__x74["="] = __x75;
+var __x76 = [];
+var __x77 = [];
+__x77.js = "&&";
+__x77.lua = "and";
+__x76["and"] = __x77;
+var __x78 = [];
+var __x79 = [];
+__x79.js = "||";
+__x79.lua = "or";
+__x78["or"] = __x79;
+var infix = [__x67, __x69, __x70, __x71, __x73, __x74, __x76, __x78];
 var unary63 = function (form) {
   return(two63(form) && in63(hd(form), ["not", "-"]));
 };
@@ -522,19 +522,19 @@ var index = function (k) {
 };
 var precedence = function (form) {
   if (!( atom63(form) || unary63(form))) {
-    var _o7 = infix;
-    var k = undefined;
-    for (k in _o7) {
-      var v = _o7[k];
-      var _e22;
-      if (numeric63(k)) {
-        _e22 = parseInt(k);
+    var __o8 = infix;
+    var _k11 = undefined;
+    for (_k11 in __o8) {
+      var _v7 = __o8[_k11];
+      var _e33;
+      if (numeric63(_k11)) {
+        _e33 = parseInt(_k11);
       } else {
-        _e22 = k;
+        _e33 = _k11;
       }
-      var _k6 = _e22;
-      if (v[hd(form)]) {
-        return(index(_k6));
+      var _k12 = _e33;
+      if (_v7[hd(form)]) {
+        return(index(_k12));
       }
     }
   }
@@ -542,12 +542,12 @@ var precedence = function (form) {
 };
 var getop = function (op) {
   return(find(function (level) {
-    var x = level[op];
-    if (x === true) {
+    var _x81 = level[op];
+    if (_x81 === true) {
       return(op);
     } else {
-      if (is63(x)) {
-        return(x[target]);
+      if (is63(_x81)) {
+        return(_x81[target]);
       }
     }
   }, infix));
@@ -556,72 +556,72 @@ var infix63 = function (x) {
   return(is63(getop(x)));
 };
 var compile_args = function (args) {
-  var s = "(";
-  var c = "";
-  var _x73 = args;
-  var _i9 = 0;
-  while (_i9 < _35(_x73)) {
-    var x = _x73[_i9];
-    s = s + c + compile(x);
-    c = ", ";
-    _i9 = _i9 + 1;
+  var _s1 = "(";
+  var _c1 = "";
+  var __x82 = args;
+  var __i15 = 0;
+  while (__i15 < _35(__x82)) {
+    var _x83 = __x82[__i15];
+    _s1 = _s1 + _c1 + compile(_x83);
+    _c1 = ", ";
+    __i15 = __i15 + 1;
   }
-  return(s + ")");
+  return(_s1 + ")");
 };
 var escape_newlines = function (s) {
-  var s1 = "";
-  var i = 0;
-  while (i < _35(s)) {
-    var c = char(s, i);
-    var _e23;
-    if (c === "\n") {
-      _e23 = "\\n";
+  var _s11 = "";
+  var _i16 = 0;
+  while (_i16 < _35(s)) {
+    var _c2 = char(s, _i16);
+    var _e34;
+    if (_c2 === "\n") {
+      _e34 = "\\n";
     } else {
-      _e23 = c;
+      _e34 = _c2;
     }
-    s1 = s1 + _e23;
-    i = i + 1;
+    _s11 = _s11 + _e34;
+    _i16 = _i16 + 1;
   }
-  return(s1);
+  return(_s11);
 };
 var id = function (id) {
-  var _e24;
+  var _e35;
   if (number_code63(code(id, 0))) {
-    _e24 = "_";
+    _e35 = "_";
   } else {
-    _e24 = "";
+    _e35 = "";
   }
-  var id1 = _e24;
-  var i = 0;
-  while (i < _35(id)) {
-    var c = char(id, i);
-    var n = code(c);
-    var _e25;
-    if (c === "-" && !( id === "-")) {
-      _e25 = "_";
+  var _id11 = _e35;
+  var _i17 = 0;
+  while (_i17 < _35(id)) {
+    var _c3 = char(id, _i17);
+    var _n9 = code(_c3);
+    var _e36;
+    if (_c3 === "-" && !( id === "-")) {
+      _e36 = "_";
     } else {
-      var _e26;
-      if (valid_code63(n)) {
-        _e26 = c;
+      var _e37;
+      if (valid_code63(_n9)) {
+        _e37 = _c3;
       } else {
-        var _e27;
-        if (i === 0) {
-          _e27 = "_" + n;
+        var _e38;
+        if (_i17 === 0) {
+          _e38 = "_" + _n9;
         } else {
-          _e27 = n;
+          _e38 = _n9;
         }
-        _e26 = _e27;
+        _e37 = _e38;
       }
-      _e25 = _e26;
+      _e36 = _e37;
     }
-    var c1 = _e25;
-    id1 = id1 + c1;
-    i = i + 1;
+    var _c11 = _e36;
+    _id11 = _id11 + _c11;
+    _i17 = _i17 + 1;
   }
-  if (reserved63(id1)) {
-    return("_" + id1);
+  if (reserved63(_id11)) {
+    return("_" + _id11);
   } else {
-    return(id1);
+    return(_id11);
   }
 };
 var compile_atom = function (x) {
@@ -683,163 +683,163 @@ var terminator = function (stmt63) {
   }
 };
 var compile_special = function (form, stmt63) {
-  var _id5 = form;
-  var x = _id5[0];
-  var args = cut(_id5, 1);
-  var _id6 = getenv(x);
-  var special = _id6.special;
-  var stmt = _id6.stmt;
-  var self_tr63 = _id6.tr;
-  var tr = terminator(stmt63 && ! self_tr63);
-  return(apply(special, args) + tr);
+  var __id6 = form;
+  var _x84 = __id6[0];
+  var _args2 = cut(__id6, 1);
+  var __id7 = getenv(_x84);
+  var _special = __id7.special;
+  var _stmt = __id7.stmt;
+  var _self_tr63 = __id7.tr;
+  var _tr = terminator(stmt63 && ! _self_tr63);
+  return(apply(_special, _args2) + _tr);
 };
 var parenthesize_call63 = function (x) {
   return(! atom63(x) && hd(x) === "%function" || precedence(x) > 0);
 };
 var compile_call = function (form) {
-  var f = hd(form);
-  var f1 = compile(f);
-  var args = compile_args(stash42(tl(form)));
-  if (parenthesize_call63(f)) {
-    return("(" + f1 + ")" + args);
+  var _f = hd(form);
+  var _f1 = compile(_f);
+  var _args3 = compile_args(stash42(tl(form)));
+  if (parenthesize_call63(_f)) {
+    return("(" + _f1 + ")" + _args3);
   } else {
-    return(f1 + args);
+    return(_f1 + _args3);
   }
 };
 var op_delims = function (parent, child) {
-  var _r56 = unstash(Array.prototype.slice.call(arguments, 2));
-  var _parent = destash33(parent, _r56);
-  var _child = destash33(child, _r56);
-  var _id7 = _r56;
-  var right = _id7.right;
-  var _e28;
-  if (right) {
-    _e28 = _6261;
+  var __r57 = unstash(Array.prototype.slice.call(arguments, 2));
+  var _parent = destash33(parent, __r57);
+  var _child = destash33(child, __r57);
+  var __id8 = __r57;
+  var _right = __id8.right;
+  var _e39;
+  if (_right) {
+    _e39 = _6261;
   } else {
-    _e28 = _62;
+    _e39 = _62;
   }
-  if (_e28(precedence(_child), precedence(_parent))) {
+  if (_e39(precedence(_child), precedence(_parent))) {
     return(["(", ")"]);
   } else {
     return(["", ""]);
   }
 };
 var compile_infix = function (form) {
-  var _id8 = form;
-  var op = _id8[0];
-  var _id9 = cut(_id8, 1);
-  var a = _id9[0];
-  var b = _id9[1];
-  var _id10 = op_delims(form, a);
-  var ao = _id10[0];
-  var ac = _id10[1];
-  var _id11 = op_delims(form, b, {_stash: true, right: true});
-  var bo = _id11[0];
-  var bc = _id11[1];
-  var _a = compile(a);
-  var _b = compile(b);
-  var _op = getop(op);
+  var __id9 = form;
+  var _op = __id9[0];
+  var __id10 = cut(__id9, 1);
+  var _a1 = __id10[0];
+  var _b3 = __id10[1];
+  var __id111 = op_delims(form, _a1);
+  var _ao = __id111[0];
+  var _ac = __id111[1];
+  var __id12 = op_delims(form, _b3, {_stash: true, right: true});
+  var _bo = __id12[0];
+  var _bc = __id12[1];
+  var _a2 = compile(_a1);
+  var _b4 = compile(_b3);
+  var _op1 = getop(_op);
   if (unary63(form)) {
-    return(_op + ao + " " + _a + ac);
+    return(_op1 + _ao + " " + _a2 + _ac);
   } else {
-    return(ao + _a + ac + " " + _op + " " + bo + _b + bc);
+    return(_ao + _a2 + _ac + " " + _op1 + " " + _bo + _b4 + _bc);
   }
 };
 compile_function = function (args, body) {
-  var _r58 = unstash(Array.prototype.slice.call(arguments, 2));
-  var _args = destash33(args, _r58);
-  var _body = destash33(body, _r58);
-  var _id12 = _r58;
-  var prefix = _id12.prefix;
-  var name = _id12.name;
-  var _e29;
-  if (name) {
-    _e29 = compile(name);
+  var __r59 = unstash(Array.prototype.slice.call(arguments, 2));
+  var _args4 = destash33(args, __r59);
+  var _body3 = destash33(body, __r59);
+  var __id13 = __r59;
+  var _name3 = __id13.name;
+  var _prefix = __id13.prefix;
+  var _e40;
+  if (_name3) {
+    _e40 = compile(_name3);
   } else {
-    _e29 = "";
+    _e40 = "";
   }
-  var _id13 = _e29;
-  var _args1 = compile_args(_args);
+  var _id14 = _e40;
+  var _args5 = compile_args(_args4);
   indent_level = indent_level + 1;
-  var _x76 = compile(_body, {_stash: true, stmt: true});
+  var __x87 = compile(_body3, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var _body1 = _x76;
-  var ind = indentation();
-  var _e30;
-  if (prefix) {
-    _e30 = prefix + " ";
+  var _body4 = __x87;
+  var _ind = indentation();
+  var _e41;
+  if (_prefix) {
+    _e41 = _prefix + " ";
   } else {
-    _e30 = "";
+    _e41 = "";
   }
-  var p = _e30;
-  var _e31;
+  var _p = _e41;
+  var _e42;
   if (target === "js") {
-    _e31 = "";
+    _e42 = "";
   } else {
-    _e31 = "end";
+    _e42 = "end";
   }
-  var tr = _e31;
-  if (name) {
-    tr = tr + "\n";
+  var _tr1 = _e42;
+  if (_name3) {
+    _tr1 = _tr1 + "\n";
   }
   if (target === "js") {
-    return("function " + _id13 + _args1 + " {\n" + _body1 + ind + "}" + tr);
+    return("function " + _id14 + _args5 + " {\n" + _body4 + _ind + "}" + _tr1);
   } else {
-    return(p + "function " + _id13 + _args1 + "\n" + _body1 + ind + tr);
+    return(_p + "function " + _id14 + _args5 + "\n" + _body4 + _ind + _tr1);
   }
 };
 var can_return63 = function (form) {
   return(is63(form) && (atom63(form) || !( hd(form) === "return") && ! statement63(hd(form))));
 };
 compile = function (form) {
-  var _r60 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _form = destash33(form, _r60);
-  var _id14 = _r60;
-  var stmt = _id14.stmt;
+  var __r61 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _form = destash33(form, __r61);
+  var __id15 = __r61;
+  var _stmt1 = __id15.stmt;
   if (nil63(_form)) {
     return("");
   } else {
     if (special_form63(_form)) {
-      return(compile_special(_form, stmt));
+      return(compile_special(_form, _stmt1));
     } else {
-      var tr = terminator(stmt);
-      var _e32;
-      if (stmt) {
-        _e32 = indentation();
+      var _tr2 = terminator(_stmt1);
+      var _e43;
+      if (_stmt1) {
+        _e43 = indentation();
       } else {
-        _e32 = "";
+        _e43 = "";
       }
-      var ind = _e32;
-      var _e33;
+      var _ind1 = _e43;
+      var _e44;
       if (atom63(_form)) {
-        _e33 = compile_atom(_form);
+        _e44 = compile_atom(_form);
       } else {
-        var _e34;
+        var _e45;
         if (infix63(hd(_form))) {
-          _e34 = compile_infix(_form);
+          _e45 = compile_infix(_form);
         } else {
-          _e34 = compile_call(_form);
+          _e45 = compile_call(_form);
         }
-        _e33 = _e34;
+        _e44 = _e45;
       }
-      var _form1 = _e33;
-      return(ind + _form1 + tr);
+      var _form1 = _e44;
+      return(_ind1 + _form1 + _tr2);
     }
   }
 };
 var lower_statement = function (form, tail63) {
-  var hoist = [];
-  var e = lower(form, hoist, true, tail63);
-  if (some63(hoist) && is63(e)) {
-    return(join(["do"], hoist, [e]));
+  var _hoist = [];
+  var _e = lower(form, _hoist, true, tail63);
+  if (some63(_hoist) && is63(_e)) {
+    return(join(["do"], _hoist, [_e]));
   } else {
-    if (is63(e)) {
-      return(e);
+    if (is63(_e)) {
+      return(_e);
     } else {
-      if (_35(hoist) > 1) {
-        return(join(["do"], hoist));
+      if (_35(_hoist) > 1) {
+        return(join(["do"], _hoist));
       } else {
-        return(hd(hoist));
+        return(hd(_hoist));
       }
     }
   }
@@ -854,112 +854,112 @@ var standalone63 = function (form) {
   return(! atom63(form) && ! infix63(hd(form)) && ! literal63(form) && !( "get" === hd(form)) || id_literal63(form));
 };
 var lower_do = function (args, hoist, stmt63, tail63) {
-  var _x81 = almost(args);
-  var _i10 = 0;
-  while (_i10 < _35(_x81)) {
-    var x = _x81[_i10];
-    var _y = lower(x, hoist, stmt63);
-    if (yes(_y)) {
-      var e = _y;
-      if (standalone63(e)) {
-        add(hoist, e);
+  var __x92 = almost(args);
+  var __i18 = 0;
+  while (__i18 < _35(__x92)) {
+    var _x93 = __x92[__i18];
+    var __y = lower(_x93, hoist, stmt63);
+    if (yes(__y)) {
+      var _e1 = __y;
+      if (standalone63(_e1)) {
+        add(hoist, _e1);
       }
     }
-    _i10 = _i10 + 1;
+    __i18 = __i18 + 1;
   }
-  var _e = lower(last(args), hoist, stmt63, tail63);
-  if (tail63 && can_return63(_e)) {
-    return(["return", _e]);
+  var _e2 = lower(last(args), hoist, stmt63, tail63);
+  if (tail63 && can_return63(_e2)) {
+    return(["return", _e2]);
   } else {
-    return(_e);
+    return(_e2);
   }
 };
 var lower_set = function (args, hoist, stmt63, tail63) {
-  var _id15 = args;
-  var lh = _id15[0];
-  var rh = _id15[1];
-  add(hoist, ["%set", lh, lower(rh, hoist)]);
+  var __id16 = args;
+  var _lh = __id16[0];
+  var _rh = __id16[1];
+  add(hoist, ["%set", _lh, lower(_rh, hoist)]);
   if (!( stmt63 && ! tail63)) {
-    return(lh);
+    return(_lh);
   }
 };
 var lower_if = function (args, hoist, stmt63, tail63) {
-  var _id16 = args;
-  var cond = _id16[0];
-  var _then = _id16[1];
-  var _else = _id16[2];
+  var __id17 = args;
+  var _cond = __id17[0];
+  var _then = __id17[1];
+  var _else = __id17[2];
   if (stmt63) {
-    var _e36;
+    var _e47;
     if (is63(_else)) {
-      _e36 = [lower_body([_else], tail63)];
+      _e47 = [lower_body([_else], tail63)];
     }
-    return(add(hoist, join(["%if", lower(cond, hoist), lower_body([_then], tail63)], _e36)));
+    return(add(hoist, join(["%if", lower(_cond, hoist), lower_body([_then], tail63)], _e47)));
   } else {
-    var e = unique("e");
-    add(hoist, ["%local", e]);
-    var _e35;
+    var _e3 = unique("e");
+    add(hoist, ["%local", _e3]);
+    var _e46;
     if (is63(_else)) {
-      _e35 = [lower(["%set", e, _else])];
+      _e46 = [lower(["%set", _e3, _else])];
     }
-    add(hoist, join(["%if", lower(cond, hoist), lower(["%set", e, _then])], _e35));
-    return(e);
+    add(hoist, join(["%if", lower(_cond, hoist), lower(["%set", _e3, _then])], _e46));
+    return(_e3);
   }
 };
 var lower_short = function (x, args, hoist) {
-  var _id17 = args;
-  var a = _id17[0];
-  var b = _id17[1];
-  var hoist1 = [];
-  var b1 = lower(b, hoist1);
-  if (some63(hoist1)) {
-    var _id18 = unique("id");
-    var _e37;
+  var __id18 = args;
+  var _a3 = __id18[0];
+  var _b5 = __id18[1];
+  var _hoist1 = [];
+  var _b11 = lower(_b5, _hoist1);
+  if (some63(_hoist1)) {
+    var _id19 = unique("id");
+    var _e48;
     if (x === "and") {
-      _e37 = ["%if", _id18, b, _id18];
+      _e48 = ["%if", _id19, _b5, _id19];
     } else {
-      _e37 = ["%if", _id18, _id18, b];
+      _e48 = ["%if", _id19, _id19, _b5];
     }
-    return(lower(["do", ["%local", _id18, a], _e37], hoist));
+    return(lower(["do", ["%local", _id19, _a3], _e48], hoist));
   } else {
-    return([x, lower(a, hoist), b1]);
+    return([x, lower(_a3, hoist), _b11]);
   }
 };
 var lower_try = function (args, hoist, tail63) {
   return(add(hoist, ["%try", lower_body(args, tail63)]));
 };
 var lower_while = function (args, hoist) {
-  var _id19 = args;
-  var c = _id19[0];
-  var body = cut(_id19, 1);
-  var pre = [];
-  var _c = lower(c, pre);
-  var _e38;
-  if (none63(pre)) {
-    _e38 = ["while", _c, lower_body(body)];
+  var __id20 = args;
+  var _c4 = __id20[0];
+  var _body5 = cut(__id20, 1);
+  var _pre = [];
+  var _c5 = lower(_c4, _pre);
+  var _e49;
+  if (none63(_pre)) {
+    _e49 = ["while", _c5, lower_body(_body5)];
   } else {
-    _e38 = ["while", true, join(["do"], pre, [["%if", ["not", _c], ["break"]], lower_body(body)])];
+    _e49 = ["while", true, join(["do"], _pre, [["%if", ["not", _c5], ["break"]], lower_body(_body5)])];
   }
-  return(add(hoist, _e38));
+  return(add(hoist, _e49));
 };
 var lower_for = function (args, hoist) {
-  var _id20 = args;
-  var t = _id20[0];
-  var k = _id20[1];
-  var body = cut(_id20, 2);
-  return(add(hoist, ["%for", lower(t, hoist), k, lower_body(body)]));
+  var __id21 = args;
+  var _t = __id21[0];
+  var _k13 = __id21[1];
+  var _body6 = cut(__id21, 2);
+  return(add(hoist, ["%for", lower(_t, hoist), _k13, lower_body(_body6)]));
 };
 var lower_function = function (args) {
-  var _id21 = args;
-  var a = _id21[0];
-  var body = cut(_id21, 1);
-  return(["%function", a, lower_body(body, true)]);
+  var __id22 = args;
+  var _a4 = __id22[0];
+  var _body7 = cut(__id22, 1);
+  return(["%function", _a4, lower_body(_body7, true)]);
 };
 var lower_definition = function (kind, args, hoist) {
-  var _id22 = args;
-  var name = _id22[0];
-  var _args2 = _id22[1];
-  var body = cut(_id22, 2);
-  return(add(hoist, [kind, name, _args2, lower_body(body, true)]));
+  var __id23 = args;
+  var _name4 = __id23[0];
+  var _args6 = __id23[1];
+  var _body8 = cut(__id23, 2);
+  return(add(hoist, [kind, _name4, _args6, lower_body(_body8, true)]));
 };
 var lower_call = function (form, hoist) {
   var _form2 = map(function (x) {
@@ -974,15 +974,15 @@ var pairwise63 = function (form) {
 };
 var lower_pairwise = function (form) {
   if (pairwise63(form)) {
-    var e = [];
-    var _id23 = form;
-    var x = _id23[0];
-    var args = cut(_id23, 1);
+    var _e4 = [];
+    var __id24 = form;
+    var _x122 = __id24[0];
+    var _args7 = cut(__id24, 1);
     reduce(function (a, b) {
-      add(e, [x, a, b]);
+      add(_e4, [_x122, a, b]);
       return(a);
-    }, args);
-    return(join(["and"], reverse(e)));
+    }, _args7);
+    return(join(["and"], reverse(_e4)));
   } else {
     return(form);
   }
@@ -992,17 +992,17 @@ var lower_infix63 = function (form) {
 };
 var lower_infix = function (form, hoist) {
   var _form3 = lower_pairwise(form);
-  var _id24 = _form3;
-  var x = _id24[0];
-  var args = cut(_id24, 1);
+  var __id25 = _form3;
+  var _x125 = __id25[0];
+  var _args8 = cut(__id25, 1);
   return(lower(reduce(function (a, b) {
-    return([x, b, a]);
-  }, reverse(args)), hoist));
+    return([_x125, b, a]);
+  }, reverse(_args8)), hoist));
 };
 var lower_special = function (form, hoist) {
-  var e = lower_call(form, hoist);
-  if (e) {
-    return(add(hoist, e));
+  var _e5 = lower_call(form, hoist);
+  if (_e5) {
+    return(add(hoist, _e5));
   }
 };
 lower = function (form, hoist, stmt63, tail63) {
@@ -1018,37 +1018,37 @@ lower = function (form, hoist, stmt63, tail63) {
         if (lower_infix63(form)) {
           return(lower_infix(form, hoist));
         } else {
-          var _id24 = form;
-          var x = _id24[0];
-          var args = cut(_id24, 1);
-          if (x === "do") {
-            return(lower_do(args, hoist, stmt63, tail63));
+          var __id26 = form;
+          var _x128 = __id26[0];
+          var _args9 = cut(__id26, 1);
+          if (_x128 === "do") {
+            return(lower_do(_args9, hoist, stmt63, tail63));
           } else {
-            if (x === "%set") {
-              return(lower_set(args, hoist, stmt63, tail63));
+            if (_x128 === "%set") {
+              return(lower_set(_args9, hoist, stmt63, tail63));
             } else {
-              if (x === "%if") {
-                return(lower_if(args, hoist, stmt63, tail63));
+              if (_x128 === "%if") {
+                return(lower_if(_args9, hoist, stmt63, tail63));
               } else {
-                if (x === "%try") {
-                  return(lower_try(args, hoist, tail63));
+                if (_x128 === "%try") {
+                  return(lower_try(_args9, hoist, tail63));
                 } else {
-                  if (x === "while") {
-                    return(lower_while(args, hoist));
+                  if (_x128 === "while") {
+                    return(lower_while(_args9, hoist));
                   } else {
-                    if (x === "%for") {
-                      return(lower_for(args, hoist));
+                    if (_x128 === "%for") {
+                      return(lower_for(_args9, hoist));
                     } else {
-                      if (x === "%function") {
-                        return(lower_function(args));
+                      if (_x128 === "%function") {
+                        return(lower_function(_args9));
                       } else {
-                        if (x === "%local-function" || x === "%global-function") {
-                          return(lower_definition(x, args, hoist));
+                        if (_x128 === "%local-function" || _x128 === "%global-function") {
+                          return(lower_definition(_x128, _args9, hoist));
                         } else {
-                          if (in63(x, ["and", "or"])) {
-                            return(lower_short(x, args, hoist));
+                          if (in63(_x128, ["and", "or"])) {
+                            return(lower_short(_x128, _args9, hoist));
                           } else {
-                            if (statement63(x)) {
+                            if (statement63(_x128)) {
                               return(lower_special(form, hoist));
                             } else {
                               return(lower_call(form, hoist));
@@ -1074,103 +1074,103 @@ global.require = require;
 var run = eval;
 _37result = undefined;
 eval = function (form) {
-  var previous = target;
+  var _previous = target;
   target = "js";
-  var code = compile(expand(["set", "%result", form]));
-  target = previous;
-  run(code);
+  var _code = compile(expand(["set", "%result", form]));
+  target = _previous;
+  run(_code);
   return(_37result);
 };
 setenv("do", {_stash: true, special: function () {
-  var forms = unstash(Array.prototype.slice.call(arguments, 0));
-  var s = "";
-  var _x115 = forms;
-  var _i12 = 0;
-  while (_i12 < _35(_x115)) {
-    var x = _x115[_i12];
-    s = s + compile(x, {_stash: true, stmt: true});
-    if (! atom63(x)) {
-      if (hd(x) === "return" || hd(x) === "break") {
+  var _forms1 = unstash(Array.prototype.slice.call(arguments, 0));
+  var _s3 = "";
+  var __x133 = _forms1;
+  var __i20 = 0;
+  while (__i20 < _35(__x133)) {
+    var _x134 = __x133[__i20];
+    _s3 = _s3 + compile(_x134, {_stash: true, stmt: true});
+    if (! atom63(_x134)) {
+      if (hd(_x134) === "return" || hd(_x134) === "break") {
         break;
       }
     }
-    _i12 = _i12 + 1;
+    __i20 = __i20 + 1;
   }
-  return(s);
+  return(_s3);
 }, stmt: true, tr: true});
 setenv("%if", {_stash: true, special: function (cond, cons, alt) {
-  var _cond1 = compile(cond);
+  var _cond2 = compile(cond);
   indent_level = indent_level + 1;
-  var _x118 = compile(cons, {_stash: true, stmt: true});
+  var __x137 = compile(cons, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var _cons1 = _x118;
-  var _e39;
+  var _cons1 = __x137;
+  var _e50;
   if (alt) {
     indent_level = indent_level + 1;
-    var _x119 = compile(alt, {_stash: true, stmt: true});
+    var __x138 = compile(alt, {_stash: true, stmt: true});
     indent_level = indent_level - 1;
-    _e39 = _x119;
+    _e50 = __x138;
   }
-  var _alt1 = _e39;
-  var ind = indentation();
-  var s = "";
+  var _alt1 = _e50;
+  var _ind3 = indentation();
+  var _s5 = "";
   if (target === "js") {
-    s = s + ind + "if (" + _cond1 + ") {\n" + _cons1 + ind + "}";
+    _s5 = _s5 + _ind3 + "if (" + _cond2 + ") {\n" + _cons1 + _ind3 + "}";
   } else {
-    s = s + ind + "if " + _cond1 + " then\n" + _cons1;
+    _s5 = _s5 + _ind3 + "if " + _cond2 + " then\n" + _cons1;
   }
   if (_alt1 && target === "js") {
-    s = s + " else {\n" + _alt1 + ind + "}";
+    _s5 = _s5 + " else {\n" + _alt1 + _ind3 + "}";
   } else {
     if (_alt1) {
-      s = s + ind + "else\n" + _alt1;
+      _s5 = _s5 + _ind3 + "else\n" + _alt1;
     }
   }
   if (target === "lua") {
-    return(s + ind + "end\n");
+    return(_s5 + _ind3 + "end\n");
   } else {
-    return(s + "\n");
+    return(_s5 + "\n");
   }
 }, stmt: true, tr: true});
 setenv("while", {_stash: true, special: function (cond, form) {
-  var _cond3 = compile(cond);
+  var _cond4 = compile(cond);
   indent_level = indent_level + 1;
-  var _x121 = compile(form, {_stash: true, stmt: true});
+  var __x140 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var body = _x121;
-  var ind = indentation();
+  var _body10 = __x140;
+  var _ind5 = indentation();
   if (target === "js") {
-    return(ind + "while (" + _cond3 + ") {\n" + body + ind + "}\n");
+    return(_ind5 + "while (" + _cond4 + ") {\n" + _body10 + _ind5 + "}\n");
   } else {
-    return(ind + "while " + _cond3 + " do\n" + body + ind + "end\n");
+    return(_ind5 + "while " + _cond4 + " do\n" + _body10 + _ind5 + "end\n");
   }
 }, stmt: true, tr: true});
 setenv("%for", {_stash: true, special: function (t, k, form) {
-  var _t1 = compile(t);
-  var ind = indentation();
+  var _t2 = compile(t);
+  var _ind7 = indentation();
   indent_level = indent_level + 1;
-  var _x123 = compile(form, {_stash: true, stmt: true});
+  var __x142 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var body = _x123;
+  var _body12 = __x142;
   if (target === "lua") {
-    return(ind + "for " + k + " in next, " + _t1 + " do\n" + body + ind + "end\n");
+    return(_ind7 + "for " + k + " in next, " + _t2 + " do\n" + _body12 + _ind7 + "end\n");
   } else {
-    return(ind + "for (" + k + " in " + _t1 + ") {\n" + body + ind + "}\n");
+    return(_ind7 + "for (" + k + " in " + _t2 + ") {\n" + _body12 + _ind7 + "}\n");
   }
 }, stmt: true, tr: true});
 setenv("%try", {_stash: true, special: function (form) {
-  var e = unique("e");
-  var ind = indentation();
+  var _e8 = unique("e");
+  var _ind9 = indentation();
   indent_level = indent_level + 1;
-  var _x128 = compile(form, {_stash: true, stmt: true});
+  var __x147 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var body = _x128;
-  var hf = ["return", ["%array", false, e]];
+  var _body14 = __x147;
+  var _hf1 = ["return", ["%array", false, _e8]];
   indent_level = indent_level + 1;
-  var _x131 = compile(hf, {_stash: true, stmt: true});
+  var __x150 = compile(_hf1, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var h = _x131;
-  return(ind + "try {\n" + body + ind + "}\n" + ind + "catch (" + e + ") {\n" + h + ind + "}\n");
+  var _h1 = __x150;
+  return(_ind9 + "try {\n" + _body14 + _ind9 + "}\n" + _ind9 + "catch (" + _e8 + ") {\n" + _h1 + _ind9 + "}\n");
 }, stmt: true, tr: true});
 setenv("%delete", {_stash: true, special: function (place) {
   return(indentation() + "delete " + compile(place));
@@ -1183,29 +1183,29 @@ setenv("%function", {_stash: true, special: function (args, body) {
 }});
 setenv("%global-function", {_stash: true, special: function (name, args, body) {
   if (target === "lua") {
-    var x = compile_function(args, body, {_stash: true, name: name});
-    return(indentation() + x);
+    var _x154 = compile_function(args, body, {_stash: true, name: name});
+    return(indentation() + _x154);
   } else {
     return(compile(["%set", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
 }, stmt: true, tr: true});
 setenv("%local-function", {_stash: true, special: function (name, args, body) {
   if (target === "lua") {
-    var x = compile_function(args, body, {_stash: true, prefix: "local", name: name});
-    return(indentation() + x);
+    var _x160 = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
+    return(indentation() + _x160);
   } else {
     return(compile(["%local", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
 }, stmt: true, tr: true});
 setenv("return", {_stash: true, special: function (x) {
-  var _e40;
+  var _e51;
   if (nil63(x)) {
-    _e40 = "return";
+    _e51 = "return";
   } else {
-    _e40 = "return(" + compile(x) + ")";
+    _e51 = "return(" + compile(x) + ")";
   }
-  var _x141 = _e40;
-  return(indentation() + _x141);
+  var _x164 = _e51;
+  return(indentation() + _x164);
 }, stmt: true});
 setenv("new", {_stash: true, special: function (x) {
   return("new " + compile(x));
@@ -1214,132 +1214,132 @@ setenv("typeof", {_stash: true, special: function (x) {
   return("typeof(" + compile(x) + ")");
 }});
 setenv("error", {_stash: true, special: function (x) {
-  var _e41;
+  var _e52;
   if (target === "js") {
-    _e41 = "throw " + compile(["new", ["Error", x]]);
+    _e52 = "throw " + compile(["new", ["Error", x]]);
   } else {
-    _e41 = "error(" + compile(x) + ")";
+    _e52 = "error(" + compile(x) + ")";
   }
-  var e = _e41;
-  return(indentation() + e);
+  var _e12 = _e52;
+  return(indentation() + _e12);
 }, stmt: true});
 setenv("%local", {_stash: true, special: function (name, value) {
-  var _id26 = compile(name);
-  var value1 = compile(value);
-  var _e42;
+  var _id28 = compile(name);
+  var _value11 = compile(value);
+  var _e53;
   if (is63(value)) {
-    _e42 = " = " + value1;
+    _e53 = " = " + _value11;
   } else {
-    _e42 = "";
+    _e53 = "";
   }
-  var rh = _e42;
-  var _e43;
+  var _rh2 = _e53;
+  var _e54;
   if (target === "js") {
-    _e43 = "var ";
+    _e54 = "var ";
   } else {
-    _e43 = "local ";
+    _e54 = "local ";
   }
-  var keyword = _e43;
-  var ind = indentation();
-  return(ind + keyword + _id26 + rh);
+  var _keyword1 = _e54;
+  var _ind11 = indentation();
+  return(_ind11 + _keyword1 + _id28 + _rh2);
 }, stmt: true});
 setenv("%set", {_stash: true, special: function (lh, rh) {
-  var _lh1 = compile(lh);
-  var _e44;
+  var _lh2 = compile(lh);
+  var _e55;
   if (nil63(rh)) {
-    _e44 = "nil";
+    _e55 = "nil";
   } else {
-    _e44 = rh;
+    _e55 = rh;
   }
-  var _rh1 = compile(_e44);
-  return(indentation() + _lh1 + " = " + _rh1);
+  var _rh4 = compile(_e55);
+  return(indentation() + _lh2 + " = " + _rh4);
 }, stmt: true});
 setenv("get", {_stash: true, special: function (t, k) {
-  var _t3 = compile(t);
-  var k1 = compile(k);
-  if (target === "lua" && char(_t3, 0) === "{") {
-    _t3 = "(" + _t3 + ")";
+  var _t4 = compile(t);
+  var _k121 = compile(k);
+  if (target === "lua" && char(_t4, 0) === "{") {
+    _t4 = "(" + _t4 + ")";
   }
   if (string_literal63(k) && valid_id63(inner(k))) {
-    return(_t3 + "." + inner(k));
+    return(_t4 + "." + inner(k));
   } else {
-    return(_t3 + "[" + k1 + "]");
+    return(_t4 + "[" + _k121 + "]");
   }
 }});
 setenv("%array", {_stash: true, special: function () {
-  var forms = unstash(Array.prototype.slice.call(arguments, 0));
-  var _e45;
+  var _forms3 = unstash(Array.prototype.slice.call(arguments, 0));
+  var _e56;
   if (target === "lua") {
-    _e45 = "{";
+    _e56 = "{";
   } else {
-    _e45 = "[";
+    _e56 = "[";
   }
-  var open = _e45;
-  var _e46;
+  var _open1 = _e56;
+  var _e57;
   if (target === "lua") {
-    _e46 = "}";
+    _e57 = "}";
   } else {
-    _e46 = "]";
+    _e57 = "]";
   }
-  var close = _e46;
-  var s = "";
-  var c = "";
-  var _o9 = forms;
-  var k = undefined;
-  for (k in _o9) {
-    var v = _o9[k];
-    var _e47;
-    if (numeric63(k)) {
-      _e47 = parseInt(k);
+  var _close1 = _e57;
+  var _s7 = "";
+  var _c7 = "";
+  var __o10 = _forms3;
+  var _k16 = undefined;
+  for (_k16 in __o10) {
+    var _v9 = __o10[_k16];
+    var _e58;
+    if (numeric63(_k16)) {
+      _e58 = parseInt(_k16);
     } else {
-      _e47 = k;
+      _e58 = _k16;
     }
-    var _k7 = _e47;
-    if (number63(_k7)) {
-      s = s + c + compile(v);
-      c = ", ";
+    var _k17 = _e58;
+    if (number63(_k17)) {
+      _s7 = _s7 + _c7 + compile(_v9);
+      _c7 = ", ";
     }
   }
-  return(open + s + close);
+  return(_open1 + _s7 + _close1);
 }});
 setenv("%object", {_stash: true, special: function () {
-  var forms = unstash(Array.prototype.slice.call(arguments, 0));
-  var s = "{";
-  var c = "";
-  var _e48;
+  var _forms5 = unstash(Array.prototype.slice.call(arguments, 0));
+  var _s9 = "{";
+  var _c9 = "";
+  var _e59;
   if (target === "lua") {
-    _e48 = " = ";
+    _e59 = " = ";
   } else {
-    _e48 = ": ";
+    _e59 = ": ";
   }
-  var sep = _e48;
-  var _o11 = pair(forms);
-  var k = undefined;
-  for (k in _o11) {
-    var v = _o11[k];
-    var _e49;
-    if (numeric63(k)) {
-      _e49 = parseInt(k);
+  var _sep1 = _e59;
+  var __o12 = pair(_forms5);
+  var _k21 = undefined;
+  for (_k21 in __o12) {
+    var _v12 = __o12[_k21];
+    var _e60;
+    if (numeric63(_k21)) {
+      _e60 = parseInt(_k21);
     } else {
-      _e49 = k;
+      _e60 = _k21;
     }
-    var _k9 = _e49;
-    if (number63(_k9)) {
-      var _id28 = v;
-      var _k10 = _id28[0];
-      var _v3 = _id28[1];
-      if (! string63(_k10)) {
-        throw new Error("Illegal key: " + str(_k10));
+    var _k22 = _e60;
+    if (number63(_k22)) {
+      var __id30 = _v12;
+      var _k23 = __id30[0];
+      var _v13 = __id30[1];
+      if (! string63(_k23)) {
+        throw new Error("Illegal key: " + str(_k23));
       }
-      s = s + c + key(_k10) + sep + compile(_v3);
-      c = ", ";
+      _s9 = _s9 + _c9 + key(_k23) + _sep1 + compile(_v13);
+      _c9 = ", ";
     }
   }
-  return(s + "}");
+  return(_s9 + "}");
 }});
 setenv("%literal", {_stash: true, special: function () {
-  var args = unstash(Array.prototype.slice.call(arguments, 0));
-  return(apply(cat, map(compile, args)));
+  var _args111 = unstash(Array.prototype.slice.call(arguments, 0));
+  return(apply(cat, map(compile, _args111)));
 }});
 exports.run = run;
 exports.eval = eval;

--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -1337,6 +1337,10 @@ setenv("%object", {_stash: true, special: function () {
   }
   return(s + "}");
 }});
+setenv("%literal", {_stash: true, special: function () {
+  var args = unstash(Array.prototype.slice.call(arguments, 0));
+  return(apply(cat, map(compile, args)));
+}});
 exports.run = run;
 exports.eval = eval;
 exports.expand = expand;

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -1,19 +1,19 @@
 local reader = require("reader")
 local function getenv(k, p)
   if string63(k) then
-    local i = edge(environment)
-    while i >= 0 do
-      local b = environment[i + 1][k]
-      if is63(b) then
-        local _e10
+    local _i = edge(environment)
+    while _i >= 0 do
+      local _b = environment[_i + 1][k]
+      if is63(_b) then
+        local _e21
         if p then
-          _e10 = b[p]
+          _e21 = _b[p]
         else
-          _e10 = b
+          _e21 = _b
         end
-        return(_e10)
+        return(_e21)
       else
-        i = i - 1
+        _i = _i - 1
       end
     end
   end
@@ -40,10 +40,10 @@ local function symbol63(k)
   return(is63(symbol_expansion(k)))
 end
 local function variable63(k)
-  local b = first(function (frame)
+  local _b1 = first(function (frame)
     return(frame[k])
   end, reverse(environment))
-  return(not atom63(b) and is63(b.variable))
+  return(not atom63(_b1) and is63(_b1.variable))
 end
 function bound63(x)
   return(macro63(x) or special63(x) or symbol63(x) or variable63(x))
@@ -69,9 +69,9 @@ end
 local _names = {}
 function unique(x)
   if _names[x] then
-    local i = _names[x]
+    local _i1 = _names[x]
     _names[x] = _names[x] + 1
-    return(unique(x .. i))
+    return(unique(x .. _i1))
   else
     _names[x] = 1
     return("_" .. x)
@@ -79,17 +79,17 @@ function unique(x)
 end
 local function stash42(args)
   if keys63(args) then
-    local l = {"%object", "\"_stash\"", true}
-    local _o = args
-    local k = nil
-    for k in next, _o do
-      local v = _o[k]
-      if not number63(k) then
-        add(l, literal(k))
-        add(l, v)
+    local _l = {"%object", "\"_stash\"", true}
+    local __o = args
+    local _k = nil
+    for _k in next, __o do
+      local _v = __o[_k]
+      if not number63(_k) then
+        add(_l, literal(_k))
+        add(_l, _v)
       end
     end
-    return(join(args, {l}))
+    return(join(args, {_l}))
   else
     return(args)
   end
@@ -108,83 +108,83 @@ function bind(lh, rh)
   if atom63(lh) then
     return({lh, rh})
   else
-    local id = unique("id")
-    local bs = {id, rh}
-    local _o1 = lh
-    local k = nil
-    for k in next, _o1 do
-      local v = _o1[k]
-      local _e11
-      if k == "rest" then
-        _e11 = {"cut", id, _35(lh)}
+    local _id = unique("id")
+    local _bs = {_id, rh}
+    local __o1 = lh
+    local _k1 = nil
+    for _k1 in next, __o1 do
+      local _v1 = __o1[_k1]
+      local _e22
+      if _k1 == "rest" then
+        _e22 = {"cut", _id, _35(lh)}
       else
-        _e11 = {"get", id, {"quote", bias(k)}}
+        _e22 = {"get", _id, {"quote", bias(_k1)}}
       end
-      local x = _e11
-      if is63(k) then
-        local _e12
-        if v == true then
-          _e12 = k
+      local _x5 = _e22
+      if is63(_k1) then
+        local _e23
+        if _v1 == true then
+          _e23 = _k1
         else
-          _e12 = v
+          _e23 = _v1
         end
-        local _k = _e12
-        bs = join(bs, bind(_k, x))
+        local _k2 = _e23
+        _bs = join(_bs, bind(_k2, _x5))
       end
     end
-    return(bs)
+    return(_bs)
   end
 end
 setenv("arguments%", {_stash = true, macro = function (from)
   return({{"get", {"get", {"get", "Array", {"quote", "prototype"}}, {"quote", "slice"}}, {"quote", "call"}}, "arguments", from})
 end})
 function bind42(args, body)
-  local args1 = {}
+  local _args1 = {}
   local function rest()
     if target == "js" then
-      return({"unstash", {"arguments%", _35(args1)}})
+      return({"unstash", {"arguments%", _35(_args1)}})
     else
-      add(args1, "|...|")
+      add(_args1, "|...|")
       return({"unstash", {"list", "|...|"}})
     end
   end
   if atom63(args) then
-    return({args1, join({"let", {args, rest()}}, body)})
+    return({_args1, join({"let", {args, rest()}}, body)})
   else
-    local bs = {}
-    local r = unique("r")
-    local _o2 = args
-    local k = nil
-    for k in next, _o2 do
-      local v = _o2[k]
-      if number63(k) then
-        if atom63(v) then
-          add(args1, v)
+    local _bs1 = {}
+    local _r21 = unique("r")
+    local __o2 = args
+    local _k3 = nil
+    for _k3 in next, __o2 do
+      local _v2 = __o2[_k3]
+      if number63(_k3) then
+        if atom63(_v2) then
+          add(_args1, _v2)
         else
-          local x = unique("x")
-          add(args1, x)
-          bs = join(bs, {v, x})
+          local _x30 = unique("x")
+          add(_args1, _x30)
+          _bs1 = join(_bs1, {_v2, _x30})
         end
       end
     end
     if keys63(args) then
-      bs = join(bs, {r, rest()})
-      local _e13
+      _bs1 = join(_bs1, {_r21, rest()})
+      local _e24
       if target == "lua" then
-        _e13 = edge(args1)
+        _e24 = edge(_args1)
       else
-        _e13 = _35(args1)
+        _e24 = _35(_args1)
       end
-      local n = _e13
-      local i = 0
-      while i < n do
-        local _v = args1[i + 1]
-        bs = join(bs, {_v, {"destash!", _v, r}})
-        i = i + 1
+      local _n3 = _e24
+      local _i5 = 0
+      while _i5 < _n3 do
+        local _v3 = _args1[_i5 + 1]
+        _bs1 = join(_bs1, {_v3, {"destash!", _v3, _r21}})
+        _i5 = _i5 + 1
       end
-      bs = join(bs, {keys(args), r})
+      _bs1 = join(_bs1, {keys(args), _r21})
     end
-    return({args1, join({"let", bs}, body)})
+    return({_args1, join({"let", _bs1}, body)})
   end
 end
 local function quoting63(depth)
@@ -199,55 +199,55 @@ end
 local function quasisplice63(x, depth)
   return(can_unquote63(depth) and not atom63(x) and hd(x) == "unquote-splicing")
 end
-local function expand_local(_x36)
-  local _id = _x36
-  local x = _id[1]
-  local name = _id[2]
-  local value = _id[3]
-  setenv(name, {_stash = true, variable = true})
-  return({"%local", name, macroexpand(value)})
+local function expand_local(_x38)
+  local __id1 = _x38
+  local _x39 = __id1[1]
+  local _name = __id1[2]
+  local _value = __id1[3]
+  setenv(_name, {_stash = true, variable = true})
+  return({"%local", _name, macroexpand(_value)})
 end
-local function expand_function(_x38)
-  local _id1 = _x38
-  local x = _id1[1]
-  local args = _id1[2]
-  local body = cut(_id1, 2)
+local function expand_function(_x41)
+  local __id2 = _x41
+  local _x42 = __id2[1]
+  local _args = __id2[2]
+  local _body = cut(__id2, 2)
   add(environment, {})
-  local _o3 = args
-  local _i3 = nil
-  for _i3 in next, _o3 do
-    local _x39 = _o3[_i3]
-    setenv(_x39, {_stash = true, variable = true})
+  local __o3 = _args
+  local __i6 = nil
+  for __i6 in next, __o3 do
+    local __x43 = __o3[__i6]
+    setenv(__x43, {_stash = true, variable = true})
   end
-  local _x40 = join({"%function", args}, macroexpand(body))
+  local __x44 = join({"%function", _args}, macroexpand(_body))
   drop(environment)
-  return(_x40)
+  return(__x44)
 end
-local function expand_definition(_x42)
-  local _id2 = _x42
-  local x = _id2[1]
-  local name = _id2[2]
-  local args = _id2[3]
-  local body = cut(_id2, 3)
+local function expand_definition(_x46)
+  local __id3 = _x46
+  local _x47 = __id3[1]
+  local _name1 = __id3[2]
+  local _args11 = __id3[3]
+  local _body1 = cut(__id3, 3)
   add(environment, {})
-  local _o4 = args
-  local _i4 = nil
-  for _i4 in next, _o4 do
-    local _x43 = _o4[_i4]
-    setenv(_x43, {_stash = true, variable = true})
+  local __o4 = _args11
+  local __i7 = nil
+  for __i7 in next, __o4 do
+    local __x48 = __o4[__i7]
+    setenv(__x48, {_stash = true, variable = true})
   end
-  local _x44 = join({x, name, args}, macroexpand(body))
+  local __x49 = join({_x47, _name1, _args11}, macroexpand(_body1))
   drop(environment)
-  return(_x44)
+  return(__x49)
 end
 local function expand_macro(form)
   return(macroexpand(expand1(form)))
 end
-function expand1(_x46)
-  local _id3 = _x46
-  local name = _id3[1]
-  local body = cut(_id3, 1)
-  return(apply(macro_function(name), body))
+function expand1(_x51)
+  local __id4 = _x51
+  local _name2 = __id4[1]
+  local _body2 = cut(__id4, 1)
+  return(apply(macro_function(_name2), _body2))
 end
 function macroexpand(form)
   if symbol63(form) then
@@ -256,20 +256,20 @@ function macroexpand(form)
     if atom63(form) then
       return(form)
     else
-      local x = hd(form)
-      if x == "%local" then
+      local _x52 = hd(form)
+      if _x52 == "%local" then
         return(expand_local(form))
       else
-        if x == "%function" then
+        if _x52 == "%function" then
           return(expand_function(form))
         else
-          if x == "%global-function" then
+          if _x52 == "%global-function" then
             return(expand_definition(form))
           else
-            if x == "%local-function" then
+            if _x52 == "%local-function" then
               return(expand_definition(form))
             else
-              if macro63(x) then
+              if macro63(_x52) then
                 return(expand_macro(form))
               else
                 return(map(macroexpand, form))
@@ -282,42 +282,42 @@ function macroexpand(form)
   end
 end
 local function quasiquote_list(form, depth)
-  local xs = {{"list"}}
-  local _o5 = form
-  local k = nil
-  for k in next, _o5 do
-    local v = _o5[k]
-    if not number63(k) then
-      local _e14
-      if quasisplice63(v, depth) then
-        _e14 = quasiexpand(v[2])
+  local _xs = {{"list"}}
+  local __o5 = form
+  local _k4 = nil
+  for _k4 in next, __o5 do
+    local _v4 = __o5[_k4]
+    if not number63(_k4) then
+      local _e25
+      if quasisplice63(_v4, depth) then
+        _e25 = quasiexpand(_v4[2])
       else
-        _e14 = quasiexpand(v, depth)
+        _e25 = quasiexpand(_v4, depth)
       end
-      local _v1 = _e14
-      last(xs)[k] = _v1
+      local _v5 = _e25
+      last(_xs)[_k4] = _v5
     end
   end
-  local _x49 = form
-  local _i6 = 0
-  while _i6 < _35(_x49) do
-    local x = _x49[_i6 + 1]
-    if quasisplice63(x, depth) then
-      local _x50 = quasiexpand(x[2])
-      add(xs, _x50)
-      add(xs, {"list"})
+  local __x55 = form
+  local __i9 = 0
+  while __i9 < _35(__x55) do
+    local _x56 = __x55[__i9 + 1]
+    if quasisplice63(_x56, depth) then
+      local _x57 = quasiexpand(_x56[2])
+      add(_xs, _x57)
+      add(_xs, {"list"})
     else
-      add(last(xs), quasiexpand(x, depth))
+      add(last(_xs), quasiexpand(_x56, depth))
     end
-    _i6 = _i6 + 1
+    __i9 = __i9 + 1
   end
-  local pruned = keep(function (x)
+  local _pruned = keep(function (x)
     return(_35(x) > 1 or not( hd(x) == "list") or keys63(x))
-  end, xs)
-  if one63(pruned) then
-    return(hd(pruned))
+  end, _xs)
+  if one63(_pruned) then
+    return(hd(_pruned))
   else
-    return(join({"join"}, pruned))
+    return(join({"join"}, _pruned))
   end
 end
 function quasiexpand(form, depth)
@@ -357,30 +357,30 @@ function quasiexpand(form, depth)
     end
   end
 end
-function expand_if(_x54)
-  local _id4 = _x54
-  local a = _id4[1]
-  local b = _id4[2]
-  local c = cut(_id4, 2)
-  if is63(b) then
-    return({join({"%if", a, b}, expand_if(c))})
+function expand_if(_x61)
+  local __id5 = _x61
+  local _a = __id5[1]
+  local _b2 = __id5[2]
+  local _c = cut(__id5, 2)
+  if is63(_b2) then
+    return({join({"%if", _a, _b2}, expand_if(_c))})
   else
-    if is63(a) then
-      return({a})
+    if is63(_a) then
+      return({_a})
     end
   end
 end
 indent_level = 0
 function indentation()
-  local s = ""
-  local i = 0
-  while i < indent_level do
-    s = s .. "  "
-    i = i + 1
+  local _s = ""
+  local _i10 = 0
+  while _i10 < indent_level do
+    _s = _s .. "  "
+    _i10 = _i10 + 1
   end
-  return(s)
+  return(_s)
 end
-local reserved = {["continue"] = true, ["finally"] = true, ["return"] = true, ["delete"] = true, ["%"] = true, ["debugger"] = true, ["+"] = true, ["-"] = true, ["/"] = true, ["end"] = true, ["<"] = true, ["=="] = true, [">"] = true, ["nil"] = true, ["instanceof"] = true, ["until"] = true, ["default"] = true, ["or"] = true, ["true"] = true, ["not"] = true, ["switch"] = true, ["case"] = true, [">="] = true, ["elseif"] = true, ["var"] = true, ["void"] = true, ["<="] = true, ["catch"] = true, ["and"] = true, ["then"] = true, ["local"] = true, ["repeat"] = true, ["if"] = true, ["false"] = true, ["*"] = true, ["else"] = true, ["throw"] = true, ["with"] = true, ["typeof"] = true, ["try"] = true, ["break"] = true, ["while"] = true, ["="] = true, ["for"] = true, ["in"] = true, ["new"] = true, ["function"] = true, ["do"] = true}
+local reserved = {["="] = true, ["=="] = true, ["+"] = true, ["-"] = true, ["%"] = true, ["*"] = true, ["/"] = true, ["<"] = true, [">"] = true, ["<="] = true, [">="] = true, ["break"] = true, ["case"] = true, ["catch"] = true, ["continue"] = true, ["debugger"] = true, ["default"] = true, ["delete"] = true, ["do"] = true, ["else"] = true, ["finally"] = true, ["for"] = true, ["function"] = true, ["if"] = true, ["in"] = true, ["instanceof"] = true, ["new"] = true, ["return"] = true, ["switch"] = true, ["throw"] = true, ["try"] = true, ["typeof"] = true, ["var"] = true, ["void"] = true, ["with"] = true, ["and"] = true, ["end"] = true, ["repeat"] = true, ["while"] = true, ["false"] = true, ["local"] = true, ["nil"] = true, ["then"] = true, ["not"] = true, ["true"] = true, ["elseif"] = true, ["or"] = true, ["until"] = true}
 function reserved63(x)
   return(reserved[x])
 end
@@ -391,20 +391,20 @@ function valid_id63(id)
   if none63(id) or reserved63(id) then
     return(false)
   else
-    local i = 0
-    while i < _35(id) do
-      if not valid_code63(code(id, i)) then
+    local _i11 = 0
+    while _i11 < _35(id) do
+      if not valid_code63(code(id, _i11)) then
         return(false)
       end
-      i = i + 1
+      _i11 = _i11 + 1
     end
     return(true)
   end
 end
 function key(k)
-  local i = inner(k)
-  if valid_id63(i) then
-    return(i)
+  local _i12 = inner(k)
+  if valid_id63(_i12) then
+    return(_i12)
   else
     if target == "js" then
       return(k)
@@ -414,57 +414,57 @@ function key(k)
   end
 end
 function mapo(f, t)
-  local o = {}
-  local _o6 = t
-  local k = nil
-  for k in next, _o6 do
-    local v = _o6[k]
-    local x = f(v)
-    if is63(x) then
-      add(o, literal(k))
-      add(o, x)
+  local _o6 = {}
+  local __o7 = t
+  local _k5 = nil
+  for _k5 in next, __o7 do
+    local _v6 = __o7[_k5]
+    local _x65 = f(_v6)
+    if is63(_x65) then
+      add(_o6, literal(_k5))
+      add(_o6, _x65)
     end
   end
-  return(o)
+  return(_o6)
 end
-local __x59 = {}
-local _x60 = {}
-_x60.js = "!"
-_x60.lua = "not"
-__x59["not"] = _x60
-local __x61 = {}
-__x61["*"] = true
-__x61["%"] = true
-__x61["/"] = true
-local __x62 = {}
-__x62["+"] = true
-__x62["-"] = true
-local __x63 = {}
-local _x64 = {}
-_x64.js = "+"
-_x64.lua = ".."
-__x63.cat = _x64
-local __x65 = {}
-__x65[">"] = true
-__x65["<="] = true
-__x65["<"] = true
-__x65[">="] = true
-local __x66 = {}
-local _x67 = {}
-_x67.js = "==="
-_x67.lua = "=="
-__x66["="] = _x67
+local __x67 = {}
 local __x68 = {}
-local _x69 = {}
-_x69.js = "&&"
-_x69.lua = "and"
-__x68["and"] = _x69
+__x68.js = "!"
+__x68.lua = "not"
+__x67["not"] = __x68
+local __x69 = {}
+__x69["*"] = true
+__x69["/"] = true
+__x69["%"] = true
 local __x70 = {}
-local _x71 = {}
-_x71.js = "||"
-_x71.lua = "or"
-__x70["or"] = _x71
-local infix = {__x59, __x61, __x62, __x63, __x65, __x66, __x68, __x70}
+__x70["+"] = true
+__x70["-"] = true
+local __x71 = {}
+local __x72 = {}
+__x72.js = "+"
+__x72.lua = ".."
+__x71.cat = __x72
+local __x73 = {}
+__x73["<"] = true
+__x73[">"] = true
+__x73["<="] = true
+__x73[">="] = true
+local __x74 = {}
+local __x75 = {}
+__x75.js = "==="
+__x75.lua = "=="
+__x74["="] = __x75
+local __x76 = {}
+local __x77 = {}
+__x77.js = "&&"
+__x77.lua = "and"
+__x76["and"] = __x77
+local __x78 = {}
+local __x79 = {}
+__x79.js = "||"
+__x79.lua = "or"
+__x78["or"] = __x79
+local infix = {__x67, __x69, __x70, __x71, __x73, __x74, __x76, __x78}
 local function unary63(form)
   return(two63(form) and in63(hd(form), {"not", "-"}))
 end
@@ -475,12 +475,12 @@ local function index(k)
 end
 local function precedence(form)
   if not( atom63(form) or unary63(form)) then
-    local _o7 = infix
-    local k = nil
-    for k in next, _o7 do
-      local v = _o7[k]
-      if v[hd(form)] then
-        return(index(k))
+    local __o8 = infix
+    local _k6 = nil
+    for _k6 in next, __o8 do
+      local _v7 = __o8[_k6]
+      if _v7[hd(form)] then
+        return(index(_k6))
       end
     end
   end
@@ -488,12 +488,12 @@ local function precedence(form)
 end
 local function getop(op)
   return(find(function (level)
-    local x = level[op]
-    if x == true then
+    local _x81 = level[op]
+    if _x81 == true then
       return(op)
     else
-      if is63(x) then
-        return(x[target])
+      if is63(_x81) then
+        return(_x81[target])
       end
     end
   end, infix))
@@ -502,72 +502,72 @@ local function infix63(x)
   return(is63(getop(x)))
 end
 local function compile_args(args)
-  local s = "("
-  local c = ""
-  local _x73 = args
-  local _i9 = 0
-  while _i9 < _35(_x73) do
-    local x = _x73[_i9 + 1]
-    s = s .. c .. compile(x)
-    c = ", "
-    _i9 = _i9 + 1
+  local _s1 = "("
+  local _c1 = ""
+  local __x82 = args
+  local __i15 = 0
+  while __i15 < _35(__x82) do
+    local _x83 = __x82[__i15 + 1]
+    _s1 = _s1 .. _c1 .. compile(_x83)
+    _c1 = ", "
+    __i15 = __i15 + 1
   end
-  return(s .. ")")
+  return(_s1 .. ")")
 end
 local function escape_newlines(s)
-  local s1 = ""
-  local i = 0
-  while i < _35(s) do
-    local c = char(s, i)
-    local _e15
-    if c == "\n" then
-      _e15 = "\\n"
+  local _s11 = ""
+  local _i16 = 0
+  while _i16 < _35(s) do
+    local _c2 = char(s, _i16)
+    local _e26
+    if _c2 == "\n" then
+      _e26 = "\\n"
     else
-      _e15 = c
+      _e26 = _c2
     end
-    s1 = s1 .. _e15
-    i = i + 1
+    _s11 = _s11 .. _e26
+    _i16 = _i16 + 1
   end
-  return(s1)
+  return(_s11)
 end
 local function id(id)
-  local _e16
+  local _e27
   if number_code63(code(id, 0)) then
-    _e16 = "_"
+    _e27 = "_"
   else
-    _e16 = ""
+    _e27 = ""
   end
-  local id1 = _e16
-  local i = 0
-  while i < _35(id) do
-    local c = char(id, i)
-    local n = code(c)
-    local _e17
-    if c == "-" and not( id == "-") then
-      _e17 = "_"
+  local _id11 = _e27
+  local _i17 = 0
+  while _i17 < _35(id) do
+    local _c3 = char(id, _i17)
+    local _n9 = code(_c3)
+    local _e28
+    if _c3 == "-" and not( id == "-") then
+      _e28 = "_"
     else
-      local _e18
-      if valid_code63(n) then
-        _e18 = c
+      local _e29
+      if valid_code63(_n9) then
+        _e29 = _c3
       else
-        local _e19
-        if i == 0 then
-          _e19 = "_" .. n
+        local _e30
+        if _i17 == 0 then
+          _e30 = "_" .. _n9
         else
-          _e19 = n
+          _e30 = _n9
         end
-        _e18 = _e19
+        _e29 = _e30
       end
-      _e17 = _e18
+      _e28 = _e29
     end
-    local c1 = _e17
-    id1 = id1 .. c1
-    i = i + 1
+    local _c11 = _e28
+    _id11 = _id11 .. _c11
+    _i17 = _i17 + 1
   end
-  if reserved63(id1) then
-    return("_" .. id1)
+  if reserved63(_id11) then
+    return("_" .. _id11)
   else
-    return(id1)
+    return(_id11)
   end
 end
 local function compile_atom(x)
@@ -629,163 +629,163 @@ local function terminator(stmt63)
   end
 end
 local function compile_special(form, stmt63)
-  local _id5 = form
-  local x = _id5[1]
-  local args = cut(_id5, 1)
-  local _id6 = getenv(x)
-  local stmt = _id6.stmt
-  local special = _id6.special
-  local self_tr63 = _id6.tr
-  local tr = terminator(stmt63 and not self_tr63)
-  return(apply(special, args) .. tr)
+  local __id6 = form
+  local _x84 = __id6[1]
+  local _args2 = cut(__id6, 1)
+  local __id7 = getenv(_x84)
+  local _special = __id7.special
+  local _stmt = __id7.stmt
+  local _self_tr63 = __id7.tr
+  local _tr = terminator(stmt63 and not _self_tr63)
+  return(apply(_special, _args2) .. _tr)
 end
 local function parenthesize_call63(x)
   return(not atom63(x) and hd(x) == "%function" or precedence(x) > 0)
 end
 local function compile_call(form)
-  local f = hd(form)
-  local f1 = compile(f)
-  local args = compile_args(stash42(tl(form)))
-  if parenthesize_call63(f) then
-    return("(" .. f1 .. ")" .. args)
+  local _f = hd(form)
+  local _f1 = compile(_f)
+  local _args3 = compile_args(stash42(tl(form)))
+  if parenthesize_call63(_f) then
+    return("(" .. _f1 .. ")" .. _args3)
   else
-    return(f1 .. args)
+    return(_f1 .. _args3)
   end
 end
 local function op_delims(parent, child, ...)
-  local _r56 = unstash({...})
-  local _parent = destash33(parent, _r56)
-  local _child = destash33(child, _r56)
-  local _id7 = _r56
-  local right = _id7.right
-  local _e20
-  if right then
-    _e20 = _6261
+  local __r57 = unstash({...})
+  local _parent = destash33(parent, __r57)
+  local _child = destash33(child, __r57)
+  local __id8 = __r57
+  local _right = __id8.right
+  local _e31
+  if _right then
+    _e31 = _6261
   else
-    _e20 = _62
+    _e31 = _62
   end
-  if _e20(precedence(_child), precedence(_parent)) then
+  if _e31(precedence(_child), precedence(_parent)) then
     return({"(", ")"})
   else
     return({"", ""})
   end
 end
 local function compile_infix(form)
-  local _id8 = form
-  local op = _id8[1]
-  local _id9 = cut(_id8, 1)
-  local a = _id9[1]
-  local b = _id9[2]
-  local _id10 = op_delims(form, a)
-  local ao = _id10[1]
-  local ac = _id10[2]
-  local _id11 = op_delims(form, b, {_stash = true, right = true})
-  local bo = _id11[1]
-  local bc = _id11[2]
-  local _a = compile(a)
-  local _b = compile(b)
-  local _op = getop(op)
+  local __id9 = form
+  local _op = __id9[1]
+  local __id10 = cut(__id9, 1)
+  local _a1 = __id10[1]
+  local _b3 = __id10[2]
+  local __id111 = op_delims(form, _a1)
+  local _ao = __id111[1]
+  local _ac = __id111[2]
+  local __id12 = op_delims(form, _b3, {_stash = true, right = true})
+  local _bo = __id12[1]
+  local _bc = __id12[2]
+  local _a2 = compile(_a1)
+  local _b4 = compile(_b3)
+  local _op1 = getop(_op)
   if unary63(form) then
-    return(_op .. ao .. " " .. _a .. ac)
+    return(_op1 .. _ao .. " " .. _a2 .. _ac)
   else
-    return(ao .. _a .. ac .. " " .. _op .. " " .. bo .. _b .. bc)
+    return(_ao .. _a2 .. _ac .. " " .. _op1 .. " " .. _bo .. _b4 .. _bc)
   end
 end
 function compile_function(args, body, ...)
-  local _r58 = unstash({...})
-  local _args = destash33(args, _r58)
-  local _body = destash33(body, _r58)
-  local _id12 = _r58
-  local name = _id12.name
-  local prefix = _id12.prefix
-  local _e21
-  if name then
-    _e21 = compile(name)
+  local __r59 = unstash({...})
+  local _args4 = destash33(args, __r59)
+  local _body3 = destash33(body, __r59)
+  local __id13 = __r59
+  local _name3 = __id13.name
+  local _prefix = __id13.prefix
+  local _e32
+  if _name3 then
+    _e32 = compile(_name3)
   else
-    _e21 = ""
+    _e32 = ""
   end
-  local _id13 = _e21
-  local _args1 = compile_args(_args)
+  local _id14 = _e32
+  local _args5 = compile_args(_args4)
   indent_level = indent_level + 1
-  local _x78 = compile(_body, {_stash = true, stmt = true})
+  local __x89 = compile(_body3, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local _body1 = _x78
-  local ind = indentation()
-  local _e22
-  if prefix then
-    _e22 = prefix .. " "
+  local _body4 = __x89
+  local _ind = indentation()
+  local _e33
+  if _prefix then
+    _e33 = _prefix .. " "
   else
-    _e22 = ""
+    _e33 = ""
   end
-  local p = _e22
-  local _e23
+  local _p = _e33
+  local _e34
   if target == "js" then
-    _e23 = ""
+    _e34 = ""
   else
-    _e23 = "end"
+    _e34 = "end"
   end
-  local tr = _e23
-  if name then
-    tr = tr .. "\n"
+  local _tr1 = _e34
+  if _name3 then
+    _tr1 = _tr1 .. "\n"
   end
   if target == "js" then
-    return("function " .. _id13 .. _args1 .. " {\n" .. _body1 .. ind .. "}" .. tr)
+    return("function " .. _id14 .. _args5 .. " {\n" .. _body4 .. _ind .. "}" .. _tr1)
   else
-    return(p .. "function " .. _id13 .. _args1 .. "\n" .. _body1 .. ind .. tr)
+    return(_p .. "function " .. _id14 .. _args5 .. "\n" .. _body4 .. _ind .. _tr1)
   end
 end
 local function can_return63(form)
   return(is63(form) and (atom63(form) or not( hd(form) == "return") and not statement63(hd(form))))
 end
 function compile(form, ...)
-  local _r60 = unstash({...})
-  local _form = destash33(form, _r60)
-  local _id14 = _r60
-  local stmt = _id14.stmt
+  local __r61 = unstash({...})
+  local _form = destash33(form, __r61)
+  local __id15 = __r61
+  local _stmt1 = __id15.stmt
   if nil63(_form) then
     return("")
   else
     if special_form63(_form) then
-      return(compile_special(_form, stmt))
+      return(compile_special(_form, _stmt1))
     else
-      local tr = terminator(stmt)
-      local _e24
-      if stmt then
-        _e24 = indentation()
+      local _tr2 = terminator(_stmt1)
+      local _e35
+      if _stmt1 then
+        _e35 = indentation()
       else
-        _e24 = ""
+        _e35 = ""
       end
-      local ind = _e24
-      local _e25
+      local _ind1 = _e35
+      local _e36
       if atom63(_form) then
-        _e25 = compile_atom(_form)
+        _e36 = compile_atom(_form)
       else
-        local _e26
+        local _e37
         if infix63(hd(_form)) then
-          _e26 = compile_infix(_form)
+          _e37 = compile_infix(_form)
         else
-          _e26 = compile_call(_form)
+          _e37 = compile_call(_form)
         end
-        _e25 = _e26
+        _e36 = _e37
       end
-      local _form1 = _e25
-      return(ind .. _form1 .. tr)
+      local _form1 = _e36
+      return(_ind1 .. _form1 .. _tr2)
     end
   end
 end
 local function lower_statement(form, tail63)
-  local hoist = {}
-  local e = lower(form, hoist, true, tail63)
-  if some63(hoist) and is63(e) then
-    return(join({"do"}, hoist, {e}))
+  local _hoist = {}
+  local _e = lower(form, _hoist, true, tail63)
+  if some63(_hoist) and is63(_e) then
+    return(join({"do"}, _hoist, {_e}))
   else
-    if is63(e) then
-      return(e)
+    if is63(_e) then
+      return(_e)
     else
-      if _35(hoist) > 1 then
-        return(join({"do"}, hoist))
+      if _35(_hoist) > 1 then
+        return(join({"do"}, _hoist))
       else
-        return(hd(hoist))
+        return(hd(_hoist))
       end
     end
   end
@@ -800,112 +800,112 @@ local function standalone63(form)
   return(not atom63(form) and not infix63(hd(form)) and not literal63(form) and not( "get" == hd(form)) or id_literal63(form))
 end
 local function lower_do(args, hoist, stmt63, tail63)
-  local _x84 = almost(args)
-  local _i10 = 0
-  while _i10 < _35(_x84) do
-    local x = _x84[_i10 + 1]
-    local _y = lower(x, hoist, stmt63)
-    if yes(_y) then
-      local e = _y
-      if standalone63(e) then
-        add(hoist, e)
+  local __x95 = almost(args)
+  local __i18 = 0
+  while __i18 < _35(__x95) do
+    local _x96 = __x95[__i18 + 1]
+    local __y = lower(_x96, hoist, stmt63)
+    if yes(__y) then
+      local _e1 = __y
+      if standalone63(_e1) then
+        add(hoist, _e1)
       end
     end
-    _i10 = _i10 + 1
+    __i18 = __i18 + 1
   end
-  local _e = lower(last(args), hoist, stmt63, tail63)
-  if tail63 and can_return63(_e) then
-    return({"return", _e})
+  local _e2 = lower(last(args), hoist, stmt63, tail63)
+  if tail63 and can_return63(_e2) then
+    return({"return", _e2})
   else
-    return(_e)
+    return(_e2)
   end
 end
 local function lower_set(args, hoist, stmt63, tail63)
-  local _id15 = args
-  local lh = _id15[1]
-  local rh = _id15[2]
-  add(hoist, {"%set", lh, lower(rh, hoist)})
+  local __id16 = args
+  local _lh = __id16[1]
+  local _rh = __id16[2]
+  add(hoist, {"%set", _lh, lower(_rh, hoist)})
   if not( stmt63 and not tail63) then
-    return(lh)
+    return(_lh)
   end
 end
 local function lower_if(args, hoist, stmt63, tail63)
-  local _id16 = args
-  local cond = _id16[1]
-  local _then = _id16[2]
-  local _else = _id16[3]
+  local __id17 = args
+  local _cond = __id17[1]
+  local _then = __id17[2]
+  local _else = __id17[3]
   if stmt63 then
-    local _e28
+    local _e39
     if is63(_else) then
-      _e28 = {lower_body({_else}, tail63)}
+      _e39 = {lower_body({_else}, tail63)}
     end
-    return(add(hoist, join({"%if", lower(cond, hoist), lower_body({_then}, tail63)}, _e28)))
+    return(add(hoist, join({"%if", lower(_cond, hoist), lower_body({_then}, tail63)}, _e39)))
   else
-    local e = unique("e")
-    add(hoist, {"%local", e})
-    local _e27
+    local _e3 = unique("e")
+    add(hoist, {"%local", _e3})
+    local _e38
     if is63(_else) then
-      _e27 = {lower({"%set", e, _else})}
+      _e38 = {lower({"%set", _e3, _else})}
     end
-    add(hoist, join({"%if", lower(cond, hoist), lower({"%set", e, _then})}, _e27))
-    return(e)
+    add(hoist, join({"%if", lower(_cond, hoist), lower({"%set", _e3, _then})}, _e38))
+    return(_e3)
   end
 end
 local function lower_short(x, args, hoist)
-  local _id17 = args
-  local a = _id17[1]
-  local b = _id17[2]
-  local hoist1 = {}
-  local b1 = lower(b, hoist1)
-  if some63(hoist1) then
-    local _id18 = unique("id")
-    local _e29
+  local __id18 = args
+  local _a3 = __id18[1]
+  local _b5 = __id18[2]
+  local _hoist1 = {}
+  local _b11 = lower(_b5, _hoist1)
+  if some63(_hoist1) then
+    local _id19 = unique("id")
+    local _e40
     if x == "and" then
-      _e29 = {"%if", _id18, b, _id18}
+      _e40 = {"%if", _id19, _b5, _id19}
     else
-      _e29 = {"%if", _id18, _id18, b}
+      _e40 = {"%if", _id19, _id19, _b5}
     end
-    return(lower({"do", {"%local", _id18, a}, _e29}, hoist))
+    return(lower({"do", {"%local", _id19, _a3}, _e40}, hoist))
   else
-    return({x, lower(a, hoist), b1})
+    return({x, lower(_a3, hoist), _b11})
   end
 end
 local function lower_try(args, hoist, tail63)
   return(add(hoist, {"%try", lower_body(args, tail63)}))
 end
 local function lower_while(args, hoist)
-  local _id19 = args
-  local c = _id19[1]
-  local body = cut(_id19, 1)
-  local pre = {}
-  local _c = lower(c, pre)
-  local _e30
-  if none63(pre) then
-    _e30 = {"while", _c, lower_body(body)}
+  local __id20 = args
+  local _c4 = __id20[1]
+  local _body5 = cut(__id20, 1)
+  local _pre = {}
+  local _c5 = lower(_c4, _pre)
+  local _e41
+  if none63(_pre) then
+    _e41 = {"while", _c5, lower_body(_body5)}
   else
-    _e30 = {"while", true, join({"do"}, pre, {{"%if", {"not", _c}, {"break"}}, lower_body(body)})}
+    _e41 = {"while", true, join({"do"}, _pre, {{"%if", {"not", _c5}, {"break"}}, lower_body(_body5)})}
   end
-  return(add(hoist, _e30))
+  return(add(hoist, _e41))
 end
 local function lower_for(args, hoist)
-  local _id20 = args
-  local t = _id20[1]
-  local k = _id20[2]
-  local body = cut(_id20, 2)
-  return(add(hoist, {"%for", lower(t, hoist), k, lower_body(body)}))
+  local __id21 = args
+  local _t = __id21[1]
+  local _k7 = __id21[2]
+  local _body6 = cut(__id21, 2)
+  return(add(hoist, {"%for", lower(_t, hoist), _k7, lower_body(_body6)}))
 end
 local function lower_function(args)
-  local _id21 = args
-  local a = _id21[1]
-  local body = cut(_id21, 1)
-  return({"%function", a, lower_body(body, true)})
+  local __id22 = args
+  local _a4 = __id22[1]
+  local _body7 = cut(__id22, 1)
+  return({"%function", _a4, lower_body(_body7, true)})
 end
 local function lower_definition(kind, args, hoist)
-  local _id22 = args
-  local name = _id22[1]
-  local _args2 = _id22[2]
-  local body = cut(_id22, 2)
-  return(add(hoist, {kind, name, _args2, lower_body(body, true)}))
+  local __id23 = args
+  local _name4 = __id23[1]
+  local _args6 = __id23[2]
+  local _body8 = cut(__id23, 2)
+  return(add(hoist, {kind, _name4, _args6, lower_body(_body8, true)}))
 end
 local function lower_call(form, hoist)
   local _form2 = map(function (x)
@@ -920,15 +920,15 @@ local function pairwise63(form)
 end
 local function lower_pairwise(form)
   if pairwise63(form) then
-    local e = {}
-    local _id23 = form
-    local x = _id23[1]
-    local args = cut(_id23, 1)
+    local _e4 = {}
+    local __id24 = form
+    local _x125 = __id24[1]
+    local _args7 = cut(__id24, 1)
     reduce(function (a, b)
-      add(e, {x, a, b})
+      add(_e4, {_x125, a, b})
       return(a)
-    end, args)
-    return(join({"and"}, reverse(e)))
+    end, _args7)
+    return(join({"and"}, reverse(_e4)))
   else
     return(form)
   end
@@ -938,17 +938,17 @@ local function lower_infix63(form)
 end
 local function lower_infix(form, hoist)
   local _form3 = lower_pairwise(form)
-  local _id24 = _form3
-  local x = _id24[1]
-  local args = cut(_id24, 1)
+  local __id25 = _form3
+  local _x128 = __id25[1]
+  local _args8 = cut(__id25, 1)
   return(lower(reduce(function (a, b)
-    return({x, b, a})
-  end, reverse(args)), hoist))
+    return({_x128, b, a})
+  end, reverse(_args8)), hoist))
 end
 local function lower_special(form, hoist)
-  local e = lower_call(form, hoist)
-  if e then
-    return(add(hoist, e))
+  local _e5 = lower_call(form, hoist)
+  if _e5 then
+    return(add(hoist, _e5))
   end
 end
 function lower(form, hoist, stmt63, tail63)
@@ -964,37 +964,37 @@ function lower(form, hoist, stmt63, tail63)
         if lower_infix63(form) then
           return(lower_infix(form, hoist))
         else
-          local _id24 = form
-          local x = _id24[1]
-          local args = cut(_id24, 1)
-          if x == "do" then
-            return(lower_do(args, hoist, stmt63, tail63))
+          local __id26 = form
+          local _x131 = __id26[1]
+          local _args9 = cut(__id26, 1)
+          if _x131 == "do" then
+            return(lower_do(_args9, hoist, stmt63, tail63))
           else
-            if x == "%set" then
-              return(lower_set(args, hoist, stmt63, tail63))
+            if _x131 == "%set" then
+              return(lower_set(_args9, hoist, stmt63, tail63))
             else
-              if x == "%if" then
-                return(lower_if(args, hoist, stmt63, tail63))
+              if _x131 == "%if" then
+                return(lower_if(_args9, hoist, stmt63, tail63))
               else
-                if x == "%try" then
-                  return(lower_try(args, hoist, tail63))
+                if _x131 == "%try" then
+                  return(lower_try(_args9, hoist, tail63))
                 else
-                  if x == "while" then
-                    return(lower_while(args, hoist))
+                  if _x131 == "while" then
+                    return(lower_while(_args9, hoist))
                   else
-                    if x == "%for" then
-                      return(lower_for(args, hoist))
+                    if _x131 == "%for" then
+                      return(lower_for(_args9, hoist))
                     else
-                      if x == "%function" then
-                        return(lower_function(args))
+                      if _x131 == "%function" then
+                        return(lower_function(_args9))
                       else
-                        if x == "%local-function" or x == "%global-function" then
-                          return(lower_definition(x, args, hoist))
+                        if _x131 == "%local-function" or _x131 == "%global-function" then
+                          return(lower_definition(_x131, _args9, hoist))
                         else
-                          if in63(x, {"and", "or"}) then
-                            return(lower_short(x, args, hoist))
+                          if in63(_x131, {"and", "or"}) then
+                            return(lower_short(_x131, _args9, hoist))
                           else
-                            if statement63(x) then
+                            if statement63(_x131) then
                               return(lower_special(form, hoist))
                             else
                               return(lower_call(form, hoist))
@@ -1027,104 +1027,104 @@ local function run(code)
 end
 _37result = nil
 function eval(form)
-  local previous = target
+  local _previous = target
   target = "lua"
-  local code = compile(expand({"set", "%result", form}))
-  target = previous
-  run(code)
+  local _code = compile(expand({"set", "%result", form}))
+  target = _previous
+  run(_code)
   return(_37result)
 end
-setenv("do", {_stash = true, stmt = true, special = function (...)
-  local forms = unstash({...})
-  local s = ""
-  local _x119 = forms
-  local _i12 = 0
-  while _i12 < _35(_x119) do
-    local x = _x119[_i12 + 1]
-    s = s .. compile(x, {_stash = true, stmt = true})
-    if not atom63(x) then
-      if hd(x) == "return" or hd(x) == "break" then
+setenv("do", {_stash = true, special = function (...)
+  local _forms1 = unstash({...})
+  local _s3 = ""
+  local __x137 = _forms1
+  local __i20 = 0
+  while __i20 < _35(__x137) do
+    local _x138 = __x137[__i20 + 1]
+    _s3 = _s3 .. compile(_x138, {_stash = true, stmt = true})
+    if not atom63(_x138) then
+      if hd(_x138) == "return" or hd(_x138) == "break" then
         break
       end
     end
-    _i12 = _i12 + 1
+    __i20 = __i20 + 1
   end
-  return(s)
-end, tr = true})
-setenv("%if", {_stash = true, stmt = true, special = function (cond, cons, alt)
-  local _cond1 = compile(cond)
+  return(_s3)
+end, stmt = true, tr = true})
+setenv("%if", {_stash = true, special = function (cond, cons, alt)
+  local _cond2 = compile(cond)
   indent_level = indent_level + 1
-  local _x122 = compile(cons, {_stash = true, stmt = true})
+  local __x141 = compile(cons, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local _cons1 = _x122
-  local _e31
+  local _cons1 = __x141
+  local _e42
   if alt then
     indent_level = indent_level + 1
-    local _x123 = compile(alt, {_stash = true, stmt = true})
+    local __x142 = compile(alt, {_stash = true, stmt = true})
     indent_level = indent_level - 1
-    _e31 = _x123
+    _e42 = __x142
   end
-  local _alt1 = _e31
-  local ind = indentation()
-  local s = ""
+  local _alt1 = _e42
+  local _ind3 = indentation()
+  local _s5 = ""
   if target == "js" then
-    s = s .. ind .. "if (" .. _cond1 .. ") {\n" .. _cons1 .. ind .. "}"
+    _s5 = _s5 .. _ind3 .. "if (" .. _cond2 .. ") {\n" .. _cons1 .. _ind3 .. "}"
   else
-    s = s .. ind .. "if " .. _cond1 .. " then\n" .. _cons1
+    _s5 = _s5 .. _ind3 .. "if " .. _cond2 .. " then\n" .. _cons1
   end
   if _alt1 and target == "js" then
-    s = s .. " else {\n" .. _alt1 .. ind .. "}"
+    _s5 = _s5 .. " else {\n" .. _alt1 .. _ind3 .. "}"
   else
     if _alt1 then
-      s = s .. ind .. "else\n" .. _alt1
+      _s5 = _s5 .. _ind3 .. "else\n" .. _alt1
     end
   end
   if target == "lua" then
-    return(s .. ind .. "end\n")
+    return(_s5 .. _ind3 .. "end\n")
   else
-    return(s .. "\n")
+    return(_s5 .. "\n")
   end
-end, tr = true})
-setenv("while", {_stash = true, stmt = true, special = function (cond, form)
-  local _cond3 = compile(cond)
+end, stmt = true, tr = true})
+setenv("while", {_stash = true, special = function (cond, form)
+  local _cond4 = compile(cond)
   indent_level = indent_level + 1
-  local _x125 = compile(form, {_stash = true, stmt = true})
+  local __x144 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local body = _x125
-  local ind = indentation()
+  local _body10 = __x144
+  local _ind5 = indentation()
   if target == "js" then
-    return(ind .. "while (" .. _cond3 .. ") {\n" .. body .. ind .. "}\n")
+    return(_ind5 .. "while (" .. _cond4 .. ") {\n" .. _body10 .. _ind5 .. "}\n")
   else
-    return(ind .. "while " .. _cond3 .. " do\n" .. body .. ind .. "end\n")
+    return(_ind5 .. "while " .. _cond4 .. " do\n" .. _body10 .. _ind5 .. "end\n")
   end
-end, tr = true})
-setenv("%for", {_stash = true, stmt = true, special = function (t, k, form)
-  local _t1 = compile(t)
-  local ind = indentation()
+end, stmt = true, tr = true})
+setenv("%for", {_stash = true, special = function (t, k, form)
+  local _t2 = compile(t)
+  local _ind7 = indentation()
   indent_level = indent_level + 1
-  local _x127 = compile(form, {_stash = true, stmt = true})
+  local __x146 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local body = _x127
+  local _body12 = __x146
   if target == "lua" then
-    return(ind .. "for " .. k .. " in next, " .. _t1 .. " do\n" .. body .. ind .. "end\n")
+    return(_ind7 .. "for " .. k .. " in next, " .. _t2 .. " do\n" .. _body12 .. _ind7 .. "end\n")
   else
-    return(ind .. "for (" .. k .. " in " .. _t1 .. ") {\n" .. body .. ind .. "}\n")
+    return(_ind7 .. "for (" .. k .. " in " .. _t2 .. ") {\n" .. _body12 .. _ind7 .. "}\n")
   end
-end, tr = true})
-setenv("%try", {_stash = true, stmt = true, special = function (form)
-  local e = unique("e")
-  local ind = indentation()
+end, stmt = true, tr = true})
+setenv("%try", {_stash = true, special = function (form)
+  local _e8 = unique("e")
+  local _ind9 = indentation()
   indent_level = indent_level + 1
-  local _x132 = compile(form, {_stash = true, stmt = true})
+  local __x151 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local body = _x132
-  local hf = {"return", {"%array", false, e}}
+  local _body14 = __x151
+  local _hf1 = {"return", {"%array", false, _e8}}
   indent_level = indent_level + 1
-  local _x135 = compile(hf, {_stash = true, stmt = true})
+  local __x154 = compile(_hf1, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local h = _x135
-  return(ind .. "try {\n" .. body .. ind .. "}\n" .. ind .. "catch (" .. e .. ") {\n" .. h .. ind .. "}\n")
-end, tr = true})
+  local _h1 = __x154
+  return(_ind9 .. "try {\n" .. _body14 .. _ind9 .. "}\n" .. _ind9 .. "catch (" .. _e8 .. ") {\n" .. _h1 .. _ind9 .. "}\n")
+end, stmt = true, tr = true})
 setenv("%delete", {_stash = true, special = function (place)
   return(indentation() .. "delete " .. compile(place))
 end, stmt = true})
@@ -1134,31 +1134,31 @@ end, stmt = true})
 setenv("%function", {_stash = true, special = function (args, body)
   return(compile_function(args, body))
 end})
-setenv("%global-function", {_stash = true, stmt = true, special = function (name, args, body)
+setenv("%global-function", {_stash = true, special = function (name, args, body)
   if target == "lua" then
-    local x = compile_function(args, body, {_stash = true, name = name})
-    return(indentation() .. x)
+    local _x158 = compile_function(args, body, {_stash = true, name = name})
+    return(indentation() .. _x158)
   else
     return(compile({"%set", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
-end, tr = true})
-setenv("%local-function", {_stash = true, stmt = true, special = function (name, args, body)
+end, stmt = true, tr = true})
+setenv("%local-function", {_stash = true, special = function (name, args, body)
   if target == "lua" then
-    local x = compile_function(args, body, {_stash = true, name = name, prefix = "local"})
-    return(indentation() .. x)
+    local _x164 = compile_function(args, body, {_stash = true, name = name, prefix = "local"})
+    return(indentation() .. _x164)
   else
     return(compile({"%local", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
-end, tr = true})
+end, stmt = true, tr = true})
 setenv("return", {_stash = true, special = function (x)
-  local _e32
+  local _e43
   if nil63(x) then
-    _e32 = "return"
+    _e43 = "return"
   else
-    _e32 = "return(" .. compile(x) .. ")"
+    _e43 = "return(" .. compile(x) .. ")"
   end
-  local _x145 = _e32
-  return(indentation() .. _x145)
+  local _x168 = _e43
+  return(indentation() .. _x168)
 end, stmt = true})
 setenv("new", {_stash = true, special = function (x)
   return("new " .. compile(x))
@@ -1167,117 +1167,117 @@ setenv("typeof", {_stash = true, special = function (x)
   return("typeof(" .. compile(x) .. ")")
 end})
 setenv("error", {_stash = true, special = function (x)
-  local _e33
+  local _e44
   if target == "js" then
-    _e33 = "throw " .. compile({"new", {"Error", x}})
+    _e44 = "throw " .. compile({"new", {"Error", x}})
   else
-    _e33 = "error(" .. compile(x) .. ")"
+    _e44 = "error(" .. compile(x) .. ")"
   end
-  local e = _e33
-  return(indentation() .. e)
+  local _e12 = _e44
+  return(indentation() .. _e12)
 end, stmt = true})
 setenv("%local", {_stash = true, special = function (name, value)
-  local _id26 = compile(name)
-  local value1 = compile(value)
-  local _e34
+  local _id28 = compile(name)
+  local _value11 = compile(value)
+  local _e45
   if is63(value) then
-    _e34 = " = " .. value1
+    _e45 = " = " .. _value11
   else
-    _e34 = ""
+    _e45 = ""
   end
-  local rh = _e34
-  local _e35
+  local _rh2 = _e45
+  local _e46
   if target == "js" then
-    _e35 = "var "
+    _e46 = "var "
   else
-    _e35 = "local "
+    _e46 = "local "
   end
-  local keyword = _e35
-  local ind = indentation()
-  return(ind .. keyword .. _id26 .. rh)
+  local _keyword1 = _e46
+  local _ind11 = indentation()
+  return(_ind11 .. _keyword1 .. _id28 .. _rh2)
 end, stmt = true})
 setenv("%set", {_stash = true, special = function (lh, rh)
-  local _lh1 = compile(lh)
-  local _e36
+  local _lh2 = compile(lh)
+  local _e47
   if nil63(rh) then
-    _e36 = "nil"
+    _e47 = "nil"
   else
-    _e36 = rh
+    _e47 = rh
   end
-  local _rh1 = compile(_e36)
-  return(indentation() .. _lh1 .. " = " .. _rh1)
+  local _rh4 = compile(_e47)
+  return(indentation() .. _lh2 .. " = " .. _rh4)
 end, stmt = true})
 setenv("get", {_stash = true, special = function (t, k)
-  local _t3 = compile(t)
-  local k1 = compile(k)
-  if target == "lua" and char(_t3, 0) == "{" then
-    _t3 = "(" .. _t3 .. ")"
+  local _t4 = compile(t)
+  local _k12 = compile(k)
+  if target == "lua" and char(_t4, 0) == "{" then
+    _t4 = "(" .. _t4 .. ")"
   end
   if string_literal63(k) and valid_id63(inner(k)) then
-    return(_t3 .. "." .. inner(k))
+    return(_t4 .. "." .. inner(k))
   else
-    return(_t3 .. "[" .. k1 .. "]")
+    return(_t4 .. "[" .. _k12 .. "]")
   end
 end})
 setenv("%array", {_stash = true, special = function (...)
-  local forms = unstash({...})
-  local _e37
+  local _forms3 = unstash({...})
+  local _e48
   if target == "lua" then
-    _e37 = "{"
+    _e48 = "{"
   else
-    _e37 = "["
+    _e48 = "["
   end
-  local open = _e37
-  local _e38
+  local _open1 = _e48
+  local _e49
   if target == "lua" then
-    _e38 = "}"
+    _e49 = "}"
   else
-    _e38 = "]"
+    _e49 = "]"
   end
-  local close = _e38
-  local s = ""
-  local c = ""
-  local _o9 = forms
-  local k = nil
-  for k in next, _o9 do
-    local v = _o9[k]
-    if number63(k) then
-      s = s .. c .. compile(v)
-      c = ", "
+  local _close1 = _e49
+  local _s7 = ""
+  local _c7 = ""
+  local __o10 = _forms3
+  local _k10 = nil
+  for _k10 in next, __o10 do
+    local _v9 = __o10[_k10]
+    if number63(_k10) then
+      _s7 = _s7 .. _c7 .. compile(_v9)
+      _c7 = ", "
     end
   end
-  return(open .. s .. close)
+  return(_open1 .. _s7 .. _close1)
 end})
 setenv("%object", {_stash = true, special = function (...)
-  local forms = unstash({...})
-  local s = "{"
-  local c = ""
-  local _e39
+  local _forms5 = unstash({...})
+  local _s9 = "{"
+  local _c9 = ""
+  local _e50
   if target == "lua" then
-    _e39 = " = "
+    _e50 = " = "
   else
-    _e39 = ": "
+    _e50 = ": "
   end
-  local sep = _e39
-  local _o11 = pair(forms)
-  local k = nil
-  for k in next, _o11 do
-    local v = _o11[k]
-    if number63(k) then
-      local _id28 = v
-      local _k2 = _id28[1]
-      local _v3 = _id28[2]
-      if not string63(_k2) then
-        error("Illegal key: " .. str(_k2))
+  local _sep1 = _e50
+  local __o12 = pair(_forms5)
+  local _k14 = nil
+  for _k14 in next, __o12 do
+    local _v12 = __o12[_k14]
+    if number63(_k14) then
+      local __id30 = _v12
+      local _k15 = __id30[1]
+      local _v13 = __id30[2]
+      if not string63(_k15) then
+        error("Illegal key: " .. str(_k15))
       end
-      s = s .. c .. key(_k2) .. sep .. compile(_v3)
-      c = ", "
+      _s9 = _s9 .. _c9 .. key(_k15) .. _sep1 .. compile(_v13)
+      _c9 = ", "
     end
   end
-  return(s .. "}")
+  return(_s9 .. "}")
 end})
 setenv("%literal", {_stash = true, special = function (...)
-  local args = unstash({...})
-  return(apply(cat, map(compile, args)))
+  local _args111 = unstash({...})
+  return(apply(cat, map(compile, _args111)))
 end})
-return({compile = compile, eval = eval, expand = expand, run = run})
+return({run = run, eval = eval, expand = expand, compile = compile})

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -1276,4 +1276,8 @@ setenv("%object", {_stash = true, special = function (...)
   end
   return(s .. "}")
 end})
+setenv("%literal", {_stash = true, special = function (...)
+  local args = unstash({...})
+  return(apply(cat, map(compile, args)))
+end})
 return({compile = compile, eval = eval, expand = expand, run = run})

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -660,13 +660,10 @@ call = function (f) {
   var _args11 = cut(__id, 0);
   return(apply(_f, _args11));
 };
-toplevel63 = function () {
-  return(one63(environment));
-};
 setenv = function (k) {
-  var __r74 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _k18 = destash33(k, __r74);
-  var __id1 = __r74;
+  var __r73 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _k18 = destash33(k, __r73);
+  var __id1 = __r73;
   var _keys = cut(__id1, 0);
   if (string63(_k18)) {
     var _e18;

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -63,63 +63,63 @@ clip = function (s, from, upto) {
   return(s.substring(from, upto));
 };
 cut = function (x, from, upto) {
-  var l = [];
-  var j = 0;
+  var _l = [];
+  var _j = 0;
   var _e;
   if (nil63(from) || from < 0) {
     _e = 0;
   } else {
     _e = from;
   }
-  var i = _e;
-  var n = _35(x);
+  var _i = _e;
+  var _n = _35(x);
   var _e1;
-  if (nil63(upto) || upto > n) {
-    _e1 = n;
+  if (nil63(upto) || upto > _n) {
+    _e1 = _n;
   } else {
     _e1 = upto;
   }
   var _upto = _e1;
-  while (i < _upto) {
-    l[j] = x[i];
-    i = i + 1;
-    j = j + 1;
+  while (_i < _upto) {
+    _l[_j] = x[_i];
+    _i = _i + 1;
+    _j = _j + 1;
   }
-  var _o = x;
-  var k = undefined;
-  for (k in _o) {
-    var v = _o[k];
+  var __o = x;
+  var _k = undefined;
+  for (_k in __o) {
+    var _v = __o[_k];
     var _e2;
-    if (numeric63(k)) {
-      _e2 = parseInt(k);
+    if (numeric63(_k)) {
+      _e2 = parseInt(_k);
     } else {
-      _e2 = k;
+      _e2 = _k;
     }
-    var _k = _e2;
-    if (! number63(_k)) {
-      l[_k] = v;
+    var _k1 = _e2;
+    if (! number63(_k1)) {
+      _l[_k1] = _v;
     }
   }
-  return(l);
+  return(_l);
 };
 keys = function (x) {
-  var t = [];
-  var _o1 = x;
-  var k = undefined;
-  for (k in _o1) {
-    var v = _o1[k];
+  var _t = [];
+  var __o1 = x;
+  var _k2 = undefined;
+  for (_k2 in __o1) {
+    var _v1 = __o1[_k2];
     var _e3;
-    if (numeric63(k)) {
-      _e3 = parseInt(k);
+    if (numeric63(_k2)) {
+      _e3 = parseInt(_k2);
     } else {
-      _e3 = k;
+      _e3 = _k2;
     }
-    var _k1 = _e3;
-    if (! number63(_k1)) {
-      t[_k1] = v;
+    var _k3 = _e3;
+    if (! number63(_k3)) {
+      _t[_k3] = _v1;
     }
   }
-  return(t);
+  return(_t);
 };
 edge = function (x) {
   return(_35(x) - 1);
@@ -156,13 +156,13 @@ almost = function (l) {
   return(cut(l, 0, edge(l)));
 };
 reverse = function (l) {
-  var l1 = keys(l);
-  var i = edge(l);
-  while (i >= 0) {
-    add(l1, l[i]);
-    i = i - 1;
+  var _l1 = keys(l);
+  var _i3 = edge(l);
+  while (_i3 >= 0) {
+    add(_l1, l[_i3]);
+    _i3 = _i3 - 1;
   }
-  return(l1);
+  return(_l1);
 };
 reduce = function (f, x, none) {
   if (none63(x)) {
@@ -176,63 +176,63 @@ reduce = function (f, x, none) {
   }
 };
 join = function () {
-  var ls = unstash(Array.prototype.slice.call(arguments, 0));
-  var r = [];
-  var _x1 = ls;
-  var _i2 = 0;
-  while (_i2 < _35(_x1)) {
-    var l = _x1[_i2];
-    if (l) {
-      var n = _35(r);
-      var _o2 = l;
-      var k = undefined;
-      for (k in _o2) {
-        var v = _o2[k];
+  var _ls = unstash(Array.prototype.slice.call(arguments, 0));
+  var _r35 = [];
+  var __x1 = _ls;
+  var __i4 = 0;
+  while (__i4 < _35(__x1)) {
+    var _l11 = __x1[__i4];
+    if (_l11) {
+      var _n3 = _35(_r35);
+      var __o2 = _l11;
+      var _k4 = undefined;
+      for (_k4 in __o2) {
+        var _v2 = __o2[_k4];
         var _e4;
-        if (numeric63(k)) {
-          _e4 = parseInt(k);
+        if (numeric63(_k4)) {
+          _e4 = parseInt(_k4);
         } else {
-          _e4 = k;
+          _e4 = _k4;
         }
-        var _k2 = _e4;
-        if (number63(_k2)) {
-          _k2 = _k2 + n;
+        var _k5 = _e4;
+        if (number63(_k5)) {
+          _k5 = _k5 + _n3;
         }
-        r[_k2] = v;
+        _r35[_k5] = _v2;
       }
     }
-    _i2 = _i2 + 1;
+    __i4 = __i4 + 1;
   }
-  return(r);
+  return(_r35);
 };
 find = function (f, t) {
-  var _o3 = t;
-  var _i4 = undefined;
-  for (_i4 in _o3) {
-    var x = _o3[_i4];
+  var __o3 = t;
+  var __i6 = undefined;
+  for (__i6 in __o3) {
+    var _x2 = __o3[__i6];
     var _e5;
-    if (numeric63(_i4)) {
-      _e5 = parseInt(_i4);
+    if (numeric63(__i6)) {
+      _e5 = parseInt(__i6);
     } else {
-      _e5 = _i4;
+      _e5 = __i6;
     }
-    var __i4 = _e5;
-    var y = f(x);
-    if (y) {
-      return(y);
+    var __i61 = _e5;
+    var _y = f(_x2);
+    if (_y) {
+      return(_y);
     }
   }
 };
 first = function (f, l) {
-  var _x2 = l;
-  var _i5 = 0;
-  while (_i5 < _35(_x2)) {
-    var x = _x2[_i5];
-    var y = f(x);
-    if (y) {
-      return(y);
+  var __x3 = l;
+  var __i7 = 0;
+  while (__i7 < _35(__x3)) {
+    var _x4 = __x3[__i7];
+    var _y1 = f(_x4);
+    if (_y1) {
+      return(_y1);
     }
-    _i5 = _i5 + 1;
+    __i7 = __i7 + 1;
   }
 };
 in63 = function (x, t) {
@@ -241,14 +241,14 @@ in63 = function (x, t) {
   }, t));
 };
 pair = function (l) {
-  var l1 = [];
-  var i = 0;
-  while (i < _35(l)) {
-    add(l1, [l[i], l[i + 1]]);
-    i = i + 1;
-    i = i + 1;
+  var _l12 = [];
+  var _i8 = 0;
+  while (_i8 < _35(l)) {
+    add(_l12, [l[_i8], l[_i8 + 1]]);
+    _i8 = _i8 + 1;
+    _i8 = _i8 + 1;
   }
-  return(l1);
+  return(_l12);
 };
 sort = function (l, f) {
   var _e6;
@@ -264,36 +264,36 @@ sort = function (l, f) {
   return(l.sort(_e6));
 };
 map = function (f, x) {
-  var t = [];
-  var _x4 = x;
-  var _i6 = 0;
-  while (_i6 < _35(_x4)) {
-    var v = _x4[_i6];
-    var y = f(v);
-    if (is63(y)) {
-      add(t, y);
+  var _t1 = [];
+  var __x6 = x;
+  var __i9 = 0;
+  while (__i9 < _35(__x6)) {
+    var _v3 = __x6[__i9];
+    var _y2 = f(_v3);
+    if (is63(_y2)) {
+      add(_t1, _y2);
     }
-    _i6 = _i6 + 1;
+    __i9 = __i9 + 1;
   }
-  var _o4 = x;
-  var k = undefined;
-  for (k in _o4) {
-    var _v = _o4[k];
+  var __o4 = x;
+  var _k6 = undefined;
+  for (_k6 in __o4) {
+    var _v4 = __o4[_k6];
     var _e7;
-    if (numeric63(k)) {
-      _e7 = parseInt(k);
+    if (numeric63(_k6)) {
+      _e7 = parseInt(_k6);
     } else {
-      _e7 = k;
+      _e7 = _k6;
     }
-    var _k3 = _e7;
-    if (! number63(_k3)) {
-      var _y = f(_v);
-      if (is63(_y)) {
-        t[_k3] = _y;
+    var _k7 = _e7;
+    if (! number63(_k7)) {
+      var _y3 = f(_v4);
+      if (is63(_y3)) {
+        _t1[_k7] = _y3;
       }
     }
   }
-  return(t);
+  return(_t1);
 };
 keep = function (f, x) {
   return(map(function (v) {
@@ -303,59 +303,59 @@ keep = function (f, x) {
   }, x));
 };
 keys63 = function (t) {
-  var _o5 = t;
-  var k = undefined;
-  for (k in _o5) {
-    var v = _o5[k];
+  var __o5 = t;
+  var _k8 = undefined;
+  for (_k8 in __o5) {
+    var _v5 = __o5[_k8];
     var _e8;
-    if (numeric63(k)) {
-      _e8 = parseInt(k);
+    if (numeric63(_k8)) {
+      _e8 = parseInt(_k8);
     } else {
-      _e8 = k;
+      _e8 = _k8;
     }
-    var _k4 = _e8;
-    if (! number63(_k4)) {
+    var _k9 = _e8;
+    if (! number63(_k9)) {
       return(true);
     }
   }
   return(false);
 };
 empty63 = function (t) {
-  var _o6 = t;
-  var _i9 = undefined;
-  for (_i9 in _o6) {
-    var x = _o6[_i9];
+  var __o6 = t;
+  var __i12 = undefined;
+  for (__i12 in __o6) {
+    var _x7 = __o6[__i12];
     var _e9;
-    if (numeric63(_i9)) {
-      _e9 = parseInt(_i9);
+    if (numeric63(__i12)) {
+      _e9 = parseInt(__i12);
     } else {
-      _e9 = _i9;
+      _e9 = __i12;
     }
-    var __i9 = _e9;
+    var __i121 = _e9;
     return(false);
   }
   return(true);
 };
 stash = function (args) {
   if (keys63(args)) {
-    var p = [];
-    var _o7 = args;
-    var k = undefined;
-    for (k in _o7) {
-      var v = _o7[k];
+    var _p = [];
+    var __o7 = args;
+    var _k10 = undefined;
+    for (_k10 in __o7) {
+      var _v6 = __o7[_k10];
       var _e10;
-      if (numeric63(k)) {
-        _e10 = parseInt(k);
+      if (numeric63(_k10)) {
+        _e10 = parseInt(_k10);
       } else {
-        _e10 = k;
+        _e10 = _k10;
       }
-      var _k5 = _e10;
-      if (! number63(_k5)) {
-        p[_k5] = v;
+      var _k11 = _e10;
+      if (! number63(_k11)) {
+        _p[_k11] = _v6;
       }
     }
-    p._stash = true;
-    add(args, p);
+    _p._stash = true;
+    add(args, _p);
   }
   return(args);
 };
@@ -363,25 +363,25 @@ unstash = function (args) {
   if (none63(args)) {
     return([]);
   } else {
-    var l = last(args);
-    if (obj63(l) && l._stash) {
-      var args1 = almost(args);
-      var _o8 = l;
-      var k = undefined;
-      for (k in _o8) {
-        var v = _o8[k];
+    var _l2 = last(args);
+    if (obj63(_l2) && _l2._stash) {
+      var _args1 = almost(args);
+      var __o8 = _l2;
+      var _k12 = undefined;
+      for (_k12 in __o8) {
+        var _v7 = __o8[_k12];
         var _e11;
-        if (numeric63(k)) {
-          _e11 = parseInt(k);
+        if (numeric63(_k12)) {
+          _e11 = parseInt(_k12);
         } else {
-          _e11 = k;
+          _e11 = _k12;
         }
-        var _k6 = _e11;
-        if (!( _k6 === "_stash")) {
-          args1[_k6] = v;
+        var _k13 = _e11;
+        if (!( _k13 === "_stash")) {
+          _args1[_k13] = _v7;
         }
       }
-      return(args1);
+      return(_args1);
     } else {
       return(args);
     }
@@ -389,19 +389,19 @@ unstash = function (args) {
 };
 destash33 = function (l, args1) {
   if (obj63(l) && l._stash) {
-    var _o9 = l;
-    var k = undefined;
-    for (k in _o9) {
-      var v = _o9[k];
+    var __o9 = l;
+    var _k14 = undefined;
+    for (_k14 in __o9) {
+      var _v8 = __o9[_k14];
       var _e12;
-      if (numeric63(k)) {
-        _e12 = parseInt(k);
+      if (numeric63(_k14)) {
+        _e12 = parseInt(_k14);
       } else {
-        _e12 = k;
+        _e12 = _k14;
       }
-      var _k7 = _e12;
-      if (!( _k7 === "_stash")) {
-        args1[_k7] = v;
+      var _k15 = _e12;
+      if (!( _k15 === "_stash")) {
+        args1[_k15] = _v8;
       }
     }
   } else {
@@ -409,159 +409,159 @@ destash33 = function (l, args1) {
   }
 };
 search = function (s, pattern, start) {
-  var i = s.indexOf(pattern, start);
-  if (i >= 0) {
-    return(i);
+  var _i16 = s.indexOf(pattern, start);
+  if (_i16 >= 0) {
+    return(_i16);
   }
 };
 split = function (s, sep) {
   if (s === "" || sep === "") {
     return([]);
   } else {
-    var l = [];
-    var n = _35(sep);
+    var _l3 = [];
+    var _n12 = _35(sep);
     while (true) {
-      var i = search(s, sep);
-      if (nil63(i)) {
+      var _i17 = search(s, sep);
+      if (nil63(_i17)) {
         break;
       } else {
-        add(l, clip(s, 0, i));
-        s = clip(s, i + n);
+        add(_l3, clip(s, 0, _i17));
+        s = clip(s, _i17 + _n12);
       }
     }
-    add(l, s);
-    return(l);
+    add(_l3, s);
+    return(_l3);
   }
 };
 cat = function () {
-  var xs = unstash(Array.prototype.slice.call(arguments, 0));
+  var _xs = unstash(Array.prototype.slice.call(arguments, 0));
   return(reduce(function (a, b) {
     return(a + b);
-  }, xs, ""));
+  }, _xs, ""));
 };
 _43 = function () {
-  var xs = unstash(Array.prototype.slice.call(arguments, 0));
+  var _xs1 = unstash(Array.prototype.slice.call(arguments, 0));
   return(reduce(function (a, b) {
     return(a + b);
-  }, xs, 0));
+  }, _xs1, 0));
 };
 _45 = function () {
-  var xs = unstash(Array.prototype.slice.call(arguments, 0));
+  var _xs2 = unstash(Array.prototype.slice.call(arguments, 0));
   return(reduce(function (b, a) {
     return(a - b);
-  }, reverse(xs), 0));
+  }, reverse(_xs2), 0));
 };
 _42 = function () {
-  var xs = unstash(Array.prototype.slice.call(arguments, 0));
+  var _xs3 = unstash(Array.prototype.slice.call(arguments, 0));
   return(reduce(function (a, b) {
     return(a * b);
-  }, xs, 1));
+  }, _xs3, 1));
 };
 _47 = function () {
-  var xs = unstash(Array.prototype.slice.call(arguments, 0));
+  var _xs4 = unstash(Array.prototype.slice.call(arguments, 0));
   return(reduce(function (b, a) {
     return(a / b);
-  }, reverse(xs), 1));
+  }, reverse(_xs4), 1));
 };
 _37 = function () {
-  var xs = unstash(Array.prototype.slice.call(arguments, 0));
+  var _xs5 = unstash(Array.prototype.slice.call(arguments, 0));
   return(reduce(function (b, a) {
     return(a % b);
-  }, reverse(xs), 0));
+  }, reverse(_xs5), 0));
 };
 var pairwise = function (f, xs) {
-  var i = 0;
-  while (i < edge(xs)) {
-    var a = xs[i];
-    var b = xs[i + 1];
-    if (! f(a, b)) {
+  var _i18 = 0;
+  while (_i18 < edge(xs)) {
+    var _a = xs[_i18];
+    var _b = xs[_i18 + 1];
+    if (! f(_a, _b)) {
       return(false);
     }
-    i = i + 1;
+    _i18 = _i18 + 1;
   }
   return(true);
 };
 _60 = function () {
-  var xs = unstash(Array.prototype.slice.call(arguments, 0));
+  var _xs6 = unstash(Array.prototype.slice.call(arguments, 0));
   return(pairwise(function (a, b) {
     return(a < b);
-  }, xs));
+  }, _xs6));
 };
 _62 = function () {
-  var xs = unstash(Array.prototype.slice.call(arguments, 0));
+  var _xs7 = unstash(Array.prototype.slice.call(arguments, 0));
   return(pairwise(function (a, b) {
     return(a > b);
-  }, xs));
+  }, _xs7));
 };
 _61 = function () {
-  var xs = unstash(Array.prototype.slice.call(arguments, 0));
+  var _xs8 = unstash(Array.prototype.slice.call(arguments, 0));
   return(pairwise(function (a, b) {
     return(a === b);
-  }, xs));
+  }, _xs8));
 };
 _6061 = function () {
-  var xs = unstash(Array.prototype.slice.call(arguments, 0));
+  var _xs9 = unstash(Array.prototype.slice.call(arguments, 0));
   return(pairwise(function (a, b) {
     return(a <= b);
-  }, xs));
+  }, _xs9));
 };
 _6261 = function () {
-  var xs = unstash(Array.prototype.slice.call(arguments, 0));
+  var _xs10 = unstash(Array.prototype.slice.call(arguments, 0));
   return(pairwise(function (a, b) {
     return(a >= b);
-  }, xs));
+  }, _xs10));
 };
 number = function (s) {
-  var n = parseFloat(s);
-  if (! isNaN(n)) {
-    return(n);
+  var _n13 = parseFloat(s);
+  if (! isNaN(_n13)) {
+    return(_n13);
   }
 };
 number_code63 = function (n) {
   return(n > 47 && n < 58);
 };
 numeric63 = function (s) {
-  var n = _35(s);
-  var i = 0;
-  while (i < n) {
-    if (! number_code63(code(s, i))) {
+  var _n14 = _35(s);
+  var _i19 = 0;
+  while (_i19 < _n14) {
+    if (! number_code63(code(s, _i19))) {
       return(false);
     }
-    i = i + 1;
+    _i19 = _i19 + 1;
   }
   return(some63(s));
 };
 var tostring = function (x) {
-  return(x.toString());
+  return(x["toString"]());
 };
 escape = function (s) {
-  var s1 = "\"";
-  var i = 0;
-  while (i < _35(s)) {
-    var c = char(s, i);
+  var _s1 = "\"";
+  var _i20 = 0;
+  while (_i20 < _35(s)) {
+    var _c = char(s, _i20);
     var _e13;
-    if (c === "\n") {
+    if (_c === "\n") {
       _e13 = "\\n";
     } else {
       var _e14;
-      if (c === "\"") {
+      if (_c === "\"") {
         _e14 = "\\\"";
       } else {
         var _e15;
-        if (c === "\\") {
+        if (_c === "\\") {
           _e15 = "\\\\";
         } else {
-          _e15 = c;
+          _e15 = _c;
         }
         _e14 = _e15;
       }
       _e13 = _e14;
     }
-    var c1 = _e13;
-    s1 = s1 + c1;
-    i = i + 1;
+    var _c1 = _e13;
+    _s1 = _s1 + _c1;
+    _i20 = _i20 + 1;
   }
-  return(s1 + "\"");
+  return(_s1 + "\"");
 };
 str = function (x, stack) {
   if (nil63(x)) {
@@ -598,46 +598,46 @@ str = function (x, stack) {
                     if (false) {
                       return(escape(tostring(x)));
                     } else {
-                      var s = "(";
-                      var sp = "";
-                      var xs = [];
-                      var ks = [];
-                      var l = stack || [];
-                      add(l, x);
-                      var _o10 = x;
-                      var k = undefined;
-                      for (k in _o10) {
-                        var v = _o10[k];
+                      var _s = "(";
+                      var _sp = "";
+                      var _xs11 = [];
+                      var _ks = [];
+                      var _l4 = stack || [];
+                      add(_l4, x);
+                      var __o10 = x;
+                      var _k16 = undefined;
+                      for (_k16 in __o10) {
+                        var _v9 = __o10[_k16];
                         var _e16;
-                        if (numeric63(k)) {
-                          _e16 = parseInt(k);
+                        if (numeric63(_k16)) {
+                          _e16 = parseInt(_k16);
                         } else {
-                          _e16 = k;
+                          _e16 = _k16;
                         }
-                        var _k8 = _e16;
-                        if (number63(_k8)) {
-                          xs[_k8] = str(v, l);
+                        var _k17 = _e16;
+                        if (number63(_k17)) {
+                          _xs11[_k17] = str(_v9, _l4);
                         } else {
-                          add(ks, _k8 + ":");
-                          add(ks, str(v, l));
+                          add(_ks, _k17 + ":");
+                          add(_ks, str(_v9, _l4));
                         }
                       }
-                      drop(l);
-                      var _o11 = join(xs, ks);
-                      var _i14 = undefined;
-                      for (_i14 in _o11) {
-                        var _v1 = _o11[_i14];
+                      drop(_l4);
+                      var __o11 = join(_xs11, _ks);
+                      var __i22 = undefined;
+                      for (__i22 in __o11) {
+                        var _v10 = __o11[__i22];
                         var _e17;
-                        if (numeric63(_i14)) {
-                          _e17 = parseInt(_i14);
+                        if (numeric63(__i22)) {
+                          _e17 = parseInt(__i22);
                         } else {
-                          _e17 = _i14;
+                          _e17 = __i22;
                         }
-                        var __i14 = _e17;
-                        s = s + sp + _v1;
-                        sp = " ";
+                        var __i221 = _e17;
+                        _s = _s + _sp + _v10;
+                        _sp = " ";
                       }
-                      return(s + ")");
+                      return(_s + ")");
                     }
                   }
                 }
@@ -654,44 +654,44 @@ apply = function (f, args) {
   return(f.apply(f, _args));
 };
 call = function (f) {
-  var _r70 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _f = destash33(f, _r70);
-  var _id = _r70;
-  var args = cut(_id, 0);
-  return(apply(_f, args));
+  var __r72 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _f = destash33(f, __r72);
+  var __id = __r72;
+  var _args11 = cut(__id, 0);
+  return(apply(_f, _args11));
 };
 toplevel63 = function () {
   return(one63(environment));
 };
 setenv = function (k) {
-  var _r72 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _k9 = destash33(k, _r72);
-  var _id1 = _r72;
-  var _keys = cut(_id1, 0);
-  if (string63(_k9)) {
+  var __r74 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _k18 = destash33(k, __r74);
+  var __id1 = __r74;
+  var _keys = cut(__id1, 0);
+  if (string63(_k18)) {
     var _e18;
     if (_keys.toplevel) {
       _e18 = hd(environment);
     } else {
       _e18 = last(environment);
     }
-    var frame = _e18;
-    var entry = frame[_k9] || {};
-    var _o12 = _keys;
-    var _k10 = undefined;
-    for (_k10 in _o12) {
-      var v = _o12[_k10];
+    var _frame = _e18;
+    var _entry = _frame[_k18] || {};
+    var __o12 = _keys;
+    var _k19 = undefined;
+    for (_k19 in __o12) {
+      var _v11 = __o12[_k19];
       var _e19;
-      if (numeric63(_k10)) {
-        _e19 = parseInt(_k10);
+      if (numeric63(_k19)) {
+        _e19 = parseInt(_k19);
       } else {
-        _e19 = _k10;
+        _e19 = _k19;
       }
-      var _k11 = _e19;
-      entry[_k11] = v;
+      var _k20 = _e19;
+      _entry[_k20] = _v11;
     }
-    frame[_k9] = entry;
-    return(frame[_k9]);
+    _frame[_k18] = _entry;
+    return(_frame[_k18]);
   }
 };
 print = function (x) {
@@ -725,13 +725,13 @@ setenv("quasiquote", {_stash: true, macro: function (form) {
   return(quasiexpand(form, 1));
 }});
 setenv("set", {_stash: true, macro: function () {
-  var args = unstash(Array.prototype.slice.call(arguments, 0));
-  return(join(["do"], map(function (_x5) {
-    var _id1 = _x5;
-    var lh = _id1[0];
-    var rh = _id1[1];
-    return(["%set", lh, rh]);
-  }, pair(args))));
+  var _args1 = unstash(Array.prototype.slice.call(arguments, 0));
+  return(join(["do"], map(function (_x4) {
+    var __id1 = _x4;
+    var _lh1 = __id1[0];
+    var _rh1 = __id1[1];
+    return(["%set", _lh1, _rh1]);
+  }, pair(_args1))));
 }});
 setenv("at", {_stash: true, macro: function (l, i) {
   if (target === "lua" && number63(i)) {
@@ -751,435 +751,433 @@ setenv("wipe", {_stash: true, macro: function (place) {
   }
 }});
 setenv("list", {_stash: true, macro: function () {
-  var body = unstash(Array.prototype.slice.call(arguments, 0));
-  var x = unique("x");
-  var l = [];
-  var forms = [];
-  var _o1 = body;
-  var k = undefined;
-  for (k in _o1) {
-    var v = _o1[k];
-    var _e5;
-    if (numeric63(k)) {
-      _e5 = parseInt(k);
+  var _body1 = unstash(Array.prototype.slice.call(arguments, 0));
+  var _x22 = unique("x");
+  var _l1 = [];
+  var _forms1 = [];
+  var __o1 = _body1;
+  var _k2 = undefined;
+  for (_k2 in __o1) {
+    var _v1 = __o1[_k2];
+    var _e8;
+    if (numeric63(_k2)) {
+      _e8 = parseInt(_k2);
     } else {
-      _e5 = k;
+      _e8 = _k2;
     }
-    var _k = _e5;
-    if (number63(_k)) {
-      l[_k] = v;
+    var _k3 = _e8;
+    if (number63(_k3)) {
+      _l1[_k3] = _v1;
     } else {
-      add(forms, ["set", ["get", x, ["quote", _k]], v]);
+      add(_forms1, ["set", ["get", _x22, ["quote", _k3]], _v1]);
     }
   }
-  if (some63(forms)) {
-    return(join(["let", x, join(["%array"], l)], forms, [x]));
+  if (some63(_forms1)) {
+    return(join(["let", _x22, join(["%array"], _l1)], _forms1, [_x22]));
   } else {
-    return(join(["%array"], l));
+    return(join(["%array"], _l1));
   }
 }});
 setenv("if", {_stash: true, macro: function () {
-  var branches = unstash(Array.prototype.slice.call(arguments, 0));
-  return(hd(expand_if(branches)));
+  var _branches1 = unstash(Array.prototype.slice.call(arguments, 0));
+  return(hd(expand_if(_branches1)));
 }});
 setenv("case", {_stash: true, macro: function (expr) {
-  var _r13 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _expr1 = destash33(expr, _r13);
-  var _id4 = _r13;
-  var clauses = cut(_id4, 0);
-  var x = unique("x");
-  var eq = function (_) {
-    return(["=", ["quote", _], x]);
+  var __r13 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _expr1 = destash33(expr, __r13);
+  var __id4 = __r13;
+  var _clauses1 = cut(__id4, 0);
+  var _x41 = unique("x");
+  var _eq1 = function (_) {
+    return(["=", ["quote", _], _x41]);
   };
-  var cl = function (_x44) {
-    var _id5 = _x44;
-    var a = _id5[0];
-    var b = _id5[1];
-    if (nil63(b)) {
-      return([a]);
+  var _cl1 = function (_x44) {
+    var __id5 = _x44;
+    var _a1 = __id5[0];
+    var _b1 = __id5[1];
+    if (nil63(_b1)) {
+      return([_a1]);
     } else {
-      if (string63(a) || number63(a)) {
-        return([eq(a), b]);
+      if (string63(_a1) || number63(_a1)) {
+        return([_eq1(_a1), _b1]);
       } else {
-        if (one63(a)) {
-          return([eq(hd(a)), b]);
+        if (one63(_a1)) {
+          return([_eq1(hd(_a1)), _b1]);
         } else {
-          if (_35(a) > 1) {
-            return([join(["or"], map(eq, a)), b]);
+          if (_35(_a1) > 1) {
+            return([join(["or"], map(_eq1, _a1)), _b1]);
           }
         }
       }
     }
   };
-  return(["let", x, _expr1, join(["if"], apply(join, map(cl, pair(clauses))))]);
+  return(["let", _x41, _expr1, join(["if"], apply(join, map(_cl1, pair(_clauses1))))]);
 }});
 setenv("when", {_stash: true, macro: function (cond) {
-  var _r17 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _cond1 = destash33(cond, _r17);
-  var _id7 = _r17;
-  var body = cut(_id7, 0);
-  return(["if", _cond1, join(["do"], body)]);
+  var __r17 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _cond1 = destash33(cond, __r17);
+  var __id7 = __r17;
+  var _body3 = cut(__id7, 0);
+  return(["if", _cond1, join(["do"], _body3)]);
 }});
 setenv("unless", {_stash: true, macro: function (cond) {
-  var _r19 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _cond3 = destash33(cond, _r19);
-  var _id9 = _r19;
-  var body = cut(_id9, 0);
-  return(["if", ["not", _cond3], join(["do"], body)]);
+  var __r19 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _cond3 = destash33(cond, __r19);
+  var __id9 = __r19;
+  var _body5 = cut(__id9, 0);
+  return(["if", ["not", _cond3], join(["do"], _body5)]);
 }});
 setenv("obj", {_stash: true, macro: function () {
-  var body = unstash(Array.prototype.slice.call(arguments, 0));
+  var _body7 = unstash(Array.prototype.slice.call(arguments, 0));
   return(join(["%object"], mapo(function (x) {
     return(x);
-  }, body)));
+  }, _body7)));
 }});
 setenv("let", {_stash: true, macro: function (bs) {
-  var _r23 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _bs1 = destash33(bs, _r23);
-  var _id13 = _r23;
-  var body = cut(_id13, 0);
-  if (atom63(_bs1)) {
-    return(join(["let", [_bs1, hd(body)]], tl(body)));
+  var __r23 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _bs11 = destash33(bs, __r23);
+  var __id14 = __r23;
+  var _body9 = cut(__id14, 0);
+  if (atom63(_bs11)) {
+    return(join(["let", [_bs11, hd(_body9)]], tl(_body9)));
   } else {
-    if (none63(_bs1)) {
-      return(join(["do"], body));
+    if (none63(_bs11)) {
+      return(join(["do"], _body9));
     } else {
-      var _id14 = _bs1;
-      var lh = _id14[0];
-      var rh = _id14[1];
-      var bs2 = cut(_id14, 2);
-      var _id15 = bind(lh, rh);
-      var id = _id15[0];
-      var val = _id15[1];
-      var bs1 = cut(_id15, 2);
-      var renames = [];
-      if (bound63(id) || toplevel63()) {
-        var id1 = unique(id);
-        renames = [id, id1];
-        id = id1;
-      } else {
-        setenv(id, {_stash: true, variable: true});
+      var __id15 = _bs11;
+      var _lh3 = __id15[0];
+      var _rh3 = __id15[1];
+      var _bs21 = cut(__id15, 2);
+      var __id16 = bind(_lh3, _rh3);
+      var _id17 = __id16[0];
+      var _val1 = __id16[1];
+      var _bs12 = cut(__id16, 2);
+      var _renames1 = [];
+      if (! id_literal63(_id17)) {
+        var _id121 = unique(_id17);
+        _renames1 = [_id17, _id121];
+        _id17 = _id121;
       }
-      return(["do", ["%local", id, val], ["let-symbol", renames, join(["let", join(bs1, bs2)], body)]]);
+      return(["do", ["%local", _id17, _val1], ["let-symbol", _renames1, join(["let", join(_bs12, _bs21)], _body9)]]);
     }
   }
 }});
 setenv("with", {_stash: true, macro: function (x, v) {
-  var _r25 = unstash(Array.prototype.slice.call(arguments, 2));
-  var _x89 = destash33(x, _r25);
-  var _v1 = destash33(v, _r25);
-  var _id17 = _r25;
-  var body = cut(_id17, 0);
-  return(join(["let", [_x89, _v1]], body, [_x89]));
+  var __r25 = unstash(Array.prototype.slice.call(arguments, 2));
+  var _x84 = destash33(x, __r25);
+  var _v3 = destash33(v, __r25);
+  var __id19 = __r25;
+  var _body11 = cut(__id19, 0);
+  return(join(["let", [_x84, _v3]], _body11, [_x84]));
 }});
 setenv("let-when", {_stash: true, macro: function (x, v) {
-  var _r27 = unstash(Array.prototype.slice.call(arguments, 2));
-  var _x100 = destash33(x, _r27);
-  var _v3 = destash33(v, _r27);
-  var _id19 = _r27;
-  var body = cut(_id19, 0);
-  var y = unique("y");
-  return(["let", y, _v3, ["when", ["yes", y], join(["let", [_x100, y]], body)]]);
+  var __r27 = unstash(Array.prototype.slice.call(arguments, 2));
+  var _x94 = destash33(x, __r27);
+  var _v5 = destash33(v, __r27);
+  var __id21 = __r27;
+  var _body13 = cut(__id21, 0);
+  var _y1 = unique("y");
+  return(["let", _y1, _v5, ["when", ["yes", _y1], join(["let", [_x94, _y1]], _body13)]]);
 }});
 setenv("define-macro", {_stash: true, macro: function (name, args) {
-  var _r29 = unstash(Array.prototype.slice.call(arguments, 2));
-  var _name1 = destash33(name, _r29);
-  var _args1 = destash33(args, _r29);
-  var _id21 = _r29;
-  var body = cut(_id21, 0);
-  var _x110 = ["setenv", ["quote", _name1]];
-  _x110.macro = join(["fn", _args1], body);
-  var form = _x110;
-  eval(form);
-  return(form);
+  var __r29 = unstash(Array.prototype.slice.call(arguments, 2));
+  var _name1 = destash33(name, __r29);
+  var _args3 = destash33(args, __r29);
+  var __id23 = __r29;
+  var _body15 = cut(__id23, 0);
+  var __x103 = ["setenv", ["quote", _name1]];
+  __x103.macro = join(["fn", _args3], _body15);
+  var _form1 = __x103;
+  eval(_form1);
+  return(_form1);
 }});
 setenv("define-special", {_stash: true, macro: function (name, args) {
-  var _r31 = unstash(Array.prototype.slice.call(arguments, 2));
-  var _name3 = destash33(name, _r31);
-  var _args3 = destash33(args, _r31);
-  var _id23 = _r31;
-  var body = cut(_id23, 0);
-  var _x117 = ["setenv", ["quote", _name3]];
-  _x117.special = join(["fn", _args3], body);
-  var form = join(_x117, keys(body));
-  eval(form);
-  return(form);
+  var __r31 = unstash(Array.prototype.slice.call(arguments, 2));
+  var _name3 = destash33(name, __r31);
+  var _args5 = destash33(args, __r31);
+  var __id25 = __r31;
+  var _body17 = cut(__id25, 0);
+  var __x109 = ["setenv", ["quote", _name3]];
+  __x109.special = join(["fn", _args5], _body17);
+  var _form3 = join(__x109, keys(_body17));
+  eval(_form3);
+  return(_form3);
 }});
 setenv("define-symbol", {_stash: true, macro: function (name, expansion) {
   setenv(name, {_stash: true, symbol: expansion});
-  var _x123 = ["setenv", ["quote", name]];
-  _x123.symbol = ["quote", expansion];
-  return(_x123);
+  var __x115 = ["setenv", ["quote", name]];
+  __x115.symbol = ["quote", expansion];
+  return(__x115);
 }});
-setenv("define-reader", {_stash: true, macro: function (_x132) {
-  var _id26 = _x132;
-  var char = _id26[0];
-  var s = _id26[1];
-  var _r35 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __x132 = destash33(_x132, _r35);
-  var _id27 = _r35;
-  var body = cut(_id27, 0);
-  return(["set", ["get", "read-table", char], join(["fn", [s]], body)]);
+setenv("define-reader", {_stash: true, macro: function (_x123) {
+  var __id28 = _x123;
+  var _char1 = __id28[0];
+  var _s1 = __id28[1];
+  var __r35 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __x123 = destash33(_x123, __r35);
+  var __id29 = __r35;
+  var _body19 = cut(__id29, 0);
+  return(["set", ["get", "read-table", _char1], join(["fn", [_s1]], _body19)]);
 }});
 setenv("define", {_stash: true, macro: function (name, x) {
-  var _r37 = unstash(Array.prototype.slice.call(arguments, 2));
-  var _name5 = destash33(name, _r37);
-  var _x141 = destash33(x, _r37);
-  var _id29 = _r37;
-  var body = cut(_id29, 0);
+  var __r37 = unstash(Array.prototype.slice.call(arguments, 2));
+  var _name5 = destash33(name, __r37);
+  var _x131 = destash33(x, __r37);
+  var __id31 = __r37;
+  var _body21 = cut(__id31, 0);
   setenv(_name5, {_stash: true, variable: true});
-  if (some63(body)) {
-    return(join(["%local-function", _name5], bind42(_x141, body)));
+  if (some63(_body21)) {
+    return(join(["%local-function", _name5], bind42(_x131, _body21)));
   } else {
-    return(["%local", _name5, _x141]);
+    return(["%local", _name5, _x131]);
   }
 }});
 setenv("define-global", {_stash: true, macro: function (name, x) {
-  var _r39 = unstash(Array.prototype.slice.call(arguments, 2));
-  var _name7 = destash33(name, _r39);
-  var _x148 = destash33(x, _r39);
-  var _id31 = _r39;
-  var body = cut(_id31, 0);
-  setenv(_name7, {_stash: true, variable: true, toplevel: true});
-  if (some63(body)) {
-    return(join(["%global-function", _name7], bind42(_x148, body)));
+  var __r39 = unstash(Array.prototype.slice.call(arguments, 2));
+  var _name7 = destash33(name, __r39);
+  var _x137 = destash33(x, __r39);
+  var __id33 = __r39;
+  var _body23 = cut(__id33, 0);
+  setenv(_name7, {_stash: true, toplevel: true, variable: true});
+  if (some63(_body23)) {
+    return(join(["%global-function", _name7], bind42(_x137, _body23)));
   } else {
-    return(["set", _name7, _x148]);
+    return(["set", _name7, _x137]);
   }
 }});
 setenv("with-frame", {_stash: true, macro: function () {
-  var body = unstash(Array.prototype.slice.call(arguments, 0));
-  var x = unique("x");
-  return(["do", ["add", "environment", ["obj"]], ["with", x, join(["do"], body), ["drop", "environment"]]]);
+  var _body25 = unstash(Array.prototype.slice.call(arguments, 0));
+  var _x147 = unique("x");
+  return(["do", ["add", "environment", ["obj"]], ["with", _x147, join(["do"], _body25), ["drop", "environment"]]]);
 }});
-setenv("with-bindings", {_stash: true, macro: function (_x169) {
-  var _id34 = _x169;
-  var names = _id34[0];
-  var _r41 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __x169 = destash33(_x169, _r41);
-  var _id35 = _r41;
-  var body = cut(_id35, 0);
-  var x = unique("x");
-  var _x172 = ["setenv", x];
-  _x172.variable = true;
-  return(join(["with-frame", ["each", x, names, _x172]], body));
+setenv("with-bindings", {_stash: true, macro: function (_x159) {
+  var __id36 = _x159;
+  var _names1 = __id36[0];
+  var __r41 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __x159 = destash33(_x159, __r41);
+  var __id37 = __r41;
+  var _body27 = cut(__id37, 0);
+  var _x160 = unique("x");
+  var __x163 = ["setenv", _x160];
+  __x163.variable = true;
+  return(join(["with-frame", ["each", _x160, _names1, __x163]], _body27));
 }});
 setenv("let-macro", {_stash: true, macro: function (definitions) {
-  var _r44 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _definitions1 = destash33(definitions, _r44);
-  var _id37 = _r44;
-  var body = cut(_id37, 0);
+  var __r44 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _definitions1 = destash33(definitions, __r44);
+  var __id39 = __r44;
+  var _body29 = cut(__id39, 0);
   add(environment, {});
   map(function (m) {
     return(macroexpand(join(["define-macro"], m)));
   }, _definitions1);
-  var _x177 = join(["do"], macroexpand(body));
+  var __x167 = join(["do"], macroexpand(_body29));
   drop(environment);
-  return(_x177);
+  return(__x167);
 }});
 setenv("let-symbol", {_stash: true, macro: function (expansions) {
-  var _r48 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _expansions1 = destash33(expansions, _r48);
-  var _id40 = _r48;
-  var body = cut(_id40, 0);
+  var __r48 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _expansions1 = destash33(expansions, __r48);
+  var __id42 = __r48;
+  var _body31 = cut(__id42, 0);
   add(environment, {});
-  map(function (_x186) {
-    var _id41 = _x186;
-    var name = _id41[0];
-    var exp = _id41[1];
-    return(macroexpand(["define-symbol", name, exp]));
+  map(function (_x175) {
+    var __id43 = _x175;
+    var _name9 = __id43[0];
+    var _exp1 = __id43[1];
+    return(macroexpand(["define-symbol", _name9, _exp1]));
   }, pair(_expansions1));
-  var _x185 = join(["do"], macroexpand(body));
+  var __x174 = join(["do"], macroexpand(_body31));
   drop(environment);
-  return(_x185);
+  return(__x174);
 }});
 setenv("let-unique", {_stash: true, macro: function (names) {
-  var _r52 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _names1 = destash33(names, _r52);
-  var _id43 = _r52;
-  var body = cut(_id43, 0);
-  var bs = map(function (n) {
+  var __r52 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _names3 = destash33(names, __r52);
+  var __id45 = __r52;
+  var _body33 = cut(__id45, 0);
+  var _bs3 = map(function (n) {
     return([n, ["unique", ["quote", n]]]);
-  }, _names1);
-  return(join(["let", apply(join, bs)], body));
+  }, _names3);
+  return(join(["let", apply(join, _bs3)], _body33));
 }});
 setenv("fn", {_stash: true, macro: function (args) {
-  var _r55 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _args5 = destash33(args, _r55);
-  var _id45 = _r55;
-  var body = cut(_id45, 0);
-  return(join(["%function"], bind42(_args5, body)));
+  var __r55 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _args7 = destash33(args, __r55);
+  var __id47 = __r55;
+  var _body35 = cut(__id47, 0);
+  return(join(["%function"], bind42(_args7, _body35)));
 }});
 setenv("apply", {_stash: true, macro: function (f) {
-  var _r57 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _f1 = destash33(f, _r57);
-  var _id47 = _r57;
-  var args = cut(_id47, 0);
-  if (_35(args) > 1) {
-    return([["do", "apply"], _f1, ["join", join(["list"], almost(args)), last(args)]]);
+  var __r57 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _f1 = destash33(f, __r57);
+  var __id49 = __r57;
+  var _args9 = cut(__id49, 0);
+  if (_35(_args9) > 1) {
+    return([["do", "apply"], _f1, ["join", join(["list"], almost(_args9)), last(_args9)]]);
   } else {
-    return(join([["do", "apply"], _f1], args));
+    return(join([["do", "apply"], _f1], _args9));
   }
 }});
 setenv("guard", {_stash: true, macro: function (expr) {
   if (target === "js") {
     return([["fn", join(), ["%try", ["list", true, expr]]]]);
   } else {
-    var x = unique("x");
-    var msg = unique("msg");
-    var trace = unique("trace");
-    var _x265 = ["obj"];
-    _x265.message = msg;
-    _x265.stack = trace;
-    return(["let", [x, "nil", msg, "nil", trace, "nil"], ["if", ["xpcall", ["fn", join(), ["set", x, expr]], ["fn", ["m"], ["set", trace, [["get", "debug", ["quote", "traceback"]]], msg, ["if", ["string?", "m"], ["clip", "m", ["+", ["search", "m", "\": \""], 2]], ["nil?", "m"], "\"\"", ["str", "m"]]]]], ["list", true, x], ["list", false, _x265]]]);
+    var _x231 = unique("x");
+    var _msg1 = unique("msg");
+    var _trace1 = unique("trace");
+    var __x253 = ["obj"];
+    __x253.message = _msg1;
+    __x253.stack = _trace1;
+    return(["let", [_x231, "nil", _msg1, "nil", _trace1, "nil"], ["if", ["xpcall", ["fn", join(), ["set", _x231, expr]], ["fn", ["m"], ["set", _trace1, [["get", "debug", ["quote", "traceback"]]], _msg1, ["if", ["string?", "m"], ["clip", "m", ["+", ["search", "m", "\": \""], 2]], ["nil?", "m"], "\"\"", ["str", "m"]]]]], ["list", true, _x231], ["list", false, __x253]]]);
   }
 }});
 setenv("each", {_stash: true, macro: function (x, t) {
-  var _r61 = unstash(Array.prototype.slice.call(arguments, 2));
-  var _x281 = destash33(x, _r61);
-  var _t1 = destash33(t, _r61);
-  var _id50 = _r61;
-  var body = cut(_id50, 0);
-  var o = unique("o");
-  var n = unique("n");
-  var i = unique("i");
-  var _e6;
-  if (atom63(_x281)) {
-    _e6 = [i, _x281];
+  var __r61 = unstash(Array.prototype.slice.call(arguments, 2));
+  var _x268 = destash33(x, __r61);
+  var _t1 = destash33(t, __r61);
+  var __id52 = __r61;
+  var _body37 = cut(__id52, 0);
+  var _o3 = unique("o");
+  var _n3 = unique("n");
+  var _i3 = unique("i");
+  var _e9;
+  if (atom63(_x268)) {
+    _e9 = [_i3, _x268];
   } else {
-    var _e7;
-    if (_35(_x281) > 1) {
-      _e7 = _x281;
+    var _e10;
+    if (_35(_x268) > 1) {
+      _e10 = _x268;
     } else {
-      _e7 = [i, hd(_x281)];
+      _e10 = [_i3, hd(_x268)];
     }
-    _e6 = _e7;
+    _e9 = _e10;
   }
-  var _id51 = _e6;
-  var k = _id51[0];
-  var v = _id51[1];
-  var _e8;
+  var __id53 = _e9;
+  var _k5 = __id53[0];
+  var _v7 = __id53[1];
+  var _e11;
   if (target === "lua") {
-    _e8 = body;
+    _e11 = _body37;
   } else {
-    _e8 = [join(["let", k, ["if", ["numeric?", k], ["parseInt", k], k]], body)];
+    _e11 = [join(["let", _k5, ["if", ["numeric?", _k5], ["parseInt", _k5], _k5]], _body37)];
   }
-  return(["let", [o, _t1, k, "nil"], ["%for", o, k, join(["let", [v, ["get", o, k]]], _e8)]]);
+  return(["let", [_o3, _t1, _k5, "nil"], ["%for", _o3, _k5, join(["let", [_v7, ["get", _o3, _k5]]], _e11)]]);
 }});
 setenv("for", {_stash: true, macro: function (i, to) {
-  var _r63 = unstash(Array.prototype.slice.call(arguments, 2));
-  var _i3 = destash33(i, _r63);
-  var _to1 = destash33(to, _r63);
-  var _id53 = _r63;
-  var body = cut(_id53, 0);
-  return(["let", _i3, 0, join(["while", ["<", _i3, _to1]], body, [["inc", _i3]])]);
+  var __r63 = unstash(Array.prototype.slice.call(arguments, 2));
+  var _i5 = destash33(i, __r63);
+  var _to1 = destash33(to, __r63);
+  var __id55 = __r63;
+  var _body39 = cut(__id55, 0);
+  return(["let", _i5, 0, join(["while", ["<", _i5, _to1]], _body39, [["inc", _i5]])]);
 }});
 setenv("step", {_stash: true, macro: function (v, t) {
-  var _r65 = unstash(Array.prototype.slice.call(arguments, 2));
-  var _v5 = destash33(v, _r65);
-  var _t3 = destash33(t, _r65);
-  var _id55 = _r65;
-  var body = cut(_id55, 0);
-  var x = unique("x");
-  var i = unique("i");
-  return(["let", [x, _t3], ["for", i, ["#", x], join(["let", [_v5, ["at", x, i]]], body)]]);
+  var __r65 = unstash(Array.prototype.slice.call(arguments, 2));
+  var _v9 = destash33(v, __r65);
+  var _t3 = destash33(t, __r65);
+  var __id57 = __r65;
+  var _body41 = cut(__id57, 0);
+  var _x300 = unique("x");
+  var _i7 = unique("i");
+  return(["let", [_x300, _t3], ["for", _i7, ["#", _x300], join(["let", [_v9, ["at", _x300, _i7]]], _body41)]]);
 }});
 setenv("set-of", {_stash: true, macro: function () {
-  var xs = unstash(Array.prototype.slice.call(arguments, 0));
-  var l = [];
-  var _o3 = xs;
-  var _i5 = undefined;
-  for (_i5 in _o3) {
-    var x = _o3[_i5];
-    var _e9;
-    if (numeric63(_i5)) {
-      _e9 = parseInt(_i5);
+  var _xs1 = unstash(Array.prototype.slice.call(arguments, 0));
+  var _l3 = [];
+  var __o5 = _xs1;
+  var __i9 = undefined;
+  for (__i9 in __o5) {
+    var _x310 = __o5[__i9];
+    var _e12;
+    if (numeric63(__i9)) {
+      _e12 = parseInt(__i9);
     } else {
-      _e9 = _i5;
+      _e12 = __i9;
     }
-    var __i5 = _e9;
-    l[x] = true;
+    var __i91 = _e12;
+    _l3[_x310] = true;
   }
-  return(join(["obj"], l));
+  return(join(["obj"], _l3));
 }});
 setenv("language", {_stash: true, macro: function () {
   return(["quote", target]);
 }});
 setenv("target", {_stash: true, macro: function () {
-  var clauses = unstash(Array.prototype.slice.call(arguments, 0));
-  return(clauses[target]);
+  var _clauses3 = unstash(Array.prototype.slice.call(arguments, 0));
+  return(_clauses3[target]);
 }});
 setenv("join!", {_stash: true, macro: function (a) {
-  var _r69 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _a1 = destash33(a, _r69);
-  var _id57 = _r69;
-  var bs = cut(_id57, 0);
-  return(["set", _a1, join(["join", _a1], bs)]);
+  var __r69 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _a3 = destash33(a, __r69);
+  var __id59 = __r69;
+  var _bs5 = cut(__id59, 0);
+  return(["set", _a3, join(["join", _a3], _bs5)]);
 }});
 setenv("cat!", {_stash: true, macro: function (a) {
-  var _r71 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _a3 = destash33(a, _r71);
-  var _id59 = _r71;
-  var bs = cut(_id59, 0);
-  return(["set", _a3, join(["cat", _a3], bs)]);
+  var __r71 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _a5 = destash33(a, __r71);
+  var __id61 = __r71;
+  var _bs7 = cut(__id61, 0);
+  return(["set", _a5, join(["cat", _a5], _bs7)]);
 }});
 setenv("inc", {_stash: true, macro: function (n, by) {
-  var _e10;
+  var _e13;
   if (nil63(by)) {
-    _e10 = 1;
+    _e13 = 1;
   } else {
-    _e10 = by;
+    _e13 = by;
   }
-  return(["set", n, ["+", n, _e10]]);
+  return(["set", n, ["+", n, _e13]]);
 }});
 setenv("dec", {_stash: true, macro: function (n, by) {
-  var _e11;
+  var _e14;
   if (nil63(by)) {
-    _e11 = 1;
+    _e14 = 1;
   } else {
-    _e11 = by;
+    _e14 = by;
   }
-  return(["set", n, ["-", n, _e11]]);
+  return(["set", n, ["-", n, _e14]]);
 }});
 setenv("with-indent", {_stash: true, macro: function (form) {
-  var x = unique("x");
-  return(["do", ["inc", "indent-level"], ["with", x, form, ["dec", "indent-level"]]]);
+  var _x335 = unique("x");
+  return(["do", ["inc", "indent-level"], ["with", _x335, form, ["dec", "indent-level"]]]);
 }});
 setenv("export", {_stash: true, macro: function () {
-  var names = unstash(Array.prototype.slice.call(arguments, 0));
+  var _names5 = unstash(Array.prototype.slice.call(arguments, 0));
   if (target === "js") {
     return(join(["do"], map(function (k) {
       return(["set", ["get", "exports", ["quote", k]], k]);
-    }, names)));
+    }, _names5)));
   } else {
-    var x = {};
-    var _o5 = names;
-    var _i7 = undefined;
-    for (_i7 in _o5) {
-      var k = _o5[_i7];
-      var _e12;
-      if (numeric63(_i7)) {
-        _e12 = parseInt(_i7);
+    var _x351 = {};
+    var __o7 = _names5;
+    var __i11 = undefined;
+    for (__i11 in __o7) {
+      var _k7 = __o7[__i11];
+      var _e15;
+      if (numeric63(__i11)) {
+        _e15 = parseInt(__i11);
       } else {
-        _e12 = _i7;
+        _e15 = __i11;
       }
-      var __i7 = _e12;
-      x[k] = k;
+      var __i111 = _e15;
+      _x351[_k7] = _k7;
     }
     return(["return", join(["%object"], mapo(function (x) {
       return(x);
-    }, x))]);
+    }, _x351))]);
   }
 }});
 setenv("when-compiling", {_stash: true, macro: function () {
-  var body = unstash(Array.prototype.slice.call(arguments, 0));
-  return(eval(join(["do"], body)));
+  var _body43 = unstash(Array.prototype.slice.call(arguments, 0));
+  return(eval(join(["do"], _body43)));
 }});
 var reader = require("reader");
 var compiler = require("compiler");
 var system = require("system");
 var eval_print = function (form) {
-  var _id = (function () {
+  var __id = (function () {
     try {
       return([true, compiler.eval(form)]);
     }
@@ -1187,13 +1185,13 @@ var eval_print = function (form) {
       return([false, _e]);
     }
   })();
-  var ok = _id[0];
-  var v = _id[1];
-  if (! ok) {
-    return(print(v.stack));
+  var _ok = __id[0];
+  var _v = __id[1];
+  if (! _ok) {
+    return(print(_v.stack));
   } else {
-    if (is63(v)) {
-      return(print(str(v)));
+    if (is63(_v)) {
+      return(print(str(_v)));
     }
   }
 };
@@ -1201,14 +1199,14 @@ var rep = function (s) {
   return(eval_print(reader["read-string"](s)));
 };
 var repl = function () {
-  var buf = "";
+  var _buf = "";
   var rep1 = function (s) {
-    buf = buf + s;
-    var more = [];
-    var form = reader["read-string"](buf, more);
-    if (!( form === more)) {
-      eval_print(form);
-      buf = "";
+    _buf = _buf + s;
+    var _more = [];
+    var _form = reader["read-string"](_buf, _more);
+    if (!( _form === _more)) {
+      eval_print(_form);
+      _buf = "";
       return(system.write("> "));
     }
   };
@@ -1218,17 +1216,17 @@ var repl = function () {
   return(_in.on("data", rep1));
 };
 compile_file = function (path) {
-  var s = reader.stream(system["read-file"](path));
-  var body = reader["read-all"](s);
-  var form = compiler.expand(join(["do"], body));
-  return(compiler.compile(form, {_stash: true, stmt: true}));
+  var _s = reader.stream(system["read-file"](path));
+  var _body = reader["read-all"](_s);
+  var _form1 = compiler.expand(join(["do"], _body));
+  return(compiler.compile(_form1, {_stash: true, stmt: true}));
 };
 load = function (path) {
-  var previous = target;
+  var _previous = target;
   target = "js";
-  var code = compile_file(path);
-  target = previous;
-  return(compiler.run(code));
+  var _code = compile_file(path);
+  target = _previous;
+  return(compiler.run(_code));
 };
 var run_file = function (path) {
   return(compiler.run(system["read-file"](path)));
@@ -1248,73 +1246,73 @@ var usage = function () {
   return(print(" -e <expr>\tExpression to evaluate"));
 };
 var main = function () {
-  var arg = hd(system.argv);
-  if (arg && script_file63(arg)) {
-    return(load(arg));
+  var _arg = hd(system.argv);
+  if (_arg && script_file63(_arg)) {
+    return(load(_arg));
   } else {
-    if (arg === "-h" || arg === "--help") {
+    if (_arg === "-h" || _arg === "--help") {
       return(usage());
     } else {
-      var pre = [];
-      var input = undefined;
-      var output = undefined;
-      var target1 = undefined;
-      var expr = undefined;
-      var argv = system.argv;
-      var i = 0;
-      while (i < _35(argv)) {
-        var a = argv[i];
-        if (a === "-c" || a === "-o" || a === "-t" || a === "-e") {
-          if (i === edge(argv)) {
-            print("missing argument for " + a);
+      var _pre = [];
+      var _input = undefined;
+      var _output = undefined;
+      var _target1 = undefined;
+      var _expr = undefined;
+      var _argv = system.argv;
+      var _i = 0;
+      while (_i < _35(_argv)) {
+        var _a = _argv[_i];
+        if (_a === "-c" || _a === "-o" || _a === "-t" || _a === "-e") {
+          if (_i === edge(_argv)) {
+            print("missing argument for " + _a);
           } else {
-            i = i + 1;
-            var val = argv[i];
-            if (a === "-c") {
-              input = val;
+            _i = _i + 1;
+            var _val = _argv[_i];
+            if (_a === "-c") {
+              _input = _val;
             } else {
-              if (a === "-o") {
-                output = val;
+              if (_a === "-o") {
+                _output = _val;
               } else {
-                if (a === "-t") {
-                  target1 = val;
+                if (_a === "-t") {
+                  _target1 = _val;
                 } else {
-                  if (a === "-e") {
-                    expr = val;
+                  if (_a === "-e") {
+                    _expr = _val;
                   }
                 }
               }
             }
           }
         } else {
-          if (!( "-" === char(a, 0))) {
-            add(pre, a);
+          if (!( "-" === char(_a, 0))) {
+            add(_pre, _a);
           }
         }
-        i = i + 1;
-      }
-      var _x2 = pre;
-      var _i = 0;
-      while (_i < _35(_x2)) {
-        var file = _x2[_i];
-        run_file(file);
         _i = _i + 1;
       }
-      if (nil63(input)) {
-        if (expr) {
-          return(rep(expr));
+      var __x2 = _pre;
+      var __i1 = 0;
+      while (__i1 < _35(__x2)) {
+        var _file = __x2[__i1];
+        run_file(_file);
+        __i1 = __i1 + 1;
+      }
+      if (nil63(_input)) {
+        if (_expr) {
+          return(rep(_expr));
         } else {
           return(repl());
         }
       } else {
-        if (target1) {
-          target = target1;
+        if (_target1) {
+          target = _target1;
         }
-        var code = compile_file(input);
-        if (nil63(output) || output === "-") {
-          return(print(code));
+        var _code1 = compile_file(_input);
+        if (nil63(_output) || _output === "-") {
+          return(print(_code1));
         } else {
-          return(system["write-file"](output, code));
+          return(system["write-file"](_output, _code1));
         }
       }
     }

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -565,13 +565,10 @@ function call(f, ...)
   local _args11 = cut(__id, 0)
   return(apply(_f, _args11))
 end
-function toplevel63()
-  return(one63(environment))
-end
 function setenv(k, ...)
-  local __r71 = unstash({...})
-  local _k9 = destash33(k, __r71)
-  local __id1 = __r71
+  local __r70 = unstash({...})
+  local _k9 = destash33(k, __r70)
+  local __id1 = __r70
   local _keys = cut(__id1, 0)
   if string63(_k9) then
     local _e7

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -60,49 +60,49 @@ function clip(s, from, upto)
   return(string.sub(s, from + 1, upto))
 end
 function cut(x, from, upto)
-  local l = {}
-  local j = 0
+  local _l = {}
+  local _j = 0
   local _e
   if nil63(from) or from < 0 then
     _e = 0
   else
     _e = from
   end
-  local i = _e
-  local n = _35(x)
+  local _i = _e
+  local _n = _35(x)
   local _e1
-  if nil63(upto) or upto > n then
-    _e1 = n
+  if nil63(upto) or upto > _n then
+    _e1 = _n
   else
     _e1 = upto
   end
   local _upto = _e1
-  while i < _upto do
-    l[j + 1] = x[i + 1]
-    i = i + 1
-    j = j + 1
+  while _i < _upto do
+    _l[_j + 1] = x[_i + 1]
+    _i = _i + 1
+    _j = _j + 1
   end
-  local _o = x
-  local k = nil
-  for k in next, _o do
-    local v = _o[k]
-    if not number63(k) then
-      l[k] = v
+  local __o = x
+  local _k = nil
+  for _k in next, __o do
+    local _v = __o[_k]
+    if not number63(_k) then
+      _l[_k] = _v
     end
   end
-  return(l)
+  return(_l)
 end
 function keys(x)
-  local t = {}
-  local _o1 = x
-  local k = nil
-  for k in next, _o1 do
-    local v = _o1[k]
-    if not number63(k) then
-      t[k] = v
+  local _t = {}
+  local __o1 = x
+  local _k1 = nil
+  for _k1 in next, __o1 do
+    local _v1 = __o1[_k1]
+    if not number63(_k1) then
+      _t[_k1] = _v1
     end
   end
-  return(t)
+  return(_t)
 end
 function edge(x)
   return(_35(x) - 1)
@@ -142,13 +142,13 @@ function almost(l)
   return(cut(l, 0, edge(l)))
 end
 function reverse(l)
-  local l1 = keys(l)
-  local i = edge(l)
-  while i >= 0 do
-    add(l1, l[i + 1])
-    i = i - 1
+  local _l1 = keys(l)
+  local _i3 = edge(l)
+  while _i3 >= 0 do
+    add(_l1, l[_i3 + 1])
+    _i3 = _i3 - 1
   end
-  return(l1)
+  return(_l1)
 end
 function reduce(f, x, none)
   if none63(x) then
@@ -162,49 +162,49 @@ function reduce(f, x, none)
   end
 end
 function join(...)
-  local ls = unstash({...})
-  local r = {}
-  local _x2 = ls
-  local _i2 = 0
-  while _i2 < _35(_x2) do
-    local l = _x2[_i2 + 1]
-    if l then
-      local n = _35(r)
-      local _o2 = l
-      local k = nil
-      for k in next, _o2 do
-        local v = _o2[k]
-        if number63(k) then
-          k = k + n
+  local _ls = unstash({...})
+  local _r34 = {}
+  local __x2 = _ls
+  local __i4 = 0
+  while __i4 < _35(__x2) do
+    local _l11 = __x2[__i4 + 1]
+    if _l11 then
+      local _n3 = _35(_r34)
+      local __o2 = _l11
+      local _k2 = nil
+      for _k2 in next, __o2 do
+        local _v2 = __o2[_k2]
+        if number63(_k2) then
+          _k2 = _k2 + _n3
         end
-        r[k] = v
+        _r34[_k2] = _v2
       end
     end
-    _i2 = _i2 + 1
+    __i4 = __i4 + 1
   end
-  return(r)
+  return(_r34)
 end
 function find(f, t)
-  local _o3 = t
-  local _i4 = nil
-  for _i4 in next, _o3 do
-    local x = _o3[_i4]
-    local y = f(x)
-    if y then
-      return(y)
+  local __o3 = t
+  local __i6 = nil
+  for __i6 in next, __o3 do
+    local _x3 = __o3[__i6]
+    local _y = f(_x3)
+    if _y then
+      return(_y)
     end
   end
 end
 function first(f, l)
-  local _x3 = l
-  local _i5 = 0
-  while _i5 < _35(_x3) do
-    local x = _x3[_i5 + 1]
-    local y = f(x)
-    if y then
-      return(y)
+  local __x4 = l
+  local __i7 = 0
+  while __i7 < _35(__x4) do
+    local _x5 = __x4[__i7 + 1]
+    local _y1 = f(_x5)
+    if _y1 then
+      return(_y1)
     end
-    _i5 = _i5 + 1
+    __i7 = __i7 + 1
   end
 end
 function in63(x, t)
@@ -213,43 +213,43 @@ function in63(x, t)
   end, t))
 end
 function pair(l)
-  local l1 = {}
-  local i = 0
-  while i < _35(l) do
-    add(l1, {l[i + 1], l[i + 1 + 1]})
-    i = i + 1
-    i = i + 1
+  local _l12 = {}
+  local _i8 = 0
+  while _i8 < _35(l) do
+    add(_l12, {l[_i8 + 1], l[_i8 + 1 + 1]})
+    _i8 = _i8 + 1
+    _i8 = _i8 + 1
   end
-  return(l1)
+  return(_l12)
 end
 function sort(l, f)
   table.sort(l, f)
   return(l)
 end
 function map(f, x)
-  local t = {}
-  local _x5 = x
-  local _i6 = 0
-  while _i6 < _35(_x5) do
-    local v = _x5[_i6 + 1]
-    local y = f(v)
-    if is63(y) then
-      add(t, y)
+  local _t1 = {}
+  local __x7 = x
+  local __i9 = 0
+  while __i9 < _35(__x7) do
+    local _v3 = __x7[__i9 + 1]
+    local _y2 = f(_v3)
+    if is63(_y2) then
+      add(_t1, _y2)
     end
-    _i6 = _i6 + 1
+    __i9 = __i9 + 1
   end
-  local _o4 = x
-  local k = nil
-  for k in next, _o4 do
-    local _v = _o4[k]
-    if not number63(k) then
-      local _y = f(_v)
-      if is63(_y) then
-        t[k] = _y
+  local __o4 = x
+  local _k3 = nil
+  for _k3 in next, __o4 do
+    local _v4 = __o4[_k3]
+    if not number63(_k3) then
+      local _y3 = f(_v4)
+      if is63(_y3) then
+        _t1[_k3] = _y3
       end
     end
   end
-  return(t)
+  return(_t1)
 end
 function keep(f, x)
   return(map(function (v)
@@ -259,38 +259,38 @@ function keep(f, x)
   end, x))
 end
 function keys63(t)
-  local _o5 = t
-  local k = nil
-  for k in next, _o5 do
-    local v = _o5[k]
-    if not number63(k) then
+  local __o5 = t
+  local _k4 = nil
+  for _k4 in next, __o5 do
+    local _v5 = __o5[_k4]
+    if not number63(_k4) then
       return(true)
     end
   end
   return(false)
 end
 function empty63(t)
-  local _o6 = t
-  local _i9 = nil
-  for _i9 in next, _o6 do
-    local x = _o6[_i9]
+  local __o6 = t
+  local __i12 = nil
+  for __i12 in next, __o6 do
+    local _x8 = __o6[__i12]
     return(false)
   end
   return(true)
 end
 function stash(args)
   if keys63(args) then
-    local p = {}
-    local _o7 = args
-    local k = nil
-    for k in next, _o7 do
-      local v = _o7[k]
-      if not number63(k) then
-        p[k] = v
+    local _p = {}
+    local __o7 = args
+    local _k5 = nil
+    for _k5 in next, __o7 do
+      local _v6 = __o7[_k5]
+      if not number63(_k5) then
+        _p[_k5] = _v6
       end
     end
-    p._stash = true
-    add(args, p)
+    _p._stash = true
+    add(args, _p)
   end
   return(args)
 end
@@ -298,18 +298,18 @@ function unstash(args)
   if none63(args) then
     return({})
   else
-    local l = last(args)
-    if obj63(l) and l._stash then
-      local args1 = almost(args)
-      local _o8 = l
-      local k = nil
-      for k in next, _o8 do
-        local v = _o8[k]
-        if not( k == "_stash") then
-          args1[k] = v
+    local _l2 = last(args)
+    if obj63(_l2) and _l2._stash then
+      local _args1 = almost(args)
+      local __o8 = _l2
+      local _k6 = nil
+      for _k6 in next, __o8 do
+        local _v7 = __o8[_k6]
+        if not( _k6 == "_stash") then
+          _args1[_k6] = _v7
         end
       end
-      return(args1)
+      return(_args1)
     else
       return(args)
     end
@@ -317,12 +317,12 @@ function unstash(args)
 end
 function destash33(l, args1)
   if obj63(l) and l._stash then
-    local _o9 = l
-    local k = nil
-    for k in next, _o9 do
-      local v = _o9[k]
-      if not( k == "_stash") then
-        args1[k] = v
+    local __o9 = l
+    local _k7 = nil
+    for _k7 in next, __o9 do
+      local _v8 = __o9[_k7]
+      if not( _k7 == "_stash") then
+        args1[_k7] = _v8
       end
     end
   else
@@ -335,105 +335,105 @@ function search(s, pattern, start)
     _e3 = start + 1
   end
   local _start = _e3
-  local i = string.find(s, pattern, _start, true)
-  return(i and i - 1)
+  local _i16 = string.find(s, pattern, _start, true)
+  return(_i16 and _i16 - 1)
 end
 function split(s, sep)
   if s == "" or sep == "" then
     return({})
   else
-    local l = {}
-    local n = _35(sep)
+    local _l3 = {}
+    local _n12 = _35(sep)
     while true do
-      local i = search(s, sep)
-      if nil63(i) then
+      local _i17 = search(s, sep)
+      if nil63(_i17) then
         break
       else
-        add(l, clip(s, 0, i))
-        s = clip(s, i + n)
+        add(_l3, clip(s, 0, _i17))
+        s = clip(s, _i17 + _n12)
       end
     end
-    add(l, s)
-    return(l)
+    add(_l3, s)
+    return(_l3)
   end
 end
 function cat(...)
-  local xs = unstash({...})
+  local _xs = unstash({...})
   return(reduce(function (a, b)
     return(a .. b)
-  end, xs, ""))
+  end, _xs, ""))
 end
 function _43(...)
-  local xs = unstash({...})
+  local _xs1 = unstash({...})
   return(reduce(function (a, b)
     return(a + b)
-  end, xs, 0))
+  end, _xs1, 0))
 end
 function _45(...)
-  local xs = unstash({...})
+  local _xs2 = unstash({...})
   return(reduce(function (b, a)
     return(a - b)
-  end, reverse(xs), 0))
+  end, reverse(_xs2), 0))
 end
 function _42(...)
-  local xs = unstash({...})
+  local _xs3 = unstash({...})
   return(reduce(function (a, b)
     return(a * b)
-  end, xs, 1))
+  end, _xs3, 1))
 end
 function _47(...)
-  local xs = unstash({...})
+  local _xs4 = unstash({...})
   return(reduce(function (b, a)
     return(a / b)
-  end, reverse(xs), 1))
+  end, reverse(_xs4), 1))
 end
 function _37(...)
-  local xs = unstash({...})
+  local _xs5 = unstash({...})
   return(reduce(function (b, a)
     return(a % b)
-  end, reverse(xs), 0))
+  end, reverse(_xs5), 0))
 end
 local function pairwise(f, xs)
-  local i = 0
-  while i < edge(xs) do
-    local a = xs[i + 1]
-    local b = xs[i + 1 + 1]
-    if not f(a, b) then
+  local _i18 = 0
+  while _i18 < edge(xs) do
+    local _a = xs[_i18 + 1]
+    local _b = xs[_i18 + 1 + 1]
+    if not f(_a, _b) then
       return(false)
     end
-    i = i + 1
+    _i18 = _i18 + 1
   end
   return(true)
 end
 function _60(...)
-  local xs = unstash({...})
+  local _xs6 = unstash({...})
   return(pairwise(function (a, b)
     return(a < b)
-  end, xs))
+  end, _xs6))
 end
 function _62(...)
-  local xs = unstash({...})
+  local _xs7 = unstash({...})
   return(pairwise(function (a, b)
     return(a > b)
-  end, xs))
+  end, _xs7))
 end
 function _61(...)
-  local xs = unstash({...})
+  local _xs8 = unstash({...})
   return(pairwise(function (a, b)
     return(a == b)
-  end, xs))
+  end, _xs8))
 end
 function _6061(...)
-  local xs = unstash({...})
+  local _xs9 = unstash({...})
   return(pairwise(function (a, b)
     return(a <= b)
-  end, xs))
+  end, _xs9))
 end
 function _6261(...)
-  local xs = unstash({...})
+  local _xs10 = unstash({...})
   return(pairwise(function (a, b)
     return(a >= b)
-  end, xs))
+  end, _xs10))
 end
 function number(s)
   return(tonumber(s))
@@ -442,44 +442,44 @@ function number_code63(n)
   return(n > 47 and n < 58)
 end
 function numeric63(s)
-  local n = _35(s)
-  local i = 0
-  while i < n do
-    if not number_code63(code(s, i)) then
+  local _n13 = _35(s)
+  local _i19 = 0
+  while _i19 < _n13 do
+    if not number_code63(code(s, _i19)) then
       return(false)
     end
-    i = i + 1
+    _i19 = _i19 + 1
   end
   return(some63(s))
 end
 function escape(s)
-  local s1 = "\""
-  local i = 0
-  while i < _35(s) do
-    local c = char(s, i)
+  local _s1 = "\""
+  local _i20 = 0
+  while _i20 < _35(s) do
+    local _c = char(s, _i20)
     local _e4
-    if c == "\n" then
+    if _c == "\n" then
       _e4 = "\\n"
     else
       local _e5
-      if c == "\"" then
+      if _c == "\"" then
         _e5 = "\\\""
       else
         local _e6
-        if c == "\\" then
+        if _c == "\\" then
           _e6 = "\\\\"
         else
-          _e6 = c
+          _e6 = _c
         end
         _e5 = _e6
       end
       _e4 = _e5
     end
-    local c1 = _e4
-    s1 = s1 .. c1
-    i = i + 1
+    local _c1 = _e4
+    _s1 = _s1 .. _c1
+    _i20 = _i20 + 1
   end
-  return(s1 .. "\"")
+  return(_s1 .. "\"")
 end
 function str(x, stack)
   if nil63(x) then
@@ -516,32 +516,32 @@ function str(x, stack)
                     if not( type(x) == "table") then
                       return(escape(tostring(x)))
                     else
-                      local s = "("
-                      local sp = ""
-                      local xs = {}
-                      local ks = {}
-                      local l = stack or {}
-                      add(l, x)
-                      local _o10 = x
-                      local k = nil
-                      for k in next, _o10 do
-                        local v = _o10[k]
-                        if number63(k) then
-                          xs[k] = str(v, l)
+                      local _s = "("
+                      local _sp = ""
+                      local _xs11 = {}
+                      local _ks = {}
+                      local _l4 = stack or {}
+                      add(_l4, x)
+                      local __o10 = x
+                      local _k8 = nil
+                      for _k8 in next, __o10 do
+                        local _v9 = __o10[_k8]
+                        if number63(_k8) then
+                          _xs11[_k8] = str(_v9, _l4)
                         else
-                          add(ks, k .. ":")
-                          add(ks, str(v, l))
+                          add(_ks, _k8 .. ":")
+                          add(_ks, str(_v9, _l4))
                         end
                       end
-                      drop(l)
-                      local _o11 = join(xs, ks)
-                      local _i14 = nil
-                      for _i14 in next, _o11 do
-                        local _v1 = _o11[_i14]
-                        s = s .. sp .. _v1
-                        sp = " "
+                      drop(_l4)
+                      local __o11 = join(_xs11, _ks)
+                      local __i22 = nil
+                      for __i22 in next, __o11 do
+                        local _v10 = __o11[__i22]
+                        _s = _s .. _sp .. _v10
+                        _sp = " "
                       end
-                      return(s .. ")")
+                      return(_s .. ")")
                     end
                   end
                 end
@@ -559,37 +559,37 @@ function apply(f, args)
   return(f(values(_args)))
 end
 function call(f, ...)
-  local _r67 = unstash({...})
-  local _f = destash33(f, _r67)
-  local _id = _r67
-  local args = cut(_id, 0)
-  return(apply(_f, args))
+  local __r69 = unstash({...})
+  local _f = destash33(f, __r69)
+  local __id = __r69
+  local _args11 = cut(__id, 0)
+  return(apply(_f, _args11))
 end
 function toplevel63()
   return(one63(environment))
 end
 function setenv(k, ...)
-  local _r69 = unstash({...})
-  local _k = destash33(k, _r69)
-  local _id1 = _r69
-  local _keys = cut(_id1, 0)
-  if string63(_k) then
+  local __r71 = unstash({...})
+  local _k9 = destash33(k, __r71)
+  local __id1 = __r71
+  local _keys = cut(__id1, 0)
+  if string63(_k9) then
     local _e7
     if _keys.toplevel then
       _e7 = hd(environment)
     else
       _e7 = last(environment)
     end
-    local frame = _e7
-    local entry = frame[_k] or {}
-    local _o12 = _keys
-    local _k1 = nil
-    for _k1 in next, _o12 do
-      local v = _o12[_k1]
-      entry[_k1] = v
+    local _frame = _e7
+    local _entry = _frame[_k9] or {}
+    local __o12 = _keys
+    local _k10 = nil
+    for _k10 in next, __o12 do
+      local _v11 = __o12[_k10]
+      _entry[_k10] = _v11
     end
-    frame[_k] = entry
-    return(frame[_k])
+    _frame[_k9] = _entry
+    return(_frame[_k9])
   end
 end
 local math = math
@@ -620,13 +620,13 @@ setenv("quasiquote", {_stash = true, macro = function (form)
   return(quasiexpand(form, 1))
 end})
 setenv("set", {_stash = true, macro = function (...)
-  local args = unstash({...})
-  return(join({"do"}, map(function (_x6)
-    local _id1 = _x6
-    local lh = _id1[1]
-    local rh = _id1[2]
-    return({"%set", lh, rh})
-  end, pair(args))))
+  local _args1 = unstash({...})
+  return(join({"do"}, map(function (_x5)
+    local __id1 = _x5
+    local _lh1 = __id1[1]
+    local _rh1 = __id1[2]
+    return({"%set", _lh1, _rh1})
+  end, pair(_args1))))
 end})
 setenv("at", {_stash = true, macro = function (l, i)
   if target == "lua" and number63(i) then
@@ -646,422 +646,420 @@ setenv("wipe", {_stash = true, macro = function (place)
   end
 end})
 setenv("list", {_stash = true, macro = function (...)
-  local body = unstash({...})
-  local x = unique("x")
-  local l = {}
-  local forms = {}
-  local _o1 = body
-  local k = nil
-  for k in next, _o1 do
-    local v = _o1[k]
-    if number63(k) then
-      l[k] = v
+  local _body1 = unstash({...})
+  local _x24 = unique("x")
+  local _l1 = {}
+  local _forms1 = {}
+  local __o1 = _body1
+  local _k2 = nil
+  for _k2 in next, __o1 do
+    local _v1 = __o1[_k2]
+    if number63(_k2) then
+      _l1[_k2] = _v1
     else
-      add(forms, {"set", {"get", x, {"quote", k}}, v})
+      add(_forms1, {"set", {"get", _x24, {"quote", _k2}}, _v1})
     end
   end
-  if some63(forms) then
-    return(join({"let", x, join({"%array"}, l)}, forms, {x}))
+  if some63(_forms1) then
+    return(join({"let", _x24, join({"%array"}, _l1)}, _forms1, {_x24}))
   else
-    return(join({"%array"}, l))
+    return(join({"%array"}, _l1))
   end
 end})
 setenv("if", {_stash = true, macro = function (...)
-  local branches = unstash({...})
-  return(hd(expand_if(branches)))
+  local _branches1 = unstash({...})
+  return(hd(expand_if(_branches1)))
 end})
 setenv("case", {_stash = true, macro = function (expr, ...)
-  local _r13 = unstash({...})
-  local _expr1 = destash33(expr, _r13)
-  local _id4 = _r13
-  local clauses = cut(_id4, 0)
-  local x = unique("x")
-  local eq = function (_)
-    return({"=", {"quote", _}, x})
+  local __r13 = unstash({...})
+  local _expr1 = destash33(expr, __r13)
+  local __id4 = __r13
+  local _clauses1 = cut(__id4, 0)
+  local _x45 = unique("x")
+  local _eq1 = function (_)
+    return({"=", {"quote", _}, _x45})
   end
-  local cl = function (_x48)
-    local _id5 = _x48
-    local a = _id5[1]
-    local b = _id5[2]
-    if nil63(b) then
-      return({a})
+  local _cl1 = function (_x48)
+    local __id5 = _x48
+    local _a1 = __id5[1]
+    local _b1 = __id5[2]
+    if nil63(_b1) then
+      return({_a1})
     else
-      if string63(a) or number63(a) then
-        return({eq(a), b})
+      if string63(_a1) or number63(_a1) then
+        return({_eq1(_a1), _b1})
       else
-        if one63(a) then
-          return({eq(hd(a)), b})
+        if one63(_a1) then
+          return({_eq1(hd(_a1)), _b1})
         else
-          if _35(a) > 1 then
-            return({join({"or"}, map(eq, a)), b})
+          if _35(_a1) > 1 then
+            return({join({"or"}, map(_eq1, _a1)), _b1})
           end
         end
       end
     end
   end
-  return({"let", x, _expr1, join({"if"}, apply(join, map(cl, pair(clauses))))})
+  return({"let", _x45, _expr1, join({"if"}, apply(join, map(_cl1, pair(_clauses1))))})
 end})
 setenv("when", {_stash = true, macro = function (cond, ...)
-  local _r17 = unstash({...})
-  local _cond1 = destash33(cond, _r17)
-  local _id7 = _r17
-  local body = cut(_id7, 0)
-  return({"if", _cond1, join({"do"}, body)})
+  local __r17 = unstash({...})
+  local _cond1 = destash33(cond, __r17)
+  local __id7 = __r17
+  local _body3 = cut(__id7, 0)
+  return({"if", _cond1, join({"do"}, _body3)})
 end})
 setenv("unless", {_stash = true, macro = function (cond, ...)
-  local _r19 = unstash({...})
-  local _cond3 = destash33(cond, _r19)
-  local _id9 = _r19
-  local body = cut(_id9, 0)
-  return({"if", {"not", _cond3}, join({"do"}, body)})
+  local __r19 = unstash({...})
+  local _cond3 = destash33(cond, __r19)
+  local __id9 = __r19
+  local _body5 = cut(__id9, 0)
+  return({"if", {"not", _cond3}, join({"do"}, _body5)})
 end})
 setenv("obj", {_stash = true, macro = function (...)
-  local body = unstash({...})
+  local _body7 = unstash({...})
   return(join({"%object"}, mapo(function (x)
     return(x)
-  end, body)))
+  end, _body7)))
 end})
 setenv("let", {_stash = true, macro = function (bs, ...)
-  local _r23 = unstash({...})
-  local _bs1 = destash33(bs, _r23)
-  local _id13 = _r23
-  local body = cut(_id13, 0)
-  if atom63(_bs1) then
-    return(join({"let", {_bs1, hd(body)}}, tl(body)))
+  local __r23 = unstash({...})
+  local _bs11 = destash33(bs, __r23)
+  local __id14 = __r23
+  local _body9 = cut(__id14, 0)
+  if atom63(_bs11) then
+    return(join({"let", {_bs11, hd(_body9)}}, tl(_body9)))
   else
-    if none63(_bs1) then
-      return(join({"do"}, body))
+    if none63(_bs11) then
+      return(join({"do"}, _body9))
     else
-      local _id14 = _bs1
-      local lh = _id14[1]
-      local rh = _id14[2]
-      local bs2 = cut(_id14, 2)
-      local _id15 = bind(lh, rh)
-      local id = _id15[1]
-      local val = _id15[2]
-      local bs1 = cut(_id15, 2)
-      local renames = {}
-      if bound63(id) or toplevel63() then
-        local id1 = unique(id)
-        renames = {id, id1}
-        id = id1
-      else
-        setenv(id, {_stash = true, variable = true})
+      local __id15 = _bs11
+      local _lh3 = __id15[1]
+      local _rh3 = __id15[2]
+      local _bs21 = cut(__id15, 2)
+      local __id16 = bind(_lh3, _rh3)
+      local _id17 = __id16[1]
+      local _val1 = __id16[2]
+      local _bs12 = cut(__id16, 2)
+      local _renames1 = {}
+      if not id_literal63(_id17) then
+        local _id121 = unique(_id17)
+        _renames1 = {_id17, _id121}
+        _id17 = _id121
       end
-      return({"do", {"%local", id, val}, {"let-symbol", renames, join({"let", join(bs1, bs2)}, body)}})
+      return({"do", {"%local", _id17, _val1}, {"let-symbol", _renames1, join({"let", join(_bs12, _bs21)}, _body9)}})
     end
   end
 end})
 setenv("with", {_stash = true, macro = function (x, v, ...)
-  local _r25 = unstash({...})
-  local _x98 = destash33(x, _r25)
-  local _v1 = destash33(v, _r25)
-  local _id17 = _r25
-  local body = cut(_id17, 0)
-  return(join({"let", {_x98, _v1}}, body, {_x98}))
+  local __r25 = unstash({...})
+  local _x93 = destash33(x, __r25)
+  local _v3 = destash33(v, __r25)
+  local __id19 = __r25
+  local _body11 = cut(__id19, 0)
+  return(join({"let", {_x93, _v3}}, _body11, {_x93}))
 end})
 setenv("let-when", {_stash = true, macro = function (x, v, ...)
-  local _r27 = unstash({...})
-  local _x110 = destash33(x, _r27)
-  local _v3 = destash33(v, _r27)
-  local _id19 = _r27
-  local body = cut(_id19, 0)
-  local y = unique("y")
-  return({"let", y, _v3, {"when", {"yes", y}, join({"let", {_x110, y}}, body)}})
+  local __r27 = unstash({...})
+  local _x104 = destash33(x, __r27)
+  local _v5 = destash33(v, __r27)
+  local __id21 = __r27
+  local _body13 = cut(__id21, 0)
+  local _y1 = unique("y")
+  return({"let", _y1, _v5, {"when", {"yes", _y1}, join({"let", {_x104, _y1}}, _body13)}})
 end})
 setenv("define-macro", {_stash = true, macro = function (name, args, ...)
-  local _r29 = unstash({...})
-  local _name1 = destash33(name, _r29)
-  local _args1 = destash33(args, _r29)
-  local _id21 = _r29
-  local body = cut(_id21, 0)
-  local _x121 = {"setenv", {"quote", _name1}}
-  _x121.macro = join({"fn", _args1}, body)
-  local form = _x121
-  eval(form)
-  return(form)
+  local __r29 = unstash({...})
+  local _name1 = destash33(name, __r29)
+  local _args3 = destash33(args, __r29)
+  local __id23 = __r29
+  local _body15 = cut(__id23, 0)
+  local __x114 = {"setenv", {"quote", _name1}}
+  __x114.macro = join({"fn", _args3}, _body15)
+  local _form1 = __x114
+  eval(_form1)
+  return(_form1)
 end})
 setenv("define-special", {_stash = true, macro = function (name, args, ...)
-  local _r31 = unstash({...})
-  local _name3 = destash33(name, _r31)
-  local _args3 = destash33(args, _r31)
-  local _id23 = _r31
-  local body = cut(_id23, 0)
-  local _x129 = {"setenv", {"quote", _name3}}
-  _x129.special = join({"fn", _args3}, body)
-  local form = join(_x129, keys(body))
-  eval(form)
-  return(form)
+  local __r31 = unstash({...})
+  local _name3 = destash33(name, __r31)
+  local _args5 = destash33(args, __r31)
+  local __id25 = __r31
+  local _body17 = cut(__id25, 0)
+  local __x121 = {"setenv", {"quote", _name3}}
+  __x121.special = join({"fn", _args5}, _body17)
+  local _form3 = join(__x121, keys(_body17))
+  eval(_form3)
+  return(_form3)
 end})
 setenv("define-symbol", {_stash = true, macro = function (name, expansion)
   setenv(name, {_stash = true, symbol = expansion})
-  local _x135 = {"setenv", {"quote", name}}
-  _x135.symbol = {"quote", expansion}
-  return(_x135)
+  local __x127 = {"setenv", {"quote", name}}
+  __x127.symbol = {"quote", expansion}
+  return(__x127)
 end})
-setenv("define-reader", {_stash = true, macro = function (_x144, ...)
-  local _id26 = _x144
-  local char = _id26[1]
-  local s = _id26[2]
-  local _r35 = unstash({...})
-  local __x144 = destash33(_x144, _r35)
-  local _id27 = _r35
-  local body = cut(_id27, 0)
-  return({"set", {"get", "read-table", char}, join({"fn", {s}}, body)})
+setenv("define-reader", {_stash = true, macro = function (_x135, ...)
+  local __id28 = _x135
+  local _char1 = __id28[1]
+  local _s1 = __id28[2]
+  local __r35 = unstash({...})
+  local __x135 = destash33(_x135, __r35)
+  local __id29 = __r35
+  local _body19 = cut(__id29, 0)
+  return({"set", {"get", "read-table", _char1}, join({"fn", {_s1}}, _body19)})
 end})
 setenv("define", {_stash = true, macro = function (name, x, ...)
-  local _r37 = unstash({...})
-  local _name5 = destash33(name, _r37)
-  local _x155 = destash33(x, _r37)
-  local _id29 = _r37
-  local body = cut(_id29, 0)
+  local __r37 = unstash({...})
+  local _name5 = destash33(name, __r37)
+  local _x145 = destash33(x, __r37)
+  local __id31 = __r37
+  local _body21 = cut(__id31, 0)
   setenv(_name5, {_stash = true, variable = true})
-  if some63(body) then
-    return(join({"%local-function", _name5}, bind42(_x155, body)))
+  if some63(_body21) then
+    return(join({"%local-function", _name5}, bind42(_x145, _body21)))
   else
-    return({"%local", _name5, _x155})
+    return({"%local", _name5, _x145})
   end
 end})
 setenv("define-global", {_stash = true, macro = function (name, x, ...)
-  local _r39 = unstash({...})
-  local _name7 = destash33(name, _r39)
-  local _x163 = destash33(x, _r39)
-  local _id31 = _r39
-  local body = cut(_id31, 0)
+  local __r39 = unstash({...})
+  local _name7 = destash33(name, __r39)
+  local _x152 = destash33(x, __r39)
+  local __id33 = __r39
+  local _body23 = cut(__id33, 0)
   setenv(_name7, {_stash = true, toplevel = true, variable = true})
-  if some63(body) then
-    return(join({"%global-function", _name7}, bind42(_x163, body)))
+  if some63(_body23) then
+    return(join({"%global-function", _name7}, bind42(_x152, _body23)))
   else
-    return({"set", _name7, _x163})
+    return({"set", _name7, _x152})
   end
 end})
 setenv("with-frame", {_stash = true, macro = function (...)
-  local body = unstash({...})
-  local x = unique("x")
-  return({"do", {"add", "environment", {"obj"}}, {"with", x, join({"do"}, body), {"drop", "environment"}}})
+  local _body25 = unstash({...})
+  local _x163 = unique("x")
+  return({"do", {"add", "environment", {"obj"}}, {"with", _x163, join({"do"}, _body25), {"drop", "environment"}}})
 end})
-setenv("with-bindings", {_stash = true, macro = function (_x185, ...)
-  local _id34 = _x185
-  local names = _id34[1]
-  local _r41 = unstash({...})
-  local __x185 = destash33(_x185, _r41)
-  local _id35 = _r41
-  local body = cut(_id35, 0)
-  local x = unique("x")
-  local _x189 = {"setenv", x}
-  _x189.variable = true
-  return(join({"with-frame", {"each", x, names, _x189}}, body))
+setenv("with-bindings", {_stash = true, macro = function (_x175, ...)
+  local __id36 = _x175
+  local _names1 = __id36[1]
+  local __r41 = unstash({...})
+  local __x175 = destash33(_x175, __r41)
+  local __id37 = __r41
+  local _body27 = cut(__id37, 0)
+  local _x177 = unique("x")
+  local __x180 = {"setenv", _x177}
+  __x180.variable = true
+  return(join({"with-frame", {"each", _x177, _names1, __x180}}, _body27))
 end})
 setenv("let-macro", {_stash = true, macro = function (definitions, ...)
-  local _r44 = unstash({...})
-  local _definitions1 = destash33(definitions, _r44)
-  local _id37 = _r44
-  local body = cut(_id37, 0)
+  local __r44 = unstash({...})
+  local _definitions1 = destash33(definitions, __r44)
+  local __id39 = __r44
+  local _body29 = cut(__id39, 0)
   add(environment, {})
   map(function (m)
     return(macroexpand(join({"define-macro"}, m)))
   end, _definitions1)
-  local _x195 = join({"do"}, macroexpand(body))
+  local __x185 = join({"do"}, macroexpand(_body29))
   drop(environment)
-  return(_x195)
+  return(__x185)
 end})
 setenv("let-symbol", {_stash = true, macro = function (expansions, ...)
-  local _r48 = unstash({...})
-  local _expansions1 = destash33(expansions, _r48)
-  local _id40 = _r48
-  local body = cut(_id40, 0)
+  local __r48 = unstash({...})
+  local _expansions1 = destash33(expansions, __r48)
+  local __id42 = __r48
+  local _body31 = cut(__id42, 0)
   add(environment, {})
-  map(function (_x205)
-    local _id41 = _x205
-    local name = _id41[1]
-    local exp = _id41[2]
-    return(macroexpand({"define-symbol", name, exp}))
+  map(function (_x194)
+    local __id43 = _x194
+    local _name9 = __id43[1]
+    local _exp1 = __id43[2]
+    return(macroexpand({"define-symbol", _name9, _exp1}))
   end, pair(_expansions1))
-  local _x204 = join({"do"}, macroexpand(body))
+  local __x193 = join({"do"}, macroexpand(_body31))
   drop(environment)
-  return(_x204)
+  return(__x193)
 end})
 setenv("let-unique", {_stash = true, macro = function (names, ...)
-  local _r52 = unstash({...})
-  local _names1 = destash33(names, _r52)
-  local _id43 = _r52
-  local body = cut(_id43, 0)
-  local bs = map(function (n)
+  local __r52 = unstash({...})
+  local _names3 = destash33(names, __r52)
+  local __id45 = __r52
+  local _body33 = cut(__id45, 0)
+  local _bs3 = map(function (n)
     return({n, {"unique", {"quote", n}}})
-  end, _names1)
-  return(join({"let", apply(join, bs)}, body))
+  end, _names3)
+  return(join({"let", apply(join, _bs3)}, _body33))
 end})
 setenv("fn", {_stash = true, macro = function (args, ...)
-  local _r55 = unstash({...})
-  local _args5 = destash33(args, _r55)
-  local _id45 = _r55
-  local body = cut(_id45, 0)
-  return(join({"%function"}, bind42(_args5, body)))
+  local __r55 = unstash({...})
+  local _args7 = destash33(args, __r55)
+  local __id47 = __r55
+  local _body35 = cut(__id47, 0)
+  return(join({"%function"}, bind42(_args7, _body35)))
 end})
 setenv("apply", {_stash = true, macro = function (f, ...)
-  local _r57 = unstash({...})
-  local _f1 = destash33(f, _r57)
-  local _id47 = _r57
-  local args = cut(_id47, 0)
-  if _35(args) > 1 then
-    return({{"do", "apply"}, _f1, {"join", join({"list"}, almost(args)), last(args)}})
+  local __r57 = unstash({...})
+  local _f1 = destash33(f, __r57)
+  local __id49 = __r57
+  local _args9 = cut(__id49, 0)
+  if _35(_args9) > 1 then
+    return({{"do", "apply"}, _f1, {"join", join({"list"}, almost(_args9)), last(_args9)}})
   else
-    return(join({{"do", "apply"}, _f1}, args))
+    return(join({{"do", "apply"}, _f1}, _args9))
   end
 end})
 setenv("guard", {_stash = true, macro = function (expr)
   if target == "js" then
     return({{"fn", join(), {"%try", {"list", true, expr}}}})
   else
-    local x = unique("x")
-    local msg = unique("msg")
-    local trace = unique("trace")
-    local _x287 = {"obj"}
-    _x287.message = msg
-    _x287.stack = trace
-    return({"let", {x, "nil", msg, "nil", trace, "nil"}, {"if", {"xpcall", {"fn", join(), {"set", x, expr}}, {"fn", {"m"}, {"set", trace, {{"get", "debug", {"quote", "traceback"}}}, msg, {"if", {"string?", "m"}, {"clip", "m", {"+", {"search", "m", "\": \""}, 2}}, {"nil?", "m"}, "\"\"", {"str", "m"}}}}}, {"list", true, x}, {"list", false, _x287}}})
+    local _x253 = unique("x")
+    local _msg1 = unique("msg")
+    local _trace1 = unique("trace")
+    local __x275 = {"obj"}
+    __x275.message = _msg1
+    __x275.stack = _trace1
+    return({"let", {_x253, "nil", _msg1, "nil", _trace1, "nil"}, {"if", {"xpcall", {"fn", join(), {"set", _x253, expr}}, {"fn", {"m"}, {"set", _trace1, {{"get", "debug", {"quote", "traceback"}}}, _msg1, {"if", {"string?", "m"}, {"clip", "m", {"+", {"search", "m", "\": \""}, 2}}, {"nil?", "m"}, "\"\"", {"str", "m"}}}}}, {"list", true, _x253}, {"list", false, __x275}}})
   end
 end})
 setenv("each", {_stash = true, macro = function (x, t, ...)
-  local _r61 = unstash({...})
-  local _x304 = destash33(x, _r61)
-  local _t1 = destash33(t, _r61)
-  local _id50 = _r61
-  local body = cut(_id50, 0)
-  local o = unique("o")
-  local n = unique("n")
-  local i = unique("i")
-  local _e5
-  if atom63(_x304) then
-    _e5 = {i, _x304}
+  local __r61 = unstash({...})
+  local _x291 = destash33(x, __r61)
+  local _t1 = destash33(t, __r61)
+  local __id52 = __r61
+  local _body37 = cut(__id52, 0)
+  local _o3 = unique("o")
+  local _n3 = unique("n")
+  local _i3 = unique("i")
+  local _e8
+  if atom63(_x291) then
+    _e8 = {_i3, _x291}
   else
-    local _e6
-    if _35(_x304) > 1 then
-      _e6 = _x304
+    local _e9
+    if _35(_x291) > 1 then
+      _e9 = _x291
     else
-      _e6 = {i, hd(_x304)}
+      _e9 = {_i3, hd(_x291)}
     end
-    _e5 = _e6
+    _e8 = _e9
   end
-  local _id51 = _e5
-  local k = _id51[1]
-  local v = _id51[2]
-  local _e7
+  local __id53 = _e8
+  local _k4 = __id53[1]
+  local _v7 = __id53[2]
+  local _e10
   if target == "lua" then
-    _e7 = body
+    _e10 = _body37
   else
-    _e7 = {join({"let", k, {"if", {"numeric?", k}, {"parseInt", k}, k}}, body)}
+    _e10 = {join({"let", _k4, {"if", {"numeric?", _k4}, {"parseInt", _k4}, _k4}}, _body37)}
   end
-  return({"let", {o, _t1, k, "nil"}, {"%for", o, k, join({"let", {v, {"get", o, k}}}, _e7)}})
+  return({"let", {_o3, _t1, _k4, "nil"}, {"%for", _o3, _k4, join({"let", {_v7, {"get", _o3, _k4}}}, _e10)}})
 end})
 setenv("for", {_stash = true, macro = function (i, to, ...)
-  local _r63 = unstash({...})
-  local _i3 = destash33(i, _r63)
-  local _to1 = destash33(to, _r63)
-  local _id53 = _r63
-  local body = cut(_id53, 0)
-  return({"let", _i3, 0, join({"while", {"<", _i3, _to1}}, body, {{"inc", _i3}})})
+  local __r63 = unstash({...})
+  local _i5 = destash33(i, __r63)
+  local _to1 = destash33(to, __r63)
+  local __id55 = __r63
+  local _body39 = cut(__id55, 0)
+  return({"let", _i5, 0, join({"while", {"<", _i5, _to1}}, _body39, {{"inc", _i5}})})
 end})
 setenv("step", {_stash = true, macro = function (v, t, ...)
-  local _r65 = unstash({...})
-  local _v5 = destash33(v, _r65)
-  local _t3 = destash33(t, _r65)
-  local _id55 = _r65
-  local body = cut(_id55, 0)
-  local x = unique("x")
-  local i = unique("i")
-  return({"let", {x, _t3}, {"for", i, {"#", x}, join({"let", {_v5, {"at", x, i}}}, body)}})
+  local __r65 = unstash({...})
+  local _v9 = destash33(v, __r65)
+  local _t3 = destash33(t, __r65)
+  local __id57 = __r65
+  local _body41 = cut(__id57, 0)
+  local _x325 = unique("x")
+  local _i7 = unique("i")
+  return({"let", {_x325, _t3}, {"for", _i7, {"#", _x325}, join({"let", {_v9, {"at", _x325, _i7}}}, _body41)}})
 end})
 setenv("set-of", {_stash = true, macro = function (...)
-  local xs = unstash({...})
-  local l = {}
-  local _o3 = xs
-  local _i5 = nil
-  for _i5 in next, _o3 do
-    local x = _o3[_i5]
-    l[x] = true
+  local _xs1 = unstash({...})
+  local _l3 = {}
+  local __o5 = _xs1
+  local __i9 = nil
+  for __i9 in next, __o5 do
+    local _x336 = __o5[__i9]
+    _l3[_x336] = true
   end
-  return(join({"obj"}, l))
+  return(join({"obj"}, _l3))
 end})
 setenv("language", {_stash = true, macro = function ()
   return({"quote", target})
 end})
 setenv("target", {_stash = true, macro = function (...)
-  local clauses = unstash({...})
-  return(clauses[target])
+  local _clauses3 = unstash({...})
+  return(_clauses3[target])
 end})
 setenv("join!", {_stash = true, macro = function (a, ...)
-  local _r69 = unstash({...})
-  local _a1 = destash33(a, _r69)
-  local _id57 = _r69
-  local bs = cut(_id57, 0)
-  return({"set", _a1, join({"join", _a1}, bs)})
+  local __r69 = unstash({...})
+  local _a3 = destash33(a, __r69)
+  local __id59 = __r69
+  local _bs5 = cut(__id59, 0)
+  return({"set", _a3, join({"join", _a3}, _bs5)})
 end})
 setenv("cat!", {_stash = true, macro = function (a, ...)
-  local _r71 = unstash({...})
-  local _a3 = destash33(a, _r71)
-  local _id59 = _r71
-  local bs = cut(_id59, 0)
-  return({"set", _a3, join({"cat", _a3}, bs)})
+  local __r71 = unstash({...})
+  local _a5 = destash33(a, __r71)
+  local __id61 = __r71
+  local _bs7 = cut(__id61, 0)
+  return({"set", _a5, join({"cat", _a5}, _bs7)})
 end})
 setenv("inc", {_stash = true, macro = function (n, by)
-  local _e8
+  local _e11
   if nil63(by) then
-    _e8 = 1
+    _e11 = 1
   else
-    _e8 = by
+    _e11 = by
   end
-  return({"set", n, {"+", n, _e8}})
+  return({"set", n, {"+", n, _e11}})
 end})
 setenv("dec", {_stash = true, macro = function (n, by)
-  local _e9
+  local _e12
   if nil63(by) then
-    _e9 = 1
+    _e12 = 1
   else
-    _e9 = by
+    _e12 = by
   end
-  return({"set", n, {"-", n, _e9}})
+  return({"set", n, {"-", n, _e12}})
 end})
 setenv("with-indent", {_stash = true, macro = function (form)
-  local x = unique("x")
-  return({"do", {"inc", "indent-level"}, {"with", x, form, {"dec", "indent-level"}}})
+  local _x364 = unique("x")
+  return({"do", {"inc", "indent-level"}, {"with", _x364, form, {"dec", "indent-level"}}})
 end})
 setenv("export", {_stash = true, macro = function (...)
-  local names = unstash({...})
+  local _names5 = unstash({...})
   if target == "js" then
     return(join({"do"}, map(function (k)
       return({"set", {"get", "exports", {"quote", k}}, k})
-    end, names)))
+    end, _names5)))
   else
-    local x = {}
-    local _o5 = names
-    local _i7 = nil
-    for _i7 in next, _o5 do
-      local k = _o5[_i7]
-      x[k] = k
+    local _x381 = {}
+    local __o7 = _names5
+    local __i11 = nil
+    for __i11 in next, __o7 do
+      local _k6 = __o7[__i11]
+      _x381[_k6] = _k6
     end
     return({"return", join({"%object"}, mapo(function (x)
       return(x)
-    end, x))})
+    end, _x381))})
   end
 end})
 setenv("when-compiling", {_stash = true, macro = function (...)
-  local body = unstash({...})
-  return(eval(join({"do"}, body)))
+  local _body43 = unstash({...})
+  return(eval(join({"do"}, _body43)))
 end})
 local reader = require("reader")
 local compiler = require("compiler")
 local system = require("system")
 local function eval_print(form)
-  local _x = nil
-  local _msg = nil
-  local _trace = nil
+  local __x = nil
+  local __msg = nil
+  local __trace = nil
   local _e
   if xpcall(function ()
-    _x = compiler.eval(form)
-    return(_x)
+    __x = compiler.eval(form)
+    return(__x)
   end, function (m)
-    _trace = debug.traceback()
+    __trace = debug.traceback()
     local _e1
     if string63(m) then
       _e1 = clip(m, search(m, ": ") + 2)
@@ -1074,21 +1072,21 @@ local function eval_print(form)
       end
       _e1 = _e2
     end
-    _msg = _e1
-    return(_msg)
+    __msg = _e1
+    return(__msg)
   end) then
-    _e = {true, _x}
+    _e = {true, __x}
   else
-    _e = {false, {stack = _trace, message = _msg}}
+    _e = {false, {message = __msg, stack = __trace}}
   end
-  local _id = _e
-  local ok = _id[1]
-  local v = _id[2]
-  if not ok then
-    return(print("error: " .. v.message .. "\n" .. v.stack))
+  local __id = _e
+  local _ok = __id[1]
+  local _v = __id[2]
+  if not _ok then
+    return(print("error: " .. _v.message .. "\n" .. _v.stack))
   else
-    if is63(v) then
-      return(print(str(v)))
+    if is63(_v) then
+      return(print(str(_v)))
     end
   end
 end
@@ -1096,39 +1094,39 @@ local function rep(s)
   return(eval_print(reader["read-string"](s)))
 end
 local function repl()
-  local buf = ""
+  local _buf = ""
   local function rep1(s)
-    buf = buf .. s
-    local more = {}
-    local form = reader["read-string"](buf, more)
-    if not( form == more) then
-      eval_print(form)
-      buf = ""
+    _buf = _buf .. s
+    local _more = {}
+    local _form = reader["read-string"](_buf, _more)
+    if not( _form == _more) then
+      eval_print(_form)
+      _buf = ""
       return(system.write("> "))
     end
   end
   system.write("> ")
   while true do
-    local s = io.read()
-    if s then
-      rep1(s .. "\n")
+    local _s = io.read()
+    if _s then
+      rep1(_s .. "\n")
     else
       break
     end
   end
 end
 function compile_file(path)
-  local s = reader.stream(system["read-file"](path))
-  local body = reader["read-all"](s)
-  local form = compiler.expand(join({"do"}, body))
-  return(compiler.compile(form, {_stash = true, stmt = true}))
+  local _s1 = reader.stream(system["read-file"](path))
+  local _body = reader["read-all"](_s1)
+  local _form1 = compiler.expand(join({"do"}, _body))
+  return(compiler.compile(_form1, {_stash = true, stmt = true}))
 end
 function load(path)
-  local previous = target
+  local _previous = target
   target = "lua"
-  local code = compile_file(path)
-  target = previous
-  return(compiler.run(code))
+  local _code = compile_file(path)
+  target = _previous
+  return(compiler.run(_code))
 end
 local function run_file(path)
   return(compiler.run(system["read-file"](path)))
@@ -1148,73 +1146,73 @@ local function usage()
   return(print(" -e <expr>\tExpression to evaluate"))
 end
 local function main()
-  local arg = hd(system.argv)
-  if arg and script_file63(arg) then
-    return(load(arg))
+  local _arg = hd(system.argv)
+  if _arg and script_file63(_arg) then
+    return(load(_arg))
   else
-    if arg == "-h" or arg == "--help" then
+    if _arg == "-h" or _arg == "--help" then
       return(usage())
     else
-      local pre = {}
-      local input = nil
-      local output = nil
-      local target1 = nil
-      local expr = nil
-      local argv = system.argv
-      local i = 0
-      while i < _35(argv) do
-        local a = argv[i + 1]
-        if a == "-c" or a == "-o" or a == "-t" or a == "-e" then
-          if i == edge(argv) then
-            print("missing argument for " .. a)
+      local _pre = {}
+      local _input = nil
+      local _output = nil
+      local _target1 = nil
+      local _expr = nil
+      local _argv = system.argv
+      local _i = 0
+      while _i < _35(_argv) do
+        local _a = _argv[_i + 1]
+        if _a == "-c" or _a == "-o" or _a == "-t" or _a == "-e" then
+          if _i == edge(_argv) then
+            print("missing argument for " .. _a)
           else
-            i = i + 1
-            local val = argv[i + 1]
-            if a == "-c" then
-              input = val
+            _i = _i + 1
+            local _val = _argv[_i + 1]
+            if _a == "-c" then
+              _input = _val
             else
-              if a == "-o" then
-                output = val
+              if _a == "-o" then
+                _output = _val
               else
-                if a == "-t" then
-                  target1 = val
+                if _a == "-t" then
+                  _target1 = _val
                 else
-                  if a == "-e" then
-                    expr = val
+                  if _a == "-e" then
+                    _expr = _val
                   end
                 end
               end
             end
           end
         else
-          if not( "-" == char(a, 0)) then
-            add(pre, a)
+          if not( "-" == char(_a, 0)) then
+            add(_pre, _a)
           end
         end
-        i = i + 1
-      end
-      local _x4 = pre
-      local _i = 0
-      while _i < _35(_x4) do
-        local file = _x4[_i + 1]
-        run_file(file)
         _i = _i + 1
       end
-      if nil63(input) then
-        if expr then
-          return(rep(expr))
+      local __x4 = _pre
+      local __i1 = 0
+      while __i1 < _35(__x4) do
+        local _file = __x4[__i1 + 1]
+        run_file(_file)
+        __i1 = __i1 + 1
+      end
+      if nil63(_input) then
+        if _expr then
+          return(rep(_expr))
         else
           return(repl())
         end
       else
-        if target1 then
-          target = target1
+        if _target1 then
+          target = _target1
         end
-        local code = compile_file(input)
-        if nil63(output) or output == "-" then
-          return(print(code))
+        local _code1 = compile_file(_input)
+        if nil63(_output) or _output == "-" then
+          return(print(_code1))
         else
-          return(system["write-file"](output, code))
+          return(system["write-file"](_output, _code1))
         end
       end
     end

--- a/bin/reader.js
+++ b/bin/reader.js
@@ -1,36 +1,36 @@
-var delimiters = {")": true, "(": true, "\n": true, ";": true};
-var whitespace = {"\t": true, "\n": true, " ": true};
+var delimiters = {"(": true, ")": true, ";": true, "\n": true};
+var whitespace = {" ": true, "\t": true, "\n": true};
 var stream = function (str, more) {
-  return({pos: 0, more: more, string: str, len: _35(str)});
+  return({pos: 0, string: str, len: _35(str), more: more});
 };
 var peek_char = function (s) {
-  var _id = s;
-  var pos = _id.pos;
-  var string = _id.string;
-  var len = _id.len;
-  if (pos < len) {
-    return(char(string, pos));
+  var __id = s;
+  var _pos = __id.pos;
+  var _len = __id.len;
+  var _string = __id.string;
+  if (_pos < _len) {
+    return(char(_string, _pos));
   }
 };
 var read_char = function (s) {
-  var c = peek_char(s);
-  if (c) {
+  var _c = peek_char(s);
+  if (_c) {
     s.pos = s.pos + 1;
-    return(c);
+    return(_c);
   }
 };
 var skip_non_code = function (s) {
   while (true) {
-    var c = peek_char(s);
-    if (nil63(c)) {
+    var _c1 = peek_char(s);
+    if (nil63(_c1)) {
       break;
     } else {
-      if (whitespace[c]) {
+      if (whitespace[_c1]) {
         read_char(s);
       } else {
-        if (c === ";") {
-          while (c && !( c === "\n")) {
-            c = read_char(s);
+        if (_c1 === ";") {
+          while (_c1 && !( _c1 === "\n")) {
+            _c1 = read_char(s);
           }
           skip_non_code(s);
         } else {
@@ -44,28 +44,28 @@ var read_table = {};
 var eof = {};
 var read = function (s) {
   skip_non_code(s);
-  var c = peek_char(s);
-  if (is63(c)) {
-    return((read_table[c] || read_table[""])(s));
+  var _c2 = peek_char(s);
+  if (is63(_c2)) {
+    return((read_table[_c2] || read_table[""])(s));
   } else {
     return(eof);
   }
 };
 var read_all = function (s) {
-  var l = [];
+  var _l = [];
   while (true) {
-    var form = read(s);
-    if (form === eof) {
+    var _form = read(s);
+    if (_form === eof) {
       break;
     }
-    add(l, form);
+    add(_l, _form);
   }
-  return(l);
+  return(_l);
 };
 read_string = function (str, more) {
-  var x = read(stream(str, more));
-  if (!( x === eof)) {
-    return(x);
+  var _x = read(stream(str, more));
+  if (!( _x === eof)) {
+    return(_x);
   }
 };
 var key63 = function (atom) {
@@ -75,25 +75,25 @@ var flag63 = function (atom) {
   return(string63(atom) && _35(atom) > 1 && char(atom, 0) === ":");
 };
 var expected = function (s, c) {
-  var _id1 = s;
-  var pos = _id1.pos;
-  var more = _id1.more;
-  var _id2 = more;
+  var __id1 = s;
+  var _more = __id1.more;
+  var _pos1 = __id1.pos;
+  var _id2 = _more;
   var _e;
   if (_id2) {
     _e = _id2;
   } else {
-    throw new Error("Expected " + c + " at " + pos);
+    throw new Error("Expected " + c + " at " + _pos1);
     _e = undefined;
   }
   return(_e);
 };
 var wrap = function (s, x) {
-  var y = read(s);
-  if (y === s.more) {
-    return(y);
+  var _y = read(s);
+  if (_y === s.more) {
+    return(_y);
   } else {
-    return([x, y]);
+    return([x, _y]);
   }
 };
 var maybe_number = function (str) {
@@ -109,54 +109,54 @@ var valid_access63 = function (str) {
 };
 var parse_access = function (str) {
   return(reduce(function (a, b) {
-    var n = number(a);
-    if (is63(n)) {
-      return(["at", b, n]);
+    var _n = number(a);
+    if (is63(_n)) {
+      return(["at", b, _n]);
     } else {
       return(["get", b, ["quote", a]]);
     }
   }, reverse(split(str, "."))));
 };
 read_table[""] = function (s) {
-  var str = "";
-  var dot63 = false;
+  var _str = "";
+  var _dot63 = false;
   while (true) {
-    var c = peek_char(s);
-    if (c && (! whitespace[c] && ! delimiters[c])) {
-      if (c === ".") {
-        dot63 = true;
+    var _c3 = peek_char(s);
+    if (_c3 && (! whitespace[_c3] && ! delimiters[_c3])) {
+      if (_c3 === ".") {
+        _dot63 = true;
       }
-      str = str + read_char(s);
+      _str = _str + read_char(s);
     } else {
       break;
     }
   }
-  if (str === "true") {
+  if (_str === "true") {
     return(true);
   } else {
-    if (str === "false") {
+    if (_str === "false") {
       return(false);
     } else {
-      if (str === "nan") {
+      if (_str === "nan") {
         return(nan);
       } else {
-        if (str === "-nan") {
+        if (_str === "-nan") {
           return(nan);
         } else {
-          if (str === "inf") {
+          if (_str === "inf") {
             return(inf);
           } else {
-            if (str === "-inf") {
+            if (_str === "-inf") {
               return(-inf);
             } else {
-              var n = maybe_number(str);
-              if (real63(n)) {
-                return(n);
+              var _n1 = maybe_number(_str);
+              if (real63(_n1)) {
+                return(_n1);
               } else {
-                if (dot63 && valid_access63(str)) {
-                  return(parse_access(str));
+                if (_dot63 && valid_access63(_str)) {
+                  return(parse_access(_str));
                 } else {
-                  return(str);
+                  return(_str);
                 }
               }
             }
@@ -168,76 +168,76 @@ read_table[""] = function (s) {
 };
 read_table["("] = function (s) {
   read_char(s);
-  var r = undefined;
-  var l = [];
-  while (nil63(r)) {
+  var _r18 = undefined;
+  var _l1 = [];
+  while (nil63(_r18)) {
     skip_non_code(s);
-    var c = peek_char(s);
-    if (c === ")") {
+    var _c4 = peek_char(s);
+    if (_c4 === ")") {
       read_char(s);
-      r = l;
+      _r18 = _l1;
     } else {
-      if (nil63(c)) {
-        r = expected(s, ")");
+      if (nil63(_c4)) {
+        _r18 = expected(s, ")");
       } else {
-        var x = read(s);
-        if (key63(x)) {
-          var k = clip(x, 0, edge(x));
-          var v = read(s);
-          l[k] = v;
+        var _x5 = read(s);
+        if (key63(_x5)) {
+          var _k = clip(_x5, 0, edge(_x5));
+          var _v = read(s);
+          _l1[_k] = _v;
         } else {
-          if (flag63(x)) {
-            l[clip(x, 1)] = true;
+          if (flag63(_x5)) {
+            _l1[clip(_x5, 1)] = true;
           } else {
-            add(l, x);
+            add(_l1, _x5);
           }
         }
       }
     }
   }
-  return(r);
+  return(_r18);
 };
 read_table[")"] = function (s) {
   throw new Error("Unexpected ) at " + s.pos);
 };
 read_table["\""] = function (s) {
   read_char(s);
-  var r = undefined;
-  var str = "\"";
-  while (nil63(r)) {
-    var c = peek_char(s);
-    if (c === "\"") {
-      r = str + read_char(s);
+  var _r21 = undefined;
+  var _str1 = "\"";
+  while (nil63(_r21)) {
+    var _c5 = peek_char(s);
+    if (_c5 === "\"") {
+      _r21 = _str1 + read_char(s);
     } else {
-      if (nil63(c)) {
-        r = expected(s, "\"");
+      if (nil63(_c5)) {
+        _r21 = expected(s, "\"");
       } else {
-        if (c === "\\") {
-          str = str + read_char(s);
+        if (_c5 === "\\") {
+          _str1 = _str1 + read_char(s);
         }
-        str = str + read_char(s);
+        _str1 = _str1 + read_char(s);
       }
     }
   }
-  return(r);
+  return(_r21);
 };
 read_table["|"] = function (s) {
   read_char(s);
-  var r = undefined;
-  var str = "|";
-  while (nil63(r)) {
-    var c = peek_char(s);
-    if (c === "|") {
-      r = str + read_char(s);
+  var _r23 = undefined;
+  var _str2 = "|";
+  while (nil63(_r23)) {
+    var _c6 = peek_char(s);
+    if (_c6 === "|") {
+      _r23 = _str2 + read_char(s);
     } else {
-      if (nil63(c)) {
-        r = expected(s, "|");
+      if (nil63(_c6)) {
+        _r23 = expected(s, "|");
       } else {
-        str = str + read_char(s);
+        _str2 = _str2 + read_char(s);
       }
     }
   }
-  return(r);
+  return(_r23);
 };
 read_table["'"] = function (s) {
   read_char(s);

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -1,36 +1,36 @@
 local delimiters = {["("] = true, [")"] = true, [";"] = true, ["\n"] = true}
 local whitespace = {[" "] = true, ["\t"] = true, ["\n"] = true}
 local function stream(str, more)
-  return({more = more, len = _35(str), string = str, pos = 0})
+  return({pos = 0, string = str, len = _35(str), more = more})
 end
 local function peek_char(s)
-  local _id = s
-  local len = _id.len
-  local string = _id.string
-  local pos = _id.pos
-  if pos < len then
-    return(char(string, pos))
+  local __id = s
+  local _pos = __id.pos
+  local _len = __id.len
+  local _string = __id.string
+  if _pos < _len then
+    return(char(_string, _pos))
   end
 end
 local function read_char(s)
-  local c = peek_char(s)
-  if c then
+  local _c = peek_char(s)
+  if _c then
     s.pos = s.pos + 1
-    return(c)
+    return(_c)
   end
 end
 local function skip_non_code(s)
   while true do
-    local c = peek_char(s)
-    if nil63(c) then
+    local _c1 = peek_char(s)
+    if nil63(_c1) then
       break
     else
-      if whitespace[c] then
+      if whitespace[_c1] then
         read_char(s)
       else
-        if c == ";" then
-          while c and not( c == "\n") do
-            c = read_char(s)
+        if _c1 == ";" then
+          while _c1 and not( _c1 == "\n") do
+            _c1 = read_char(s)
           end
           skip_non_code(s)
         else
@@ -44,28 +44,28 @@ local read_table = {}
 local eof = {}
 local function read(s)
   skip_non_code(s)
-  local c = peek_char(s)
-  if is63(c) then
-    return((read_table[c] or read_table[""])(s))
+  local _c2 = peek_char(s)
+  if is63(_c2) then
+    return((read_table[_c2] or read_table[""])(s))
   else
     return(eof)
   end
 end
 local function read_all(s)
-  local l = {}
+  local _l = {}
   while true do
-    local form = read(s)
-    if form == eof then
+    local _form = read(s)
+    if _form == eof then
       break
     end
-    add(l, form)
+    add(_l, _form)
   end
-  return(l)
+  return(_l)
 end
 function read_string(str, more)
-  local x = read(stream(str, more))
-  if not( x == eof) then
-    return(x)
+  local _x = read(stream(str, more))
+  if not( _x == eof) then
+    return(_x)
   end
 end
 local function key63(atom)
@@ -75,25 +75,25 @@ local function flag63(atom)
   return(string63(atom) and _35(atom) > 1 and char(atom, 0) == ":")
 end
 local function expected(s, c)
-  local _id1 = s
-  local pos = _id1.pos
-  local more = _id1.more
-  local _id2 = more
+  local __id1 = s
+  local _more = __id1.more
+  local _pos1 = __id1.pos
+  local _id2 = _more
   local _e
   if _id2 then
     _e = _id2
   else
-    error("Expected " .. c .. " at " .. pos)
+    error("Expected " .. c .. " at " .. _pos1)
     _e = nil
   end
   return(_e)
 end
 local function wrap(s, x)
-  local y = read(s)
-  if y == s.more then
-    return(y)
+  local _y = read(s)
+  if _y == s.more then
+    return(_y)
   else
-    return({x, y})
+    return({x, _y})
   end
 end
 local function maybe_number(str)
@@ -109,54 +109,54 @@ local function valid_access63(str)
 end
 local function parse_access(str)
   return(reduce(function (a, b)
-    local n = number(a)
-    if is63(n) then
-      return({"at", b, n})
+    local _n = number(a)
+    if is63(_n) then
+      return({"at", b, _n})
     else
       return({"get", b, {"quote", a}})
     end
   end, reverse(split(str, "."))))
 end
 read_table[""] = function (s)
-  local str = ""
-  local dot63 = false
+  local _str = ""
+  local _dot63 = false
   while true do
-    local c = peek_char(s)
-    if c and (not whitespace[c] and not delimiters[c]) then
-      if c == "." then
-        dot63 = true
+    local _c3 = peek_char(s)
+    if _c3 and (not whitespace[_c3] and not delimiters[_c3]) then
+      if _c3 == "." then
+        _dot63 = true
       end
-      str = str .. read_char(s)
+      _str = _str .. read_char(s)
     else
       break
     end
   end
-  if str == "true" then
+  if _str == "true" then
     return(true)
   else
-    if str == "false" then
+    if _str == "false" then
       return(false)
     else
-      if str == "nan" then
+      if _str == "nan" then
         return(nan)
       else
-        if str == "-nan" then
+        if _str == "-nan" then
           return(nan)
         else
-          if str == "inf" then
+          if _str == "inf" then
             return(inf)
           else
-            if str == "-inf" then
+            if _str == "-inf" then
               return(-inf)
             else
-              local n = maybe_number(str)
-              if real63(n) then
-                return(n)
+              local _n1 = maybe_number(_str)
+              if real63(_n1) then
+                return(_n1)
               else
-                if dot63 and valid_access63(str) then
-                  return(parse_access(str))
+                if _dot63 and valid_access63(_str) then
+                  return(parse_access(_str))
                 else
-                  return(str)
+                  return(_str)
                 end
               end
             end
@@ -168,76 +168,76 @@ read_table[""] = function (s)
 end
 read_table["("] = function (s)
   read_char(s)
-  local r = nil
-  local l = {}
-  while nil63(r) do
+  local _r18 = nil
+  local _l1 = {}
+  while nil63(_r18) do
     skip_non_code(s)
-    local c = peek_char(s)
-    if c == ")" then
+    local _c4 = peek_char(s)
+    if _c4 == ")" then
       read_char(s)
-      r = l
+      _r18 = _l1
     else
-      if nil63(c) then
-        r = expected(s, ")")
+      if nil63(_c4) then
+        _r18 = expected(s, ")")
       else
-        local x = read(s)
-        if key63(x) then
-          local k = clip(x, 0, edge(x))
-          local v = read(s)
-          l[k] = v
+        local _x5 = read(s)
+        if key63(_x5) then
+          local _k = clip(_x5, 0, edge(_x5))
+          local _v = read(s)
+          _l1[_k] = _v
         else
-          if flag63(x) then
-            l[clip(x, 1)] = true
+          if flag63(_x5) then
+            _l1[clip(_x5, 1)] = true
           else
-            add(l, x)
+            add(_l1, _x5)
           end
         end
       end
     end
   end
-  return(r)
+  return(_r18)
 end
 read_table[")"] = function (s)
   error("Unexpected ) at " .. s.pos)
 end
 read_table["\""] = function (s)
   read_char(s)
-  local r = nil
-  local str = "\""
-  while nil63(r) do
-    local c = peek_char(s)
-    if c == "\"" then
-      r = str .. read_char(s)
+  local _r21 = nil
+  local _str1 = "\""
+  while nil63(_r21) do
+    local _c5 = peek_char(s)
+    if _c5 == "\"" then
+      _r21 = _str1 .. read_char(s)
     else
-      if nil63(c) then
-        r = expected(s, "\"")
+      if nil63(_c5) then
+        _r21 = expected(s, "\"")
       else
-        if c == "\\" then
-          str = str .. read_char(s)
+        if _c5 == "\\" then
+          _str1 = _str1 .. read_char(s)
         end
-        str = str .. read_char(s)
+        _str1 = _str1 .. read_char(s)
       end
     end
   end
-  return(r)
+  return(_r21)
 end
 read_table["|"] = function (s)
   read_char(s)
-  local r = nil
-  local str = "|"
-  while nil63(r) do
-    local c = peek_char(s)
-    if c == "|" then
-      r = str .. read_char(s)
+  local _r23 = nil
+  local _str2 = "|"
+  while nil63(_r23) do
+    local _c6 = peek_char(s)
+    if _c6 == "|" then
+      _r23 = _str2 .. read_char(s)
     else
-      if nil63(c) then
-        r = expected(s, "|")
+      if nil63(_c6) then
+        _r23 = expected(s, "|")
       else
-        str = str .. read_char(s)
+        _str2 = _str2 .. read_char(s)
       end
     end
   end
-  return(r)
+  return(_r23)
 end
 read_table["'"] = function (s)
   read_char(s)
@@ -256,4 +256,4 @@ read_table[","] = function (s)
     return(wrap(s, "unquote"))
   end
 end
-return({["read-all"] = read_all, ["read-table"] = read_table, stream = stream, ["read-string"] = read_string, read = read})
+return({stream = stream, read = read, ["read-all"] = read_all, ["read-string"] = read_string, ["read-table"] = read_table})

--- a/bin/system.js
+++ b/bin/system.js
@@ -14,17 +14,17 @@ var directory_exists63 = function (path) {
 };
 var path_separator = require("path").sep;
 var path_join = function () {
-  var parts = unstash(Array.prototype.slice.call(arguments, 0));
+  var _parts = unstash(Array.prototype.slice.call(arguments, 0));
   return(reduce(function (x, y) {
     return(x + path_separator + y);
-  }, parts) || "");
+  }, _parts) || "");
 };
 var get_environment_variable = function (name) {
   return(process.env[name]);
 };
 var write = function (x) {
-  var out = process.stdout;
-  return(out.write(x));
+  var _out = process.stdout;
+  return(_out.write(x));
 };
 var exit = function (code) {
   return(process.exit(code));
@@ -35,7 +35,7 @@ var reload = function (module) {
   return(require(module));
 };
 var run = function (command) {
-  return(child_process.execSync(command).toString());
+  return(child_process.execSync(command)["toString"]());
 };
 exports["read-file"] = read_file;
 exports["write-file"] = write_file;

--- a/bin/system.lua
+++ b/bin/system.lua
@@ -3,9 +3,9 @@ local function call_with_file(f, path, mode)
   if not h then
     error(e)
   end
-  local x = f(h)
+  local _x = f(h)
   h.close(h)
-  return(x)
+  return(_x)
 end
 local function read_file(path)
   return(call_with_file(function (f)
@@ -18,26 +18,26 @@ local function write_file(path, data)
   end, path, "w"))
 end
 local function file_exists63(path)
-  local f = io.open(path)
-  local _id = is63(f)
+  local _f = io.open(path)
+  local _id = is63(_f)
   local _e
   if _id then
-    local r = is63(f.read(f, 0)) or 0 == f.seek(f, "end")
-    f.close(f)
-    _e = r
+    local _r6 = is63(_f.read(_f, 0)) or 0 == _f.seek(_f, "end")
+    _f.close(_f)
+    _e = _r6
   else
     _e = _id
   end
   return(_e)
 end
 local function directory_exists63(path)
-  local f = io.open(path)
-  local _id1 = is63(f)
+  local _f1 = io.open(path)
+  local _id1 = is63(_f1)
   local _e1
   if _id1 then
-    local r = not f.read(f, 0) and not( 0 == f.seek(f, "end"))
-    f.close(f)
-    _e1 = r
+    local _r8 = not _f1.read(_f1, 0) and not( 0 == _f1.seek(_f1, "end"))
+    _f1.close(_f1)
+    _e1 = _r8
   else
     _e1 = _id1
   end
@@ -45,10 +45,10 @@ local function directory_exists63(path)
 end
 local path_separator = char(_G.package.config, 0)
 local function path_join(...)
-  local parts = unstash({...})
+  local _parts = unstash({...})
   return(reduce(function (x, y)
     return(x .. path_separator .. y)
-  end, parts) or "")
+  end, _parts) or "")
 end
 local function get_environment_variable(name)
   return(os.getenv(name))
@@ -65,9 +65,9 @@ local function reload(module)
   return(require(module))
 end
 local function run(command)
-  local f = io.popen(command)
-  local x = f.read(f, "*all")
-  f.close(f)
-  return(x)
+  local _f2 = io.popen(command)
+  local _x2 = _f2.read(_f2, "*all")
+  _f2.close(_f2)
+  return(_x2)
 end
-return({exit = exit, ["get-environment-variable"] = get_environment_variable, ["write-file"] = write_file, ["file-exists?"] = file_exists63, ["read-file"] = read_file, reload = reload, run = run, argv = argv, ["directory-exists?"] = directory_exists63, write = write, ["path-join"] = path_join, ["path-separator"] = path_separator})
+return({["read-file"] = read_file, ["write-file"] = write_file, ["file-exists?"] = file_exists63, ["directory-exists?"] = directory_exists63, ["path-separator"] = path_separator, ["path-join"] = path_join, ["get-environment-variable"] = get_environment_variable, write = write, exit = exit, argv = argv, reload = reload, run = run})

--- a/compiler.l
+++ b/compiler.l
@@ -715,6 +715,9 @@
           (set c ", "))))
     (cat s "}")))
 
+(define-special %literal args
+  (apply cat (map compile args)))
+
 (export run
         eval
         expand

--- a/macros.l
+++ b/macros.l
@@ -60,11 +60,10 @@
     (let ((lh rh rest: bs2) bs
           (id val rest: bs1) (bind lh rh))
       (let renames ()
-        (if (or (bound? id) (toplevel?))
-            (let id1 (unique id)
-              (set renames (list id id1)
-                   id id1))
-          (setenv id :variable))
+        (unless (id-literal? id)
+          (let id1 (unique id)
+            (set renames (list id id1)
+                 id id1)))
         `(do (%local ,id ,val)
              (let-symbol ,renames
                (let ,(join bs1 bs2) ,@body)))))))

--- a/runtime.l
+++ b/runtime.l
@@ -320,9 +320,6 @@
 (define-global call (f rest: args)
   (apply f args))
 
-(define-global toplevel? ()
-  (one? environment))
-
 (define-global setenv (k rest: keys)
   (when (string? k)
     (let (frame (if (get keys 'toplevel)

--- a/test.l
+++ b/test.l
@@ -799,10 +799,10 @@ c"
 
 (define-test let-unique
   (let-unique (ham chap)
-    (test= '_ham1 ham)
-    (test= '_chap chap)
+    (test= '_ham2 ham)
+    (test= '_chap1 chap)
     (let-unique (ham)
-      (test= '_ham2 ham))))
+      (test= '_ham3 ham))))
 
 (define-test literals
   (test= true true)

--- a/test.l
+++ b/test.l
@@ -198,7 +198,7 @@
     (test= 10 x))
   (test= 12 (do (get but zz) 12))
   (let y nil
-    (let ignore (do |y = 10;| 42)
+    (let ignore (do (%literal y | = 10;|) 42)
       (test= 10 y))))
 
 (define-test string
@@ -339,9 +339,9 @@ c"
         b (obj x: 20)
         f (fn () 30))
     (test= 10 a)
-    (test= 10 |a|)
-    (test= 20 |b.x|)
-    (test= 30 |f()|)))
+    (test= 10 (%literal a))
+    (test= 20 (%literal b |.| x))
+    (test= 30 (%literal f |()|))))
 
 (define-test names
   (let (a! 0

--- a/test.l
+++ b/test.l
@@ -456,7 +456,7 @@ c"
           (if (= i 19)
               (break)
             (inc i)))
-      (test= nil a)
+      (test= nil b)
       (test= 19 i))))
 
 (define-test for

--- a/test.l
+++ b/test.l
@@ -340,7 +340,7 @@ c"
         f (fn () 30))
     (test= 10 a)
     (test= 10 (%literal a))
-    (test= 20 (%literal b |.| x))
+    (test= 20 (%literal b |.x|))
     (test= 30 (%literal f |()|))))
 
 (define-test names


### PR DESCRIPTION
Closes #80, #92.

This PR implements the strategy you proposed in #92. It also introduces a new special form, `%literal`, which compiles all of its arguments. See the `id` test:

```
(define-test id
  (let (a 10
        b (obj x: 20)
        f (fn () 30))
    (test= 10 a)
    (test= 10 (%literal a))
    (test= 20 (%literal b |.| x))
    (test= 30 (%literal f |()|))))
```
`%literal` was introduced because e.g. `|#x|` is no longer valid when `x` is let-bound, and

```(when-compiling (cat "|#" (macroexpand 'x) "|"))```

is rather cumbersome.
