### PR TITLE
Minor fix in UNIQUE; make ID global

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -68,13 +68,14 @@ var literal = function (s) {
 };
 var _names = {};
 unique = function (x) {
-  if (_names[x]) {
-    var _i1 = _names[x];
-    _names[x] = _names[x] + 1;
-    return(unique(x + _i1));
+  var _x1 = id(x);
+  if (_names[_x1]) {
+    var _i1 = _names[_x1];
+    _names[_x1] = _names[_x1] + 1;
+    return(unique(_x1 + _i1));
   } else {
-    _names[x] = 1;
-    return("_" + x);
+    _names[_x1] = 1;
+    return("_" + _x1);
   }
 };
 var stash42 = function (args) {
@@ -134,7 +135,7 @@ bind = function (lh, rh) {
       } else {
         _e24 = ["get", _id, ["quote", bias(_k3)]];
       }
-      var _x5 = _e24;
+      var _x6 = _e24;
       if (is63(_k3)) {
         var _e25;
         if (_v1 === true) {
@@ -143,7 +144,7 @@ bind = function (lh, rh) {
           _e25 = _v1;
         }
         var _k4 = _e25;
-        _bs = join(_bs, bind(_k4, _x5));
+        _bs = join(_bs, bind(_k4, _x6));
       }
     }
     return(_bs);
@@ -182,9 +183,9 @@ bind42 = function (args, body) {
         if (atom63(_v2)) {
           add(_args1, _v2);
         } else {
-          var _x30 = unique("x");
-          add(_args1, _x30);
-          _bs1 = join(_bs1, [_v2, _x30]);
+          var _x31 = unique("x");
+          add(_args1, _x31);
+          _bs1 = join(_bs1, [_v2, _x31]);
         }
       }
     }
@@ -220,24 +221,24 @@ var can_unquote63 = function (depth) {
 var quasisplice63 = function (x, depth) {
   return(can_unquote63(depth) && ! atom63(x) && hd(x) === "unquote-splicing");
 };
-var expand_local = function (_x38) {
-  var __id1 = _x38;
-  var _x39 = __id1[0];
+var expand_local = function (_x39) {
+  var __id1 = _x39;
+  var _x40 = __id1[0];
   var _name = __id1[1];
   var _value = __id1[2];
   setenv(_name, {_stash: true, variable: true});
   return(["%local", _name, macroexpand(_value)]);
 };
-var expand_function = function (_x41) {
-  var __id2 = _x41;
-  var _x42 = __id2[0];
+var expand_function = function (_x42) {
+  var __id2 = _x42;
+  var _x43 = __id2[0];
   var _args = __id2[1];
   var _body = cut(__id2, 2);
   add(environment, {});
   var __o3 = _args;
   var __i6 = undefined;
   for (__i6 in __o3) {
-    var __x43 = __o3[__i6];
+    var __x44 = __o3[__i6];
     var _e28;
     if (numeric63(__i6)) {
       _e28 = parseInt(__i6);
@@ -245,15 +246,15 @@ var expand_function = function (_x41) {
       _e28 = __i6;
     }
     var __i61 = _e28;
-    setenv(__x43, {_stash: true, variable: true});
+    setenv(__x44, {_stash: true, variable: true});
   }
-  var __x44 = join(["%function", _args], macroexpand(_body));
+  var __x45 = join(["%function", _args], macroexpand(_body));
   drop(environment);
-  return(__x44);
+  return(__x45);
 };
-var expand_definition = function (_x46) {
-  var __id3 = _x46;
-  var _x47 = __id3[0];
+var expand_definition = function (_x47) {
+  var __id3 = _x47;
+  var _x48 = __id3[0];
   var _name1 = __id3[1];
   var _args11 = __id3[2];
   var _body1 = cut(__id3, 3);
@@ -261,7 +262,7 @@ var expand_definition = function (_x46) {
   var __o4 = _args11;
   var __i7 = undefined;
   for (__i7 in __o4) {
-    var __x48 = __o4[__i7];
+    var __x49 = __o4[__i7];
     var _e29;
     if (numeric63(__i7)) {
       _e29 = parseInt(__i7);
@@ -269,17 +270,17 @@ var expand_definition = function (_x46) {
       _e29 = __i7;
     }
     var __i71 = _e29;
-    setenv(__x48, {_stash: true, variable: true});
+    setenv(__x49, {_stash: true, variable: true});
   }
-  var __x49 = join([_x47, _name1, _args11], macroexpand(_body1));
+  var __x50 = join([_x48, _name1, _args11], macroexpand(_body1));
   drop(environment);
-  return(__x49);
+  return(__x50);
 };
 var expand_macro = function (form) {
   return(macroexpand(expand1(form)));
 };
-expand1 = function (_x51) {
-  var __id4 = _x51;
+expand1 = function (_x52) {
+  var __id4 = _x52;
   var _name2 = __id4[0];
   var _body2 = cut(__id4, 1);
   return(apply(macro_function(_name2), _body2));
@@ -291,20 +292,20 @@ macroexpand = function (form) {
     if (atom63(form)) {
       return(form);
     } else {
-      var _x52 = hd(form);
-      if (_x52 === "%local") {
+      var _x53 = hd(form);
+      if (_x53 === "%local") {
         return(expand_local(form));
       } else {
-        if (_x52 === "%function") {
+        if (_x53 === "%function") {
           return(expand_function(form));
         } else {
-          if (_x52 === "%global-function") {
+          if (_x53 === "%global-function") {
             return(expand_definition(form));
           } else {
-            if (_x52 === "%local-function") {
+            if (_x53 === "%local-function") {
               return(expand_definition(form));
             } else {
-              if (macro63(_x52)) {
+              if (macro63(_x53)) {
                 return(expand_macro(form));
               } else {
                 return(map(macroexpand, form));
@@ -340,16 +341,16 @@ var quasiquote_list = function (form, depth) {
       last(_xs)[_k8] = _v5;
     }
   }
-  var __x55 = form;
+  var __x56 = form;
   var __i9 = 0;
-  while (__i9 < _35(__x55)) {
-    var _x56 = __x55[__i9];
-    if (quasisplice63(_x56, depth)) {
-      var _x57 = quasiexpand(_x56[1]);
-      add(_xs, _x57);
+  while (__i9 < _35(__x56)) {
+    var _x57 = __x56[__i9];
+    if (quasisplice63(_x57, depth)) {
+      var _x58 = quasiexpand(_x57[1]);
+      add(_xs, _x58);
       add(_xs, ["list"]);
     } else {
-      add(last(_xs), quasiexpand(_x56, depth));
+      add(last(_xs), quasiexpand(_x57, depth));
     }
     __i9 = __i9 + 1;
   }
@@ -399,8 +400,8 @@ quasiexpand = function (form, depth) {
     }
   }
 };
-expand_if = function (_x61) {
-  var __id5 = _x61;
+expand_if = function (_x62) {
+  var __id5 = _x62;
   var _a = __id5[0];
   var _b2 = __id5[1];
   var _c = cut(__id5, 2);
@@ -430,7 +431,7 @@ var valid_code63 = function (n) {
   return(number_code63(n) || n > 64 && n < 91 || n > 96 && n < 123 || n === 95);
 };
 valid_id63 = function (id) {
-  if (none63(id) || reserved63(id)) {
+  if (none63(id) || reserved63(id) || number_code63(code(id, 0))) {
     return(false);
   } else {
     var _i11 = 0;
@@ -468,52 +469,52 @@ mapo = function (f, t) {
       _e32 = _k9;
     }
     var _k10 = _e32;
-    var _x65 = f(_v6);
-    if (is63(_x65)) {
+    var _x66 = f(_v6);
+    if (is63(_x66)) {
       add(_o6, literal(_k10));
-      add(_o6, _x65);
+      add(_o6, _x66);
     }
   }
   return(_o6);
 };
-var __x67 = [];
 var __x68 = [];
-__x68.js = "!";
-__x68.lua = "not";
-__x67["not"] = __x68;
 var __x69 = [];
-__x69["*"] = true;
-__x69["/"] = true;
-__x69["%"] = true;
+__x69.js = "!";
+__x69.lua = "not";
+__x68["not"] = __x69;
 var __x70 = [];
-__x70["+"] = true;
-__x70["-"] = true;
+__x70["*"] = true;
+__x70["/"] = true;
+__x70["%"] = true;
 var __x71 = [];
+__x71["+"] = true;
+__x71["-"] = true;
 var __x72 = [];
-__x72.js = "+";
-__x72.lua = "..";
-__x71.cat = __x72;
 var __x73 = [];
-__x73["<"] = true;
-__x73[">"] = true;
-__x73["<="] = true;
-__x73[">="] = true;
+__x73.js = "+";
+__x73.lua = "..";
+__x72.cat = __x73;
 var __x74 = [];
+__x74["<"] = true;
+__x74[">"] = true;
+__x74["<="] = true;
+__x74[">="] = true;
 var __x75 = [];
-__x75.js = "===";
-__x75.lua = "==";
-__x74["="] = __x75;
 var __x76 = [];
+__x76.js = "===";
+__x76.lua = "==";
+__x75["="] = __x76;
 var __x77 = [];
-__x77.js = "&&";
-__x77.lua = "and";
-__x76["and"] = __x77;
 var __x78 = [];
+__x78.js = "&&";
+__x78.lua = "and";
+__x77["and"] = __x78;
 var __x79 = [];
-__x79.js = "||";
-__x79.lua = "or";
-__x78["or"] = __x79;
-var infix = [__x67, __x69, __x70, __x71, __x73, __x74, __x76, __x78];
+var __x80 = [];
+__x80.js = "||";
+__x80.lua = "or";
+__x79["or"] = __x80;
+var infix = [__x68, __x70, __x71, __x72, __x74, __x75, __x77, __x79];
 var unary63 = function (form) {
   return(two63(form) && in63(hd(form), ["not", "-"]));
 };
@@ -542,12 +543,12 @@ var precedence = function (form) {
 };
 var getop = function (op) {
   return(find(function (level) {
-    var _x81 = level[op];
-    if (_x81 === true) {
+    var _x82 = level[op];
+    if (_x82 === true) {
       return(op);
     } else {
-      if (is63(_x81)) {
-        return(_x81[target]);
+      if (is63(_x82)) {
+        return(_x82[target]);
       }
     }
   }, infix));
@@ -558,11 +559,11 @@ var infix63 = function (x) {
 var compile_args = function (args) {
   var _s1 = "(";
   var _c1 = "";
-  var __x82 = args;
+  var __x83 = args;
   var __i15 = 0;
-  while (__i15 < _35(__x82)) {
-    var _x83 = __x82[__i15];
-    _s1 = _s1 + _c1 + compile(_x83);
+  while (__i15 < _35(__x83)) {
+    var _x84 = __x83[__i15];
+    _s1 = _s1 + _c1 + compile(_x84);
     _c1 = ", ";
     __i15 = __i15 + 1;
   }
@@ -584,7 +585,7 @@ var escape_newlines = function (s) {
   }
   return(_s11);
 };
-var id = function (id) {
+id = function (id) {
   var _e35;
   if (number_code63(code(id, 0))) {
     _e35 = "_";
@@ -684,9 +685,9 @@ var terminator = function (stmt63) {
 };
 var compile_special = function (form, stmt63) {
   var __id6 = form;
-  var _x84 = __id6[0];
+  var _x85 = __id6[0];
   var _args2 = cut(__id6, 1);
-  var __id7 = getenv(_x84);
+  var __id7 = getenv(_x85);
   var _special = __id7.special;
   var _stmt = __id7.stmt;
   var _self_tr63 = __id7.tr;
@@ -761,9 +762,9 @@ compile_function = function (args, body) {
   var _id14 = _e40;
   var _args5 = compile_args(_args4);
   indent_level = indent_level + 1;
-  var __x87 = compile(_body3, {_stash: true, stmt: true});
+  var __x88 = compile(_body3, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var _body4 = __x87;
+  var _body4 = __x88;
   var _ind = indentation();
   var _e41;
   if (_prefix) {
@@ -854,11 +855,11 @@ var standalone63 = function (form) {
   return(! atom63(form) && ! infix63(hd(form)) && ! literal63(form) && !( "get" === hd(form)) || id_literal63(form));
 };
 var lower_do = function (args, hoist, stmt63, tail63) {
-  var __x92 = almost(args);
+  var __x93 = almost(args);
   var __i18 = 0;
-  while (__i18 < _35(__x92)) {
-    var _x93 = __x92[__i18];
-    var __y = lower(_x93, hoist, stmt63);
+  while (__i18 < _35(__x93)) {
+    var _x94 = __x93[__i18];
+    var __y = lower(_x94, hoist, stmt63);
     if (yes(__y)) {
       var _e1 = __y;
       if (standalone63(_e1)) {
@@ -886,22 +887,22 @@ var lower_set = function (args, hoist, stmt63, tail63) {
 var lower_if = function (args, hoist, stmt63, tail63) {
   var __id17 = args;
   var _cond = __id17[0];
-  var _then = __id17[1];
-  var _else = __id17[2];
+  var __then = __id17[1];
+  var __else = __id17[2];
   if (stmt63) {
     var _e47;
-    if (is63(_else)) {
-      _e47 = [lower_body([_else], tail63)];
+    if (is63(__else)) {
+      _e47 = [lower_body([__else], tail63)];
     }
-    return(add(hoist, join(["%if", lower(_cond, hoist), lower_body([_then], tail63)], _e47)));
+    return(add(hoist, join(["%if", lower(_cond, hoist), lower_body([__then], tail63)], _e47)));
   } else {
     var _e3 = unique("e");
     add(hoist, ["%local", _e3]);
     var _e46;
-    if (is63(_else)) {
-      _e46 = [lower(["%set", _e3, _else])];
+    if (is63(__else)) {
+      _e46 = [lower(["%set", _e3, __else])];
     }
-    add(hoist, join(["%if", lower(_cond, hoist), lower(["%set", _e3, _then])], _e46));
+    add(hoist, join(["%if", lower(_cond, hoist), lower(["%set", _e3, __then])], _e46));
     return(_e3);
   }
 };
@@ -976,10 +977,10 @@ var lower_pairwise = function (form) {
   if (pairwise63(form)) {
     var _e4 = [];
     var __id24 = form;
-    var _x122 = __id24[0];
+    var _x123 = __id24[0];
     var _args7 = cut(__id24, 1);
     reduce(function (a, b) {
-      add(_e4, [_x122, a, b]);
+      add(_e4, [_x123, a, b]);
       return(a);
     }, _args7);
     return(join(["and"], reverse(_e4)));
@@ -993,10 +994,10 @@ var lower_infix63 = function (form) {
 var lower_infix = function (form, hoist) {
   var _form3 = lower_pairwise(form);
   var __id25 = _form3;
-  var _x125 = __id25[0];
+  var _x126 = __id25[0];
   var _args8 = cut(__id25, 1);
   return(lower(reduce(function (a, b) {
-    return([_x125, b, a]);
+    return([_x126, b, a]);
   }, reverse(_args8)), hoist));
 };
 var lower_special = function (form, hoist) {
@@ -1019,36 +1020,36 @@ lower = function (form, hoist, stmt63, tail63) {
           return(lower_infix(form, hoist));
         } else {
           var __id26 = form;
-          var _x128 = __id26[0];
+          var _x129 = __id26[0];
           var _args9 = cut(__id26, 1);
-          if (_x128 === "do") {
+          if (_x129 === "do") {
             return(lower_do(_args9, hoist, stmt63, tail63));
           } else {
-            if (_x128 === "%set") {
+            if (_x129 === "%set") {
               return(lower_set(_args9, hoist, stmt63, tail63));
             } else {
-              if (_x128 === "%if") {
+              if (_x129 === "%if") {
                 return(lower_if(_args9, hoist, stmt63, tail63));
               } else {
-                if (_x128 === "%try") {
+                if (_x129 === "%try") {
                   return(lower_try(_args9, hoist, tail63));
                 } else {
-                  if (_x128 === "while") {
+                  if (_x129 === "while") {
                     return(lower_while(_args9, hoist));
                   } else {
-                    if (_x128 === "%for") {
+                    if (_x129 === "%for") {
                       return(lower_for(_args9, hoist));
                     } else {
-                      if (_x128 === "%function") {
+                      if (_x129 === "%function") {
                         return(lower_function(_args9));
                       } else {
-                        if (_x128 === "%local-function" || _x128 === "%global-function") {
-                          return(lower_definition(_x128, _args9, hoist));
+                        if (_x129 === "%local-function" || _x129 === "%global-function") {
+                          return(lower_definition(_x129, _args9, hoist));
                         } else {
-                          if (in63(_x128, ["and", "or"])) {
-                            return(lower_short(_x128, _args9, hoist));
+                          if (in63(_x129, ["and", "or"])) {
+                            return(lower_short(_x129, _args9, hoist));
                           } else {
-                            if (statement63(_x128)) {
+                            if (statement63(_x129)) {
                               return(lower_special(form, hoist));
                             } else {
                               return(lower_call(form, hoist));
@@ -1084,13 +1085,13 @@ eval = function (form) {
 setenv("do", {_stash: true, special: function () {
   var _forms1 = unstash(Array.prototype.slice.call(arguments, 0));
   var _s3 = "";
-  var __x133 = _forms1;
+  var __x134 = _forms1;
   var __i20 = 0;
-  while (__i20 < _35(__x133)) {
-    var _x134 = __x133[__i20];
-    _s3 = _s3 + compile(_x134, {_stash: true, stmt: true});
-    if (! atom63(_x134)) {
-      if (hd(_x134) === "return" || hd(_x134) === "break") {
+  while (__i20 < _35(__x134)) {
+    var _x135 = __x134[__i20];
+    _s3 = _s3 + compile(_x135, {_stash: true, stmt: true});
+    if (! atom63(_x135)) {
+      if (hd(_x135) === "return" || hd(_x135) === "break") {
         break;
       }
     }
@@ -1101,15 +1102,15 @@ setenv("do", {_stash: true, special: function () {
 setenv("%if", {_stash: true, special: function (cond, cons, alt) {
   var _cond2 = compile(cond);
   indent_level = indent_level + 1;
-  var __x137 = compile(cons, {_stash: true, stmt: true});
+  var __x138 = compile(cons, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var _cons1 = __x137;
+  var _cons1 = __x138;
   var _e50;
   if (alt) {
     indent_level = indent_level + 1;
-    var __x138 = compile(alt, {_stash: true, stmt: true});
+    var __x139 = compile(alt, {_stash: true, stmt: true});
     indent_level = indent_level - 1;
-    _e50 = __x138;
+    _e50 = __x139;
   }
   var _alt1 = _e50;
   var _ind3 = indentation();
@@ -1135,9 +1136,9 @@ setenv("%if", {_stash: true, special: function (cond, cons, alt) {
 setenv("while", {_stash: true, special: function (cond, form) {
   var _cond4 = compile(cond);
   indent_level = indent_level + 1;
-  var __x140 = compile(form, {_stash: true, stmt: true});
+  var __x141 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var _body10 = __x140;
+  var _body10 = __x141;
   var _ind5 = indentation();
   if (target === "js") {
     return(_ind5 + "while (" + _cond4 + ") {\n" + _body10 + _ind5 + "}\n");
@@ -1149,9 +1150,9 @@ setenv("%for", {_stash: true, special: function (t, k, form) {
   var _t2 = compile(t);
   var _ind7 = indentation();
   indent_level = indent_level + 1;
-  var __x142 = compile(form, {_stash: true, stmt: true});
+  var __x143 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var _body12 = __x142;
+  var _body12 = __x143;
   if (target === "lua") {
     return(_ind7 + "for " + k + " in next, " + _t2 + " do\n" + _body12 + _ind7 + "end\n");
   } else {
@@ -1162,14 +1163,14 @@ setenv("%try", {_stash: true, special: function (form) {
   var _e8 = unique("e");
   var _ind9 = indentation();
   indent_level = indent_level + 1;
-  var __x147 = compile(form, {_stash: true, stmt: true});
+  var __x148 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var _body14 = __x147;
+  var _body14 = __x148;
   var _hf1 = ["return", ["%array", false, _e8]];
   indent_level = indent_level + 1;
-  var __x150 = compile(_hf1, {_stash: true, stmt: true});
+  var __x151 = compile(_hf1, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var _h1 = __x150;
+  var _h1 = __x151;
   return(_ind9 + "try {\n" + _body14 + _ind9 + "}\n" + _ind9 + "catch (" + _e8 + ") {\n" + _h1 + _ind9 + "}\n");
 }, stmt: true, tr: true});
 setenv("%delete", {_stash: true, special: function (place) {
@@ -1183,16 +1184,16 @@ setenv("%function", {_stash: true, special: function (args, body) {
 }});
 setenv("%global-function", {_stash: true, special: function (name, args, body) {
   if (target === "lua") {
-    var _x154 = compile_function(args, body, {_stash: true, name: name});
-    return(indentation() + _x154);
+    var _x155 = compile_function(args, body, {_stash: true, name: name});
+    return(indentation() + _x155);
   } else {
     return(compile(["%set", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
 }, stmt: true, tr: true});
 setenv("%local-function", {_stash: true, special: function (name, args, body) {
   if (target === "lua") {
-    var _x160 = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
-    return(indentation() + _x160);
+    var _x161 = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
+    return(indentation() + _x161);
   } else {
     return(compile(["%local", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
@@ -1204,8 +1205,8 @@ setenv("return", {_stash: true, special: function (x) {
   } else {
     _e51 = "return(" + compile(x) + ")";
   }
-  var _x164 = _e51;
-  return(indentation() + _x164);
+  var _x165 = _e51;
+  return(indentation() + _x165);
 }, stmt: true});
 setenv("new", {_stash: true, special: function (x) {
   return("new " + compile(x));

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -68,13 +68,14 @@ local function literal(s)
 end
 local _names = {}
 function unique(x)
-  if _names[x] then
-    local _i1 = _names[x]
-    _names[x] = _names[x] + 1
-    return(unique(x .. _i1))
+  local _x1 = id(x)
+  if _names[_x1] then
+    local _i1 = _names[_x1]
+    _names[_x1] = _names[_x1] + 1
+    return(unique(_x1 .. _i1))
   else
-    _names[x] = 1
-    return("_" .. x)
+    _names[_x1] = 1
+    return("_" .. _x1)
   end
 end
 local function stash42(args)
@@ -120,7 +121,7 @@ function bind(lh, rh)
       else
         _e22 = {"get", _id, {"quote", bias(_k1)}}
       end
-      local _x5 = _e22
+      local _x6 = _e22
       if is63(_k1) then
         local _e23
         if _v1 == true then
@@ -129,7 +130,7 @@ function bind(lh, rh)
           _e23 = _v1
         end
         local _k2 = _e23
-        _bs = join(_bs, bind(_k2, _x5))
+        _bs = join(_bs, bind(_k2, _x6))
       end
     end
     return(_bs)
@@ -161,9 +162,9 @@ function bind42(args, body)
         if atom63(_v2) then
           add(_args1, _v2)
         else
-          local _x30 = unique("x")
-          add(_args1, _x30)
-          _bs1 = join(_bs1, {_v2, _x30})
+          local _x31 = unique("x")
+          add(_args1, _x31)
+          _bs1 = join(_bs1, {_v2, _x31})
         end
       end
     end
@@ -199,33 +200,33 @@ end
 local function quasisplice63(x, depth)
   return(can_unquote63(depth) and not atom63(x) and hd(x) == "unquote-splicing")
 end
-local function expand_local(_x38)
-  local __id1 = _x38
-  local _x39 = __id1[1]
+local function expand_local(_x39)
+  local __id1 = _x39
+  local _x40 = __id1[1]
   local _name = __id1[2]
   local _value = __id1[3]
   setenv(_name, {_stash = true, variable = true})
   return({"%local", _name, macroexpand(_value)})
 end
-local function expand_function(_x41)
-  local __id2 = _x41
-  local _x42 = __id2[1]
+local function expand_function(_x42)
+  local __id2 = _x42
+  local _x43 = __id2[1]
   local _args = __id2[2]
   local _body = cut(__id2, 2)
   add(environment, {})
   local __o3 = _args
   local __i6 = nil
   for __i6 in next, __o3 do
-    local __x43 = __o3[__i6]
-    setenv(__x43, {_stash = true, variable = true})
+    local __x44 = __o3[__i6]
+    setenv(__x44, {_stash = true, variable = true})
   end
-  local __x44 = join({"%function", _args}, macroexpand(_body))
+  local __x45 = join({"%function", _args}, macroexpand(_body))
   drop(environment)
-  return(__x44)
+  return(__x45)
 end
-local function expand_definition(_x46)
-  local __id3 = _x46
-  local _x47 = __id3[1]
+local function expand_definition(_x47)
+  local __id3 = _x47
+  local _x48 = __id3[1]
   local _name1 = __id3[2]
   local _args11 = __id3[3]
   local _body1 = cut(__id3, 3)
@@ -233,18 +234,18 @@ local function expand_definition(_x46)
   local __o4 = _args11
   local __i7 = nil
   for __i7 in next, __o4 do
-    local __x48 = __o4[__i7]
-    setenv(__x48, {_stash = true, variable = true})
+    local __x49 = __o4[__i7]
+    setenv(__x49, {_stash = true, variable = true})
   end
-  local __x49 = join({_x47, _name1, _args11}, macroexpand(_body1))
+  local __x50 = join({_x48, _name1, _args11}, macroexpand(_body1))
   drop(environment)
-  return(__x49)
+  return(__x50)
 end
 local function expand_macro(form)
   return(macroexpand(expand1(form)))
 end
-function expand1(_x51)
-  local __id4 = _x51
+function expand1(_x52)
+  local __id4 = _x52
   local _name2 = __id4[1]
   local _body2 = cut(__id4, 1)
   return(apply(macro_function(_name2), _body2))
@@ -256,20 +257,20 @@ function macroexpand(form)
     if atom63(form) then
       return(form)
     else
-      local _x52 = hd(form)
-      if _x52 == "%local" then
+      local _x53 = hd(form)
+      if _x53 == "%local" then
         return(expand_local(form))
       else
-        if _x52 == "%function" then
+        if _x53 == "%function" then
           return(expand_function(form))
         else
-          if _x52 == "%global-function" then
+          if _x53 == "%global-function" then
             return(expand_definition(form))
           else
-            if _x52 == "%local-function" then
+            if _x53 == "%local-function" then
               return(expand_definition(form))
             else
-              if macro63(_x52) then
+              if macro63(_x53) then
                 return(expand_macro(form))
               else
                 return(map(macroexpand, form))
@@ -298,16 +299,16 @@ local function quasiquote_list(form, depth)
       last(_xs)[_k4] = _v5
     end
   end
-  local __x55 = form
+  local __x56 = form
   local __i9 = 0
-  while __i9 < _35(__x55) do
-    local _x56 = __x55[__i9 + 1]
-    if quasisplice63(_x56, depth) then
-      local _x57 = quasiexpand(_x56[2])
-      add(_xs, _x57)
+  while __i9 < _35(__x56) do
+    local _x57 = __x56[__i9 + 1]
+    if quasisplice63(_x57, depth) then
+      local _x58 = quasiexpand(_x57[2])
+      add(_xs, _x58)
       add(_xs, {"list"})
     else
-      add(last(_xs), quasiexpand(_x56, depth))
+      add(last(_xs), quasiexpand(_x57, depth))
     end
     __i9 = __i9 + 1
   end
@@ -357,8 +358,8 @@ function quasiexpand(form, depth)
     end
   end
 end
-function expand_if(_x61)
-  local __id5 = _x61
+function expand_if(_x62)
+  local __id5 = _x62
   local _a = __id5[1]
   local _b2 = __id5[2]
   local _c = cut(__id5, 2)
@@ -388,7 +389,7 @@ local function valid_code63(n)
   return(number_code63(n) or n > 64 and n < 91 or n > 96 and n < 123 or n == 95)
 end
 function valid_id63(id)
-  if none63(id) or reserved63(id) then
+  if none63(id) or reserved63(id) or number_code63(code(id, 0)) then
     return(false)
   else
     local _i11 = 0
@@ -419,52 +420,52 @@ function mapo(f, t)
   local _k5 = nil
   for _k5 in next, __o7 do
     local _v6 = __o7[_k5]
-    local _x65 = f(_v6)
-    if is63(_x65) then
+    local _x66 = f(_v6)
+    if is63(_x66) then
       add(_o6, literal(_k5))
-      add(_o6, _x65)
+      add(_o6, _x66)
     end
   end
   return(_o6)
 end
-local __x67 = {}
 local __x68 = {}
-__x68.js = "!"
-__x68.lua = "not"
-__x67["not"] = __x68
 local __x69 = {}
-__x69["*"] = true
-__x69["/"] = true
-__x69["%"] = true
+__x69.js = "!"
+__x69.lua = "not"
+__x68["not"] = __x69
 local __x70 = {}
-__x70["+"] = true
-__x70["-"] = true
+__x70["*"] = true
+__x70["/"] = true
+__x70["%"] = true
 local __x71 = {}
+__x71["+"] = true
+__x71["-"] = true
 local __x72 = {}
-__x72.js = "+"
-__x72.lua = ".."
-__x71.cat = __x72
 local __x73 = {}
-__x73["<"] = true
-__x73[">"] = true
-__x73["<="] = true
-__x73[">="] = true
+__x73.js = "+"
+__x73.lua = ".."
+__x72.cat = __x73
 local __x74 = {}
+__x74["<"] = true
+__x74[">"] = true
+__x74["<="] = true
+__x74[">="] = true
 local __x75 = {}
-__x75.js = "==="
-__x75.lua = "=="
-__x74["="] = __x75
 local __x76 = {}
+__x76.js = "==="
+__x76.lua = "=="
+__x75["="] = __x76
 local __x77 = {}
-__x77.js = "&&"
-__x77.lua = "and"
-__x76["and"] = __x77
 local __x78 = {}
+__x78.js = "&&"
+__x78.lua = "and"
+__x77["and"] = __x78
 local __x79 = {}
-__x79.js = "||"
-__x79.lua = "or"
-__x78["or"] = __x79
-local infix = {__x67, __x69, __x70, __x71, __x73, __x74, __x76, __x78}
+local __x80 = {}
+__x80.js = "||"
+__x80.lua = "or"
+__x79["or"] = __x80
+local infix = {__x68, __x70, __x71, __x72, __x74, __x75, __x77, __x79}
 local function unary63(form)
   return(two63(form) and in63(hd(form), {"not", "-"}))
 end
@@ -488,12 +489,12 @@ local function precedence(form)
 end
 local function getop(op)
   return(find(function (level)
-    local _x81 = level[op]
-    if _x81 == true then
+    local _x82 = level[op]
+    if _x82 == true then
       return(op)
     else
-      if is63(_x81) then
-        return(_x81[target])
+      if is63(_x82) then
+        return(_x82[target])
       end
     end
   end, infix))
@@ -504,11 +505,11 @@ end
 local function compile_args(args)
   local _s1 = "("
   local _c1 = ""
-  local __x82 = args
+  local __x83 = args
   local __i15 = 0
-  while __i15 < _35(__x82) do
-    local _x83 = __x82[__i15 + 1]
-    _s1 = _s1 .. _c1 .. compile(_x83)
+  while __i15 < _35(__x83) do
+    local _x84 = __x83[__i15 + 1]
+    _s1 = _s1 .. _c1 .. compile(_x84)
     _c1 = ", "
     __i15 = __i15 + 1
   end
@@ -530,7 +531,7 @@ local function escape_newlines(s)
   end
   return(_s11)
 end
-local function id(id)
+function id(id)
   local _e27
   if number_code63(code(id, 0)) then
     _e27 = "_"
@@ -630,9 +631,9 @@ local function terminator(stmt63)
 end
 local function compile_special(form, stmt63)
   local __id6 = form
-  local _x84 = __id6[1]
+  local _x85 = __id6[1]
   local _args2 = cut(__id6, 1)
-  local __id7 = getenv(_x84)
+  local __id7 = getenv(_x85)
   local _special = __id7.special
   local _stmt = __id7.stmt
   local _self_tr63 = __id7.tr
@@ -707,9 +708,9 @@ function compile_function(args, body, ...)
   local _id14 = _e32
   local _args5 = compile_args(_args4)
   indent_level = indent_level + 1
-  local __x89 = compile(_body3, {_stash = true, stmt = true})
+  local __x90 = compile(_body3, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local _body4 = __x89
+  local _body4 = __x90
   local _ind = indentation()
   local _e33
   if _prefix then
@@ -800,11 +801,11 @@ local function standalone63(form)
   return(not atom63(form) and not infix63(hd(form)) and not literal63(form) and not( "get" == hd(form)) or id_literal63(form))
 end
 local function lower_do(args, hoist, stmt63, tail63)
-  local __x95 = almost(args)
+  local __x96 = almost(args)
   local __i18 = 0
-  while __i18 < _35(__x95) do
-    local _x96 = __x95[__i18 + 1]
-    local __y = lower(_x96, hoist, stmt63)
+  while __i18 < _35(__x96) do
+    local _x97 = __x96[__i18 + 1]
+    local __y = lower(_x97, hoist, stmt63)
     if yes(__y) then
       local _e1 = __y
       if standalone63(_e1) then
@@ -832,22 +833,22 @@ end
 local function lower_if(args, hoist, stmt63, tail63)
   local __id17 = args
   local _cond = __id17[1]
-  local _then = __id17[2]
-  local _else = __id17[3]
+  local __then = __id17[2]
+  local __else = __id17[3]
   if stmt63 then
     local _e39
-    if is63(_else) then
-      _e39 = {lower_body({_else}, tail63)}
+    if is63(__else) then
+      _e39 = {lower_body({__else}, tail63)}
     end
-    return(add(hoist, join({"%if", lower(_cond, hoist), lower_body({_then}, tail63)}, _e39)))
+    return(add(hoist, join({"%if", lower(_cond, hoist), lower_body({__then}, tail63)}, _e39)))
   else
     local _e3 = unique("e")
     add(hoist, {"%local", _e3})
     local _e38
-    if is63(_else) then
-      _e38 = {lower({"%set", _e3, _else})}
+    if is63(__else) then
+      _e38 = {lower({"%set", _e3, __else})}
     end
-    add(hoist, join({"%if", lower(_cond, hoist), lower({"%set", _e3, _then})}, _e38))
+    add(hoist, join({"%if", lower(_cond, hoist), lower({"%set", _e3, __then})}, _e38))
     return(_e3)
   end
 end
@@ -922,10 +923,10 @@ local function lower_pairwise(form)
   if pairwise63(form) then
     local _e4 = {}
     local __id24 = form
-    local _x125 = __id24[1]
+    local _x126 = __id24[1]
     local _args7 = cut(__id24, 1)
     reduce(function (a, b)
-      add(_e4, {_x125, a, b})
+      add(_e4, {_x126, a, b})
       return(a)
     end, _args7)
     return(join({"and"}, reverse(_e4)))
@@ -939,10 +940,10 @@ end
 local function lower_infix(form, hoist)
   local _form3 = lower_pairwise(form)
   local __id25 = _form3
-  local _x128 = __id25[1]
+  local _x129 = __id25[1]
   local _args8 = cut(__id25, 1)
   return(lower(reduce(function (a, b)
-    return({_x128, b, a})
+    return({_x129, b, a})
   end, reverse(_args8)), hoist))
 end
 local function lower_special(form, hoist)
@@ -965,36 +966,36 @@ function lower(form, hoist, stmt63, tail63)
           return(lower_infix(form, hoist))
         else
           local __id26 = form
-          local _x131 = __id26[1]
+          local _x132 = __id26[1]
           local _args9 = cut(__id26, 1)
-          if _x131 == "do" then
+          if _x132 == "do" then
             return(lower_do(_args9, hoist, stmt63, tail63))
           else
-            if _x131 == "%set" then
+            if _x132 == "%set" then
               return(lower_set(_args9, hoist, stmt63, tail63))
             else
-              if _x131 == "%if" then
+              if _x132 == "%if" then
                 return(lower_if(_args9, hoist, stmt63, tail63))
               else
-                if _x131 == "%try" then
+                if _x132 == "%try" then
                   return(lower_try(_args9, hoist, tail63))
                 else
-                  if _x131 == "while" then
+                  if _x132 == "while" then
                     return(lower_while(_args9, hoist))
                   else
-                    if _x131 == "%for" then
+                    if _x132 == "%for" then
                       return(lower_for(_args9, hoist))
                     else
-                      if _x131 == "%function" then
+                      if _x132 == "%function" then
                         return(lower_function(_args9))
                       else
-                        if _x131 == "%local-function" or _x131 == "%global-function" then
-                          return(lower_definition(_x131, _args9, hoist))
+                        if _x132 == "%local-function" or _x132 == "%global-function" then
+                          return(lower_definition(_x132, _args9, hoist))
                         else
-                          if in63(_x131, {"and", "or"}) then
-                            return(lower_short(_x131, _args9, hoist))
+                          if in63(_x132, {"and", "or"}) then
+                            return(lower_short(_x132, _args9, hoist))
                           else
-                            if statement63(_x131) then
+                            if statement63(_x132) then
                               return(lower_special(form, hoist))
                             else
                               return(lower_call(form, hoist))
@@ -1037,13 +1038,13 @@ end
 setenv("do", {_stash = true, special = function (...)
   local _forms1 = unstash({...})
   local _s3 = ""
-  local __x137 = _forms1
+  local __x138 = _forms1
   local __i20 = 0
-  while __i20 < _35(__x137) do
-    local _x138 = __x137[__i20 + 1]
-    _s3 = _s3 .. compile(_x138, {_stash = true, stmt = true})
-    if not atom63(_x138) then
-      if hd(_x138) == "return" or hd(_x138) == "break" then
+  while __i20 < _35(__x138) do
+    local _x139 = __x138[__i20 + 1]
+    _s3 = _s3 .. compile(_x139, {_stash = true, stmt = true})
+    if not atom63(_x139) then
+      if hd(_x139) == "return" or hd(_x139) == "break" then
         break
       end
     end
@@ -1054,15 +1055,15 @@ end, stmt = true, tr = true})
 setenv("%if", {_stash = true, special = function (cond, cons, alt)
   local _cond2 = compile(cond)
   indent_level = indent_level + 1
-  local __x141 = compile(cons, {_stash = true, stmt = true})
+  local __x142 = compile(cons, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local _cons1 = __x141
+  local _cons1 = __x142
   local _e42
   if alt then
     indent_level = indent_level + 1
-    local __x142 = compile(alt, {_stash = true, stmt = true})
+    local __x143 = compile(alt, {_stash = true, stmt = true})
     indent_level = indent_level - 1
-    _e42 = __x142
+    _e42 = __x143
   end
   local _alt1 = _e42
   local _ind3 = indentation()
@@ -1088,9 +1089,9 @@ end, stmt = true, tr = true})
 setenv("while", {_stash = true, special = function (cond, form)
   local _cond4 = compile(cond)
   indent_level = indent_level + 1
-  local __x144 = compile(form, {_stash = true, stmt = true})
+  local __x145 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local _body10 = __x144
+  local _body10 = __x145
   local _ind5 = indentation()
   if target == "js" then
     return(_ind5 .. "while (" .. _cond4 .. ") {\n" .. _body10 .. _ind5 .. "}\n")
@@ -1102,9 +1103,9 @@ setenv("%for", {_stash = true, special = function (t, k, form)
   local _t2 = compile(t)
   local _ind7 = indentation()
   indent_level = indent_level + 1
-  local __x146 = compile(form, {_stash = true, stmt = true})
+  local __x147 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local _body12 = __x146
+  local _body12 = __x147
   if target == "lua" then
     return(_ind7 .. "for " .. k .. " in next, " .. _t2 .. " do\n" .. _body12 .. _ind7 .. "end\n")
   else
@@ -1115,14 +1116,14 @@ setenv("%try", {_stash = true, special = function (form)
   local _e8 = unique("e")
   local _ind9 = indentation()
   indent_level = indent_level + 1
-  local __x151 = compile(form, {_stash = true, stmt = true})
+  local __x152 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local _body14 = __x151
+  local _body14 = __x152
   local _hf1 = {"return", {"%array", false, _e8}}
   indent_level = indent_level + 1
-  local __x154 = compile(_hf1, {_stash = true, stmt = true})
+  local __x155 = compile(_hf1, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local _h1 = __x154
+  local _h1 = __x155
   return(_ind9 .. "try {\n" .. _body14 .. _ind9 .. "}\n" .. _ind9 .. "catch (" .. _e8 .. ") {\n" .. _h1 .. _ind9 .. "}\n")
 end, stmt = true, tr = true})
 setenv("%delete", {_stash = true, special = function (place)
@@ -1136,16 +1137,16 @@ setenv("%function", {_stash = true, special = function (args, body)
 end})
 setenv("%global-function", {_stash = true, special = function (name, args, body)
   if target == "lua" then
-    local _x158 = compile_function(args, body, {_stash = true, name = name})
-    return(indentation() .. _x158)
+    local _x159 = compile_function(args, body, {_stash = true, name = name})
+    return(indentation() .. _x159)
   else
     return(compile({"%set", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
 end, stmt = true, tr = true})
 setenv("%local-function", {_stash = true, special = function (name, args, body)
   if target == "lua" then
-    local _x164 = compile_function(args, body, {_stash = true, name = name, prefix = "local"})
-    return(indentation() .. _x164)
+    local _x165 = compile_function(args, body, {_stash = true, name = name, prefix = "local"})
+    return(indentation() .. _x165)
   else
     return(compile({"%local", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
@@ -1157,8 +1158,8 @@ setenv("return", {_stash = true, special = function (x)
   else
     _e43 = "return(" .. compile(x) .. ")"
   end
-  local _x168 = _e43
-  return(indentation() .. _x168)
+  local _x169 = _e43
+  return(indentation() .. _x169)
 end, stmt = true})
 setenv("new", {_stash = true, special = function (x)
   return("new " .. compile(x))

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -532,7 +532,7 @@ numeric63 = function (s) {
   return(some63(s));
 };
 var tostring = function (x) {
-  return(x["toString"]());
+  return(x.toString());
 };
 escape = function (s) {
   var _s1 = "\"";
@@ -1208,9 +1208,9 @@ var repl = function () {
     }
   };
   system.write("> ");
-  var _in = process.stdin;
-  _in.setEncoding("utf8");
-  return(_in.on("data", rep1));
+  var __in = process.stdin;
+  __in.setEncoding("utf8");
+  return(__in.on("data", rep1));
 };
 compile_file = function (path) {
   var _s = reader.stream(system["read-file"](path));

--- a/bin/system.js
+++ b/bin/system.js
@@ -35,7 +35,7 @@ var reload = function (module) {
   return(require(module));
 };
 var run = function (command) {
-  return(child_process.execSync(command)["toString"]());
+  return(child_process.execSync(command).toString());
 };
 exports["read-file"] = read_file;
 exports["write-file"] = write_file;

--- a/compiler.l
+++ b/compiler.l
@@ -52,12 +52,13 @@
 
 (let (names (obj))
   (define-global unique (x)
-    (if (get names x)
-        (let i (get names x)
-          (inc (get names x))
-          (unique (cat x i)))
-      (do (set (get names x) 1)
-          (cat "_" x)))))
+    (let x (id x)
+      (if (get names x)
+          (let i (get names x)
+            (inc (get names x))
+            (unique (cat x i)))
+        (do (set (get names x) 1)
+            (cat "_" x))))))
 
 (define stash* (args)
   (if (keys? args)
@@ -244,7 +245,9 @@
       (= n 95)))               ; _
 
 (define-global valid-id? (id)
-  (if (or (none? id) (reserved? id))
+  (if (or (none? id)
+          (reserved? id)
+          (number-code? (code id 0)))
       false
     (do (for i (# id)
           (unless (valid-code? (code id i))
@@ -310,7 +313,7 @@
       (let c (char s i)
         (cat! s1 (if (= c "\n") "\\n" c))))))
 
-(define id (id)
+(define-global id (id)
   (let id1 (if (number-code? (code id 0)) "_" "")
     (for i (# id)
       (let (c (char id i)

--- a/test.l
+++ b/test.l
@@ -805,7 +805,16 @@ c"
     (test= '_ham2 ham)
     (test= '_chap1 chap)
     (let-unique (ham)
-      (test= '_ham3 ham))))
+      (test= '_ham3 ham)))
+  (let-unique (an in %x 37x)
+    (test= true (valid-id? 'an))
+    (test= false (valid-id? 'in))
+    (test= false (valid-id? '%x))
+    (test= false (valid-id? '37x))
+    (test= '_an1 an)
+    (test= '__in1 in)
+    (test= '__37x2 %x)
+    (test= '__37x3 37x)))
 
 (define-test literals
   (test= true true)


### PR DESCRIPTION
- `unique` now returns unique compiled identifiers rather than unique names
- `id` is now a global function

It seems logical for `id` to be accessible to users rather than relying on `compile`.

For example, I notice this (quite amusingly) works:

```
> (let ("a" 42) "a")
42
```
However, `(compile '"a")` gives `"\"a\""`, whereas `(id '"a")` correctly gives `_34a34`.

I can make `id` private again if you'd prefer, though.

Closes #108 
