### PR TITLE
Fix STR for tables with non-atom keys in Lua

### DIFF
--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -529,6 +529,9 @@ function str(x, stack)
                         if number63(_k8) then
                           _xs11[_k8] = str(_v9, _l4)
                         else
+                          if not string63(_k8) then
+                            _k8 = str(_k8, _l4)
+                          end
                           add(_ks, _k8 .. ":")
                           add(_ks, str(_v9, _l4))
                         end

--- a/runtime.l
+++ b/runtime.l
@@ -301,7 +301,10 @@
       (each (k v) x
         (if (number? k)
             (set (get xs k) (str v l))
-          (do (add ks (cat k ":"))
+          (do (target lua:
+                (unless (string? k)
+                  (set k (str k l))))
+              (add ks (cat k ":"))
               (add ks (str v l)))))
       (drop l)
       (each v (join xs ks)

--- a/test.l
+++ b/test.l
@@ -996,6 +996,15 @@ c"
   (test= false (obj? 'zz))
   (test= false (obj? (fn ()))))
 
+(define-test str
+  (define f (x) x)
+  (let (l () l2 ())
+    (set (get l f) true)
+    (set (get l2 (target js: (str l) lua: l)) true)
+    (let k (target js: f lua: 'function)
+      (test= (cat "(" k ": true)") (str l))
+      (test= (cat "((" k ": true): true)") (str l2)))))
+
 (define-test apply
   (test= 4 (apply (fn (a b) (+ a b)) '(2 2)))
   (test= '(2 2) (apply (fn a a) '(2 2)))


### PR DESCRIPTION
This PR fixes the following bug:

```
$ lumen -e "(str (with l () (set (get l (fn ())) true)))"
error: attempt to concatenate local 'k' (a function value)
```