### PR TITLE
Fix LET to not generate bindings that sometimes compile to identical strings

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -886,22 +886,22 @@ var lower_set = function (args, hoist, stmt63, tail63) {
 var lower_if = function (args, hoist, stmt63, tail63) {
   var __id17 = args;
   var _cond = __id17[0];
-  var _then = __id17[1];
-  var _else = __id17[2];
+  var __then = __id17[1];
+  var __else = __id17[2];
   if (stmt63) {
     var _e47;
-    if (is63(_else)) {
-      _e47 = [lower_body([_else], tail63)];
+    if (is63(__else)) {
+      _e47 = [lower_body([__else], tail63)];
     }
-    return(add(hoist, join(["%if", lower(_cond, hoist), lower_body([_then], tail63)], _e47)));
+    return(add(hoist, join(["%if", lower(_cond, hoist), lower_body([__then], tail63)], _e47)));
   } else {
     var _e3 = unique("e");
     add(hoist, ["%local", _e3]);
     var _e46;
-    if (is63(_else)) {
-      _e46 = [lower(["%set", _e3, _else])];
+    if (is63(__else)) {
+      _e46 = [lower(["%set", _e3, __else])];
     }
-    add(hoist, join(["%if", lower(_cond, hoist), lower(["%set", _e3, _then])], _e46));
+    add(hoist, join(["%if", lower(_cond, hoist), lower(["%set", _e3, __then])], _e46));
     return(_e3);
   }
 };

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -832,22 +832,22 @@ end
 local function lower_if(args, hoist, stmt63, tail63)
   local __id17 = args
   local _cond = __id17[1]
-  local _then = __id17[2]
-  local _else = __id17[3]
+  local __then = __id17[2]
+  local __else = __id17[3]
   if stmt63 then
     local _e39
-    if is63(_else) then
-      _e39 = {lower_body({_else}, tail63)}
+    if is63(__else) then
+      _e39 = {lower_body({__else}, tail63)}
     end
-    return(add(hoist, join({"%if", lower(_cond, hoist), lower_body({_then}, tail63)}, _e39)))
+    return(add(hoist, join({"%if", lower(_cond, hoist), lower_body({__then}, tail63)}, _e39)))
   else
     local _e3 = unique("e")
     add(hoist, {"%local", _e3})
     local _e38
-    if is63(_else) then
-      _e38 = {lower({"%set", _e3, _else})}
+    if is63(__else) then
+      _e38 = {lower({"%set", _e3, __else})}
     end
-    add(hoist, join({"%if", lower(_cond, hoist), lower({"%set", _e3, _then})}, _e38))
+    add(hoist, join({"%if", lower(_cond, hoist), lower({"%set", _e3, __then})}, _e38))
     return(_e3)
   end
 end

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -532,7 +532,7 @@ numeric63 = function (s) {
   return(some63(s));
 };
 var tostring = function (x) {
-  return(x["toString"]());
+  return(x.toString());
 };
 escape = function (s) {
   var _s1 = "\"";
@@ -851,7 +851,7 @@ setenv("let", {_stash: true, macro: function (bs) {
       var _bs12 = cut(__id16, 2);
       var _renames1 = [];
       if (! id_literal63(_id17)) {
-        var _id121 = unique(_id17);
+        var _id121 = unique(compile(_id17));
         _renames1 = [_id17, _id121];
         _id17 = _id121;
       }
@@ -1208,9 +1208,9 @@ var repl = function () {
     }
   };
   system.write("> ");
-  var _in = process.stdin;
-  _in.setEncoding("utf8");
-  return(_in.on("data", rep1));
+  var __in = process.stdin;
+  __in.setEncoding("utf8");
+  return(__in.on("data", rep1));
 };
 compile_file = function (path) {
   var _s = reader.stream(system["read-file"](path));

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -739,7 +739,7 @@ setenv("let", {_stash = true, macro = function (bs, ...)
       local _bs12 = cut(__id16, 2)
       local _renames1 = {}
       if not id_literal63(_id17) then
-        local _id121 = unique(_id17)
+        local _id121 = unique(compile(_id17))
         _renames1 = {_id17, _id121}
         _id17 = _id121
       end

--- a/bin/system.js
+++ b/bin/system.js
@@ -35,7 +35,7 @@ var reload = function (module) {
   return(require(module));
 };
 var run = function (command) {
-  return(child_process.execSync(command)["toString"]());
+  return(child_process.execSync(command).toString());
 };
 exports["read-file"] = read_file;
 exports["write-file"] = write_file;

--- a/macros.l
+++ b/macros.l
@@ -61,7 +61,7 @@
           (id val rest: bs1) (bind lh rh))
       (let renames ()
         (unless (id-literal? id)
-          (let id1 (unique id)
+          (let id1 (unique (compile id))
             (set renames (list id id1)
                  id id1)))
         `(do (%local ,id ,val)

--- a/test.l
+++ b/test.l
@@ -651,7 +651,11 @@ c"
        (test= 9 q))))
   (test= 0 (+ (abs -1)
               (let abs (fn (x) x)
-                (abs -1)))))
+                (abs -1))))
+  (define %i 1)
+  (let %i 2
+    (test= 2 %i))
+  (test= 1 %i))
 
 (define-test with
   (test= 10 (with x 9 (inc x))))


### PR DESCRIPTION
Closes #109 and #108.

This PR modifies LET to call `(unique (compile id))` to rename variables, rather than `(unique id)`. This prevents LET from generating bindings that happen to compile to identical strings.

Note that `let-unique` is still vulnerable:


```
> (do (define-macro foo () 
      (let-unique (%f %f)
        `(%local ,%f 42)))

    (let e (let-unique (37f 37f 37f)
             `(do (%local ,37f 21)
                  (foo)))

      (print (compile (expand e)))))

local _37f5 = 21
local _37f5 = 42
```

The above code is admittedly bizarre, but the point is that unless we change `let-unique` the same way we changed `let` -- modifying it to call `(unique (compile ...))` instead of `(unique ...)` -- then users might run into errors whenever they try to use `let-unique` within a macro to generate names of bindings.

(This is true for all macros, not just `let-unique`. Any macro that generates bindings via `unique` must do so by calling `(unique (compile name))`, not `(unique name)`.  Without that `(compile name)` call, it's impossible to guarantee that `(unique name)` won't compile to exactly the same string as some other, differently-named binding.)

A good question at this point would be to ask: Why don't we just modify `unique`'s implementation so that it always calls `compile` on its argument? That way, users can just call `(unique ...)` everywhere, and they never have to worry about any of the above concerns. Well, unfortunately, changing `unique` turned out to be a bad idea. It ended up being slow (around ~4% increase in total compilation time) and seemingly somewhat brittle: `(unique "nil")` ended up behaving differently than `(unique "var")` (even though they're both reserved words and should behave the same) due to the fact that `(unique "nil")` calls `(compile "nil")` which of course returns "nil"/"undefined" instead of what we really need it to return: `(id "nil")`; one of `compiler`'s internal functions that we don't have access to.

Etc, etc. That specific example wasn't necessarily a problem, since even with the wonky `(compile "nil")` output, the resulting string ends up being unique. But the surprising behavior plus the performance hit seemed to suggest that `unique` might be the wrong level of abstraction for implementing ways of preventing bindings from compiling to identical strings.
