### PR TITLE
Remove dot syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,22 +112,6 @@ hi
 10
 ```
 
-It's common to access the values of a list variable where the position or key is known in advance, so there is a shorthand for that:		
-```		
-> (let x (list foo: 10 bar: 20)		
-    x.bar)		
-20		
-> (let x (list foo: 10 bar: 20)		
-    (get x "bar")) ; equivalent		
-20		
-> (let x (list 10 20 30)		
-    x.2)		
-30		
-> (let x (list 10 20 30)		
-    (at x 2)) ; equivalent		
-30		
-```		
-
 #### Assignment
 Variables and list values can be updated using `set`, which evaluates to the value that it updated:
 ```

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -532,7 +532,7 @@ numeric63 = function (s) {
   return(some63(s));
 };
 var tostring = function (x) {
-  return(x["toString"]());
+  return(x.toString());
 };
 escape = function (s) {
   var _s1 = "\"";

--- a/bin/reader.js
+++ b/bin/reader.js
@@ -104,28 +104,11 @@ var maybe_number = function (str) {
 var real63 = function (x) {
   return(number63(x) && ! nan63(x) && ! inf63(x));
 };
-var valid_access63 = function (str) {
-  return(_35(str) > 2 && !( "." === char(str, 0)) && !( "." === char(str, edge(str))) && ! search(str, ".."));
-};
-var parse_access = function (str) {
-  return(reduce(function (a, b) {
-    var _n = number(a);
-    if (is63(_n)) {
-      return(["at", b, _n]);
-    } else {
-      return(["get", b, ["quote", a]]);
-    }
-  }, reverse(split(str, "."))));
-};
 read_table[""] = function (s) {
   var _str = "";
-  var _dot63 = false;
   while (true) {
     var _c3 = peek_char(s);
     if (_c3 && (! whitespace[_c3] && ! delimiters[_c3])) {
-      if (_c3 === ".") {
-        _dot63 = true;
-      }
       _str = _str + read_char(s);
     } else {
       break;
@@ -149,15 +132,11 @@ read_table[""] = function (s) {
             if (_str === "-inf") {
               return(-inf);
             } else {
-              var _n1 = maybe_number(_str);
-              if (real63(_n1)) {
-                return(_n1);
+              var _n = maybe_number(_str);
+              if (real63(_n)) {
+                return(_n);
               } else {
-                if (_dot63 && valid_access63(_str)) {
-                  return(parse_access(_str));
-                } else {
-                  return(_str);
-                }
+                return(_str);
               }
             }
           }
@@ -168,49 +147,49 @@ read_table[""] = function (s) {
 };
 read_table["("] = function (s) {
   read_char(s);
-  var _r18 = undefined;
+  var _r15 = undefined;
   var _l1 = [];
-  while (nil63(_r18)) {
+  while (nil63(_r15)) {
     skip_non_code(s);
     var _c4 = peek_char(s);
     if (_c4 === ")") {
       read_char(s);
-      _r18 = _l1;
+      _r15 = _l1;
     } else {
       if (nil63(_c4)) {
-        _r18 = expected(s, ")");
+        _r15 = expected(s, ")");
       } else {
-        var _x5 = read(s);
-        if (key63(_x5)) {
-          var _k = clip(_x5, 0, edge(_x5));
+        var _x2 = read(s);
+        if (key63(_x2)) {
+          var _k = clip(_x2, 0, edge(_x2));
           var _v = read(s);
           _l1[_k] = _v;
         } else {
-          if (flag63(_x5)) {
-            _l1[clip(_x5, 1)] = true;
+          if (flag63(_x2)) {
+            _l1[clip(_x2, 1)] = true;
           } else {
-            add(_l1, _x5);
+            add(_l1, _x2);
           }
         }
       }
     }
   }
-  return(_r18);
+  return(_r15);
 };
 read_table[")"] = function (s) {
   throw new Error("Unexpected ) at " + s.pos);
 };
 read_table["\""] = function (s) {
   read_char(s);
-  var _r21 = undefined;
+  var _r18 = undefined;
   var _str1 = "\"";
-  while (nil63(_r21)) {
+  while (nil63(_r18)) {
     var _c5 = peek_char(s);
     if (_c5 === "\"") {
-      _r21 = _str1 + read_char(s);
+      _r18 = _str1 + read_char(s);
     } else {
       if (nil63(_c5)) {
-        _r21 = expected(s, "\"");
+        _r18 = expected(s, "\"");
       } else {
         if (_c5 === "\\") {
           _str1 = _str1 + read_char(s);
@@ -219,25 +198,25 @@ read_table["\""] = function (s) {
       }
     }
   }
-  return(_r21);
+  return(_r18);
 };
 read_table["|"] = function (s) {
   read_char(s);
-  var _r23 = undefined;
+  var _r20 = undefined;
   var _str2 = "|";
-  while (nil63(_r23)) {
+  while (nil63(_r20)) {
     var _c6 = peek_char(s);
     if (_c6 === "|") {
-      _r23 = _str2 + read_char(s);
+      _r20 = _str2 + read_char(s);
     } else {
       if (nil63(_c6)) {
-        _r23 = expected(s, "|");
+        _r20 = expected(s, "|");
       } else {
         _str2 = _str2 + read_char(s);
       }
     }
   }
-  return(_r23);
+  return(_r20);
 };
 read_table["'"] = function (s) {
   read_char(s);

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -104,28 +104,11 @@ end
 local function real63(x)
   return(number63(x) and not nan63(x) and not inf63(x))
 end
-local function valid_access63(str)
-  return(_35(str) > 2 and not( "." == char(str, 0)) and not( "." == char(str, edge(str))) and not search(str, ".."))
-end
-local function parse_access(str)
-  return(reduce(function (a, b)
-    local _n = number(a)
-    if is63(_n) then
-      return({"at", b, _n})
-    else
-      return({"get", b, {"quote", a}})
-    end
-  end, reverse(split(str, "."))))
-end
 read_table[""] = function (s)
   local _str = ""
-  local _dot63 = false
   while true do
     local _c3 = peek_char(s)
     if _c3 and (not whitespace[_c3] and not delimiters[_c3]) then
-      if _c3 == "." then
-        _dot63 = true
-      end
       _str = _str .. read_char(s)
     else
       break
@@ -149,15 +132,11 @@ read_table[""] = function (s)
             if _str == "-inf" then
               return(-inf)
             else
-              local _n1 = maybe_number(_str)
-              if real63(_n1) then
-                return(_n1)
+              local _n = maybe_number(_str)
+              if real63(_n) then
+                return(_n)
               else
-                if _dot63 and valid_access63(_str) then
-                  return(parse_access(_str))
-                else
-                  return(_str)
-                end
+                return(_str)
               end
             end
           end
@@ -168,49 +147,49 @@ read_table[""] = function (s)
 end
 read_table["("] = function (s)
   read_char(s)
-  local _r18 = nil
+  local _r15 = nil
   local _l1 = {}
-  while nil63(_r18) do
+  while nil63(_r15) do
     skip_non_code(s)
     local _c4 = peek_char(s)
     if _c4 == ")" then
       read_char(s)
-      _r18 = _l1
+      _r15 = _l1
     else
       if nil63(_c4) then
-        _r18 = expected(s, ")")
+        _r15 = expected(s, ")")
       else
-        local _x5 = read(s)
-        if key63(_x5) then
-          local _k = clip(_x5, 0, edge(_x5))
+        local _x2 = read(s)
+        if key63(_x2) then
+          local _k = clip(_x2, 0, edge(_x2))
           local _v = read(s)
           _l1[_k] = _v
         else
-          if flag63(_x5) then
-            _l1[clip(_x5, 1)] = true
+          if flag63(_x2) then
+            _l1[clip(_x2, 1)] = true
           else
-            add(_l1, _x5)
+            add(_l1, _x2)
           end
         end
       end
     end
   end
-  return(_r18)
+  return(_r15)
 end
 read_table[")"] = function (s)
   error("Unexpected ) at " .. s.pos)
 end
 read_table["\""] = function (s)
   read_char(s)
-  local _r21 = nil
+  local _r18 = nil
   local _str1 = "\""
-  while nil63(_r21) do
+  while nil63(_r18) do
     local _c5 = peek_char(s)
     if _c5 == "\"" then
-      _r21 = _str1 .. read_char(s)
+      _r18 = _str1 .. read_char(s)
     else
       if nil63(_c5) then
-        _r21 = expected(s, "\"")
+        _r18 = expected(s, "\"")
       else
         if _c5 == "\\" then
           _str1 = _str1 .. read_char(s)
@@ -219,25 +198,25 @@ read_table["\""] = function (s)
       end
     end
   end
-  return(_r21)
+  return(_r18)
 end
 read_table["|"] = function (s)
   read_char(s)
-  local _r23 = nil
+  local _r20 = nil
   local _str2 = "|"
-  while nil63(_r23) do
+  while nil63(_r20) do
     local _c6 = peek_char(s)
     if _c6 == "|" then
-      _r23 = _str2 .. read_char(s)
+      _r20 = _str2 .. read_char(s)
     else
       if nil63(_c6) then
-        _r23 = expected(s, "|")
+        _r20 = expected(s, "|")
       else
         _str2 = _str2 .. read_char(s)
       end
     end
   end
-  return(_r23)
+  return(_r20)
 end
 read_table["'"] = function (s)
   read_char(s)

--- a/bin/system.js
+++ b/bin/system.js
@@ -35,7 +35,7 @@ var reload = function (module) {
   return(require(module));
 };
 var run = function (command) {
-  return(child_process.execSync(command)["toString"]());
+  return(child_process.execSync(command).toString());
 };
 exports["read-file"] = read_file;
 exports["write-file"] = write_file;

--- a/reader.l
+++ b/reader.l
@@ -73,28 +73,13 @@
 (define real? (x)
   (and (number? x) (not (nan? x)) (not (inf? x))))
 
-(define valid-access? (str)
-  (and (> (# str) 2)
-       (not (= "." (char str 0)))
-       (not (= "." (char str (edge str))))
-       (not (search str ".."))))
-
-(define parse-access (str)
-  (reduce (fn (a b)
-            (let n (number a)
-              (if (is? n)
-                  `(at ,b ,n)
-                `(get ,b (quote ,a)))))
-          (reverse (split str "."))))
-
 (define-reader ("" s) ; atom
-  (let (str "" dot? false)
+  (let (str "")
     (while true
       (let c (peek-char s)
         (if (and c (and (not (get whitespace c))
                         (not (get delimiters c))))
-            (do (if (= c ".") (set dot? true))
-                (cat! str (read-char s)))
+            (cat! str (read-char s))
           (break))))
   (if (= str "true") true
       (= str "false") false
@@ -104,8 +89,6 @@
       (= str "-inf") -inf
     (let n (maybe-number str)
       (if (real? n) n
-          (and dot? (valid-access? str))
-          (parse-access str)
         str)))))
 
 (define-reader ("(" s)

--- a/test.l
+++ b/test.l
@@ -486,7 +486,6 @@ c"
 (define-test at
   (let l '(a b c d)
     (test= 'a (at l 0))
-    (test= 'a l.0)
     (test= 'b (at l 1))
     (set (at l 0) 9)
     (test= 9 (at l 0))
@@ -498,7 +497,6 @@ c"
     (set (get t 'foo) 'bar)
     (test= 'bar (get t 'foo))
     (test= 'bar (get t "foo"))
-    (test= 'bar t.foo)
     (let k 'foo
       (test= 'bar (get t k)))
     (test= 'bar (get t (cat "f" "oo")))))


### PR DESCRIPTION
I changed my mind. I agree that Lumen doesn't need dot syntax. It interferes with using Lumen to implement support for other Lisps that use dots in ways that aren't necessarily equivalent to `(get a 'b)`.

Instead, I think it would be better to modify `compile-file` so that it reads an expression, expands it, reads the next expression, expands that, etc. That way it would be possible to write a Lumen file that modifies Lumen's reader at compile time, at the top of the file, within a `when-compiling` block.

At that point it'd be straightforward to write a user library that enables dot syntax by modifying `read-table`'s atom reader.