### PR TITLE
Define EITHER

### DIFF
--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -12,6 +12,13 @@ no = function (x) {
 yes = function (x) {
   return(! no(x));
 };
+either = function (x, y) {
+  if (is63(x)) {
+    return(x);
+  } else {
+    return(y);
+  }
+};
 _35 = function (x) {
   return(x.length || 0);
 };
@@ -164,9 +171,9 @@ reverse = function (l) {
   }
   return(_l1);
 };
-reduce = function (f, x, none) {
+reduce = function (f, x) {
   if (none63(x)) {
-    return(none);
+    return(undefined);
   } else {
     if (one63(x)) {
       return(hd(x));
@@ -435,39 +442,39 @@ split = function (s, sep) {
 };
 cat = function () {
   var _xs = unstash(Array.prototype.slice.call(arguments, 0));
-  return(reduce(function (a, b) {
+  return(either(reduce(function (a, b) {
     return(a + b);
-  }, _xs, ""));
+  }, _xs), ""));
 };
 _43 = function () {
   var _xs1 = unstash(Array.prototype.slice.call(arguments, 0));
-  return(reduce(function (a, b) {
+  return(either(reduce(function (a, b) {
     return(a + b);
-  }, _xs1, 0));
+  }, _xs1), 0));
 };
 _45 = function () {
   var _xs2 = unstash(Array.prototype.slice.call(arguments, 0));
-  return(reduce(function (b, a) {
+  return(either(reduce(function (b, a) {
     return(a - b);
-  }, reverse(_xs2), 0));
+  }, reverse(_xs2)), 0));
 };
 _42 = function () {
   var _xs3 = unstash(Array.prototype.slice.call(arguments, 0));
-  return(reduce(function (a, b) {
+  return(either(reduce(function (a, b) {
     return(a * b);
-  }, _xs3, 1));
+  }, _xs3), 1));
 };
 _47 = function () {
   var _xs4 = unstash(Array.prototype.slice.call(arguments, 0));
-  return(reduce(function (b, a) {
+  return(either(reduce(function (b, a) {
     return(a / b);
-  }, reverse(_xs4), 1));
+  }, reverse(_xs4)), 1));
 };
 _37 = function () {
   var _xs5 = unstash(Array.prototype.slice.call(arguments, 0));
-  return(reduce(function (b, a) {
+  return(either(reduce(function (b, a) {
     return(a % b);
-  }, reverse(_xs5), 0));
+  }, reverse(_xs5)), 0));
 };
 var pairwise = function (f, xs) {
   var _i18 = 0;

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -12,6 +12,13 @@ end
 function yes(x)
   return(not no(x))
 end
+function either(x, y)
+  if is63(x) then
+    return(x)
+  else
+    return(y)
+  end
+end
 function _35(x)
   return(#x)
 end
@@ -150,9 +157,9 @@ function reverse(l)
   end
   return(_l1)
 end
-function reduce(f, x, none)
+function reduce(f, x)
   if none63(x) then
-    return(none)
+    return(nil)
   else
     if one63(x) then
       return(hd(x))
@@ -359,39 +366,39 @@ function split(s, sep)
 end
 function cat(...)
   local _xs = unstash({...})
-  return(reduce(function (a, b)
+  return(either(reduce(function (a, b)
     return(a .. b)
-  end, _xs, ""))
+  end, _xs), ""))
 end
 function _43(...)
   local _xs1 = unstash({...})
-  return(reduce(function (a, b)
+  return(either(reduce(function (a, b)
     return(a + b)
-  end, _xs1, 0))
+  end, _xs1), 0))
 end
 function _45(...)
   local _xs2 = unstash({...})
-  return(reduce(function (b, a)
+  return(either(reduce(function (b, a)
     return(a - b)
-  end, reverse(_xs2), 0))
+  end, reverse(_xs2)), 0))
 end
 function _42(...)
   local _xs3 = unstash({...})
-  return(reduce(function (a, b)
+  return(either(reduce(function (a, b)
     return(a * b)
-  end, _xs3, 1))
+  end, _xs3), 1))
 end
 function _47(...)
   local _xs4 = unstash({...})
-  return(reduce(function (b, a)
+  return(either(reduce(function (b, a)
     return(a / b)
-  end, reverse(_xs4), 1))
+  end, reverse(_xs4)), 1))
 end
 function _37(...)
   local _xs5 = unstash({...})
-  return(reduce(function (b, a)
+  return(either(reduce(function (b, a)
     return(a % b)
-  end, reverse(_xs5), 0))
+  end, reverse(_xs5)), 0))
 end
 local function pairwise(f, xs)
   local _i18 = 0

--- a/runtime.l
+++ b/runtime.l
@@ -10,6 +10,7 @@
 
 (define-global no (x) (or (nil? x) (= x false)))
 (define-global yes (x) (not (no x)))
+(define-global either (x y) (if (is? x) x y))
 
 (define-global # (x)
   (target js: (or (get x 'length) 0) lua: |#x|))
@@ -111,8 +112,8 @@
         (add l1 (at l i))
         (dec i)))))
 
-(define-global reduce (f x none)
-  (if (none? x) none
+(define-global reduce (f x)
+  (if (none? x) nil
       (one? x) (hd x)
     (f (hd x) (reduce f (tl x)))))
 
@@ -222,22 +223,22 @@
         (add l s)))))
 
 (define-global cat xs
-  (reduce (fn (a b) (cat a b)) xs ""))
+  (either (reduce (fn (a b) (cat a b)) xs) ""))
 
 (define-global + xs
-  (reduce (fn (a b) (+ a b)) xs 0))
+  (either (reduce (fn (a b) (+ a b)) xs) 0))
 
 (define-global - xs
-  (reduce (fn (b a) (- a b)) (reverse xs) 0))
+  (either (reduce (fn (b a) (- a b)) (reverse xs)) 0))
 
 (define-global * xs
-  (reduce (fn (a b) (* a b)) xs 1))
+  (either (reduce (fn (a b) (* a b)) xs) 1))
 
 (define-global / xs
-  (reduce (fn (b a) (/ a b)) (reverse xs) 1))
+  (either (reduce (fn (b a) (/ a b)) (reverse xs)) 1))
 
 (define-global % xs
-  (reduce (fn (b a) (% a b)) (reverse xs) 0))
+  (either (reduce (fn (b a) (% a b)) (reverse xs)) 0))
 
 (define pairwise (f xs)
   (for i (edge xs)

--- a/test.l
+++ b/test.l
@@ -921,8 +921,8 @@ c"
   (test= (list "a" "b" "") (split "azzbzz" "zz")))
 
 (define-test reduce
-  (test= 'a (reduce (fn (a b) (+ a b)) '() 'a))
-  (test= 'a (reduce (fn (a b) (+ a b)) '(a)))
+  (test= 'a (either (reduce (fn (a b) (+ a b)) '()) 'a))
+  (test= 'a (either (reduce (fn (a b) (+ a b)) '(a)) 'a))
   (test= 6 (reduce (fn (a b) (+ a b)) '(1 2 3)))
   (test= '(1 (2 3))
          (reduce


### PR DESCRIPTION
This PR introduces a new runtime function, `(either x y)`, which returns `(if (is? x) x y)`.

My recent change to `reduce` was a little awkward. It's strange for reduce to take an argument to be returned if the input list is empty. This PR reverts `reduce` to the previous version, while using `(either (reduce ...` in the appropriate places to maintain the existing fixes.

`either` is also useful in situations where you'd want to use `(if (is? x) x y)`. For example:

```
(define foo (x)
  (set x (either x 42))
  ...)
```
