### PR TITLE
Fix GET when the first argument is an infix op

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -555,6 +555,9 @@ var getop = function (op) {
 var infix63 = function (x) {
   return(is63(getop(x)));
 };
+infix_operator63 = function (x) {
+  return(obj63(x) && infix63(hd(x)));
+};
 var compile_args = function (args) {
   var _s1 = "(";
   var _c1 = "";
@@ -1255,15 +1258,15 @@ setenv("%set", {_stash: true, special: function (lh, rh) {
   return(indentation() + _lh2 + " = " + _rh4);
 }, stmt: true});
 setenv("get", {_stash: true, special: function (t, k) {
-  var _t4 = compile(t);
+  var _t12 = compile(t);
   var _k121 = compile(k);
-  if (target === "lua" && char(_t4, 0) === "{") {
-    _t4 = "(" + _t4 + ")";
+  if (target === "lua" && char(_t12, 0) === "{" || infix_operator63(t)) {
+    _t12 = "(" + _t12 + ")";
   }
   if (string_literal63(k) && valid_id63(inner(k))) {
-    return(_t4 + "." + inner(k));
+    return(_t12 + "." + inner(k));
   } else {
-    return(_t4 + "[" + _k121 + "]");
+    return(_t12 + "[" + _k121 + "]");
   }
 }});
 setenv("%array", {_stash: true, special: function () {

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -501,6 +501,9 @@ end
 local function infix63(x)
   return(is63(getop(x)))
 end
+function infix_operator63(x)
+  return(obj63(x) and infix63(hd(x)))
+end
 local function compile_args(args)
   local _s1 = "("
   local _c1 = ""
@@ -1208,15 +1211,15 @@ setenv("%set", {_stash = true, special = function (lh, rh)
   return(indentation() .. _lh2 .. " = " .. _rh4)
 end, stmt = true})
 setenv("get", {_stash = true, special = function (t, k)
-  local _t4 = compile(t)
+  local _t12 = compile(t)
   local _k12 = compile(k)
-  if target == "lua" and char(_t4, 0) == "{" then
-    _t4 = "(" .. _t4 .. ")"
+  if target == "lua" and char(_t12, 0) == "{" or infix_operator63(t) then
+    _t12 = "(" .. _t12 .. ")"
   end
   if string_literal63(k) and valid_id63(inner(k)) then
-    return(_t4 .. "." .. inner(k))
+    return(_t12 .. "." .. inner(k))
   else
-    return(_t4 .. "[" .. _k12 .. "]")
+    return(_t12 .. "[" .. _k12 .. "]")
   end
 end})
 setenv("%array", {_stash = true, special = function (...)

--- a/compiler.l
+++ b/compiler.l
@@ -297,6 +297,9 @@
 (define infix? (x)
   (is? (getop x)))
 
+(define-global infix-operator? (x)
+  (and (obj? x) (infix? (hd x))))
+
 (define compile-args (args)
   (let (s "(" c "")
     (step x args
@@ -685,15 +688,16 @@
     (cat (indentation) lh " = " rh)))
 
 (define-special get (t k)
-  (let (t (compile t)
+  (let (t1 (compile t)
         k1 (compile k))
-    (when (and (= target 'lua)
-               (= (char t 0) "{"))
-      (set t (cat "(" t ")")))
+    (when (or (and (= target 'lua)
+                   (= (char t1 0) "{"))
+              (infix-operator? t))
+      (set t1 (cat "(" t1 ")")))
     (if (and (string-literal? k)
              (valid-id? (inner k)))
-        (cat t "." (inner k))
-      (cat t "[" k1 "]"))))
+        (cat t1 "." (inner k))
+      (cat t1 "[" k1 "]"))))
 
 (define-special %array forms
   (let (open (if (= target 'lua) "{" "[")

--- a/test.l
+++ b/test.l
@@ -501,7 +501,11 @@ c"
     (test= 'bar t.foo)
     (let k 'foo
       (test= 'bar (get t k)))
-    (test= 'bar (get t (cat "f" "oo")))))
+    (test= 'bar (get t (cat "f" "oo"))))
+  (let (t1 (obj) t2 (obj))
+    (set (get (or nil t1 t2) 'foo) 'bar)
+    (test= 'bar (get t1 'foo))
+    (test= nil (get t2 'foo))))
 
 (define-test each
   (let t '(1 2 3 :a b: false)


### PR DESCRIPTION
Closes #104.

This PR also defines a new global function `(infix-operator? x)` which returns `(and (obj? x) (infix? (hd x)))`.