### PR TITLE
Fix REQUIRE on JS

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -1070,6 +1070,8 @@ lower = function (form, hoist, stmt63, tail63) {
 expand = function (form) {
   return(lower(macroexpand(form)));
 };
+module.filename = require("path").resolve("repl");
+module.paths = require("module")._nodeModulePaths(module.filename);
 global.require = require;
 var run = eval;
 _37result = undefined;

--- a/bin/lumen
+++ b/bin/lumen
@@ -31,7 +31,7 @@ fi
 case $host in
     node*)
         code=lumen.js
-        export NODE_PATH="$NODE_PATH:${home}:${dir}/lib:${dir}/node_modules";;
+        export NODE_PATH="$NODE_PATH:${home}:${dir}/lib";;
     *)
         code=lumen.lua
         export LUA_PATH="$LUA_PATH;${home}/?.lua;${dir}/lib/?.lua;;";;

--- a/compiler.l
+++ b/compiler.l
@@ -563,6 +563,11 @@
 (define-global expand (form)
   (lower (macroexpand form)))
 
+(target js: (set (get module 'filename)
+                 ((get (require 'path) 'resolve) 'repl)))
+(target js: (set (get module 'paths)
+                 ((get (require 'module) '_nodeModulePaths)
+                  (get module 'filename))))
 (target js: (set (get global 'require) require))
 (target js: (define run eval))
 


### PR DESCRIPTION
On JS, when evaluating expressions via Lumen's REPL, via the `-e`
command-line argument, or via Lumen's scripting system, the following
scenarios now match Node's behavior:

1. `(require "./foo")` will correctly require "./foo.js"

2. `(require "foo")` will correctly perform the node_modules
   lookup algorithm.

The motivation here is exactly the same as in #82, but #82 fails in
certain circumstances, such as when Lumen is installed locally via
npm. It's also simpler than #82, and more in line with Lumen's goal
of attempting to match the JS runtime as closely as possible.

This PR implements this feature in the same way as Node.js itself.
See [Node.js/lib/repl.js](https://github.com/nodejs/node/blob/aea7269c45f91fd983e8ca91fddd4021fc40d099/lib/repl.js#L76-L88)

