### PR TITLE
Remove dot syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,22 +112,6 @@ hi
 10
 ```
 
-It's common to access the values of a list variable where the position or key is known in advance, so there is a shorthand for that:		
-```		
-> (let x (list foo: 10 bar: 20)		
-    x.bar)		
-20		
-> (let x (list foo: 10 bar: 20)		
-    (get x "bar")) ; equivalent		
-20		
-> (let x (list 10 20 30)		
-    x.2)		
-30		
-> (let x (list 10 20 30)		
-    (at x 2)) ; equivalent		
-30		
-```		
-
 #### Assignment
 Variables and list values can be updated using `set`, which evaluates to the value that it updated:
 ```

--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -759,8 +759,8 @@ compile_function = function (args, body) {
   } else {
     _e40 = _args4;
   }
-  var _args5 = _e40;
-  var _args6 = compile_args(_args5);
+  var _args12 = _e40;
+  var _args5 = compile_args(_args12);
   indent_level = indent_level + 1;
   var __x88 = compile(_body3, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
@@ -784,9 +784,9 @@ compile_function = function (args, body) {
     _tr1 = _tr1 + "\n";
   }
   if (target === "js") {
-    return("function " + _id14 + _args6 + " {\n" + _body4 + _ind + "}" + _tr1);
+    return("function " + _id14 + _args5 + " {\n" + _body4 + _ind + "}" + _tr1);
   } else {
-    return(_p + "function " + _id14 + _args6 + "\n" + _body4 + _ind + _tr1);
+    return(_p + "function " + _id14 + _args5 + "\n" + _body4 + _ind + _tr1);
   }
 };
 var can_return63 = function (form) {
@@ -958,9 +958,9 @@ var lower_function = function (args) {
 var lower_definition = function (kind, args, hoist) {
   var __id23 = args;
   var _name4 = __id23[0];
-  var _args7 = __id23[1];
+  var _args6 = __id23[1];
   var _body8 = cut(__id23, 2);
-  return(add(hoist, [kind, _name4, _args7, lower_body(_body8, true)]));
+  return(add(hoist, [kind, _name4, _args6, lower_body(_body8, true)]));
 };
 var lower_call = function (form, hoist) {
   var _form2 = map(function (x) {
@@ -978,11 +978,11 @@ var lower_pairwise = function (form) {
     var _e4 = [];
     var __id24 = form;
     var _x123 = __id24[0];
-    var _args8 = cut(__id24, 1);
+    var _args7 = cut(__id24, 1);
     reduce(function (a, b) {
       add(_e4, [_x123, a, b]);
       return(a);
-    }, _args8);
+    }, _args7);
     return(join(["and"], reverse(_e4)));
   } else {
     return(form);
@@ -995,10 +995,10 @@ var lower_infix = function (form, hoist) {
   var _form3 = lower_pairwise(form);
   var __id25 = _form3;
   var _x126 = __id25[0];
-  var _args9 = cut(__id25, 1);
+  var _args8 = cut(__id25, 1);
   return(lower(reduce(function (a, b) {
     return([_x126, b, a]);
-  }, reverse(_args9)), hoist));
+  }, reverse(_args8)), hoist));
 };
 var lower_special = function (form, hoist) {
   var _e5 = lower_call(form, hoist);
@@ -1021,33 +1021,33 @@ lower = function (form, hoist, stmt63, tail63) {
         } else {
           var __id26 = form;
           var _x129 = __id26[0];
-          var _args10 = cut(__id26, 1);
+          var _args9 = cut(__id26, 1);
           if (_x129 === "do") {
-            return(lower_do(_args10, hoist, stmt63, tail63));
+            return(lower_do(_args9, hoist, stmt63, tail63));
           } else {
             if (_x129 === "%set") {
-              return(lower_set(_args10, hoist, stmt63, tail63));
+              return(lower_set(_args9, hoist, stmt63, tail63));
             } else {
               if (_x129 === "%if") {
-                return(lower_if(_args10, hoist, stmt63, tail63));
+                return(lower_if(_args9, hoist, stmt63, tail63));
               } else {
                 if (_x129 === "%try") {
-                  return(lower_try(_args10, hoist, tail63));
+                  return(lower_try(_args9, hoist, tail63));
                 } else {
                   if (_x129 === "while") {
-                    return(lower_while(_args10, hoist));
+                    return(lower_while(_args9, hoist));
                   } else {
                     if (_x129 === "%for") {
-                      return(lower_for(_args10, hoist));
+                      return(lower_for(_args9, hoist));
                     } else {
                       if (_x129 === "%function") {
-                        return(lower_function(_args10));
+                        return(lower_function(_args9));
                       } else {
                         if (_x129 === "%local-function" || _x129 === "%global-function") {
-                          return(lower_definition(_x129, _args10, hoist));
+                          return(lower_definition(_x129, _args9, hoist));
                         } else {
                           if (in63(_x129, ["and", "or"])) {
-                            return(lower_short(_x129, _args10, hoist));
+                            return(lower_short(_x129, _args9, hoist));
                           } else {
                             if (statement63(_x129)) {
                               return(lower_special(form, hoist));
@@ -1339,8 +1339,8 @@ setenv("%object", {_stash: true, special: function () {
   return(_s9 + "}");
 }});
 setenv("%literal", {_stash: true, special: function () {
-  var _args12 = unstash(Array.prototype.slice.call(arguments, 0));
-  return(apply(cat, map(compile, _args12)));
+  var _args111 = unstash(Array.prototype.slice.call(arguments, 0));
+  return(apply(cat, map(compile, _args111)));
 }});
 exports.run = run;
 exports.eval = eval;

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -705,8 +705,8 @@ function compile_function(args, body, ...)
   else
     _e32 = _args4
   end
-  local _args5 = _e32
-  local _args6 = compile_args(_args5)
+  local _args12 = _e32
+  local _args5 = compile_args(_args12)
   indent_level = indent_level + 1
   local __x90 = compile(_body3, {_stash = true, stmt = true})
   indent_level = indent_level - 1
@@ -730,9 +730,9 @@ function compile_function(args, body, ...)
     _tr1 = _tr1 .. "\n"
   end
   if target == "js" then
-    return("function " .. _id14 .. _args6 .. " {\n" .. _body4 .. _ind .. "}" .. _tr1)
+    return("function " .. _id14 .. _args5 .. " {\n" .. _body4 .. _ind .. "}" .. _tr1)
   else
-    return(_p .. "function " .. _id14 .. _args6 .. "\n" .. _body4 .. _ind .. _tr1)
+    return(_p .. "function " .. _id14 .. _args5 .. "\n" .. _body4 .. _ind .. _tr1)
   end
 end
 local function can_return63(form)
@@ -904,9 +904,9 @@ end
 local function lower_definition(kind, args, hoist)
   local __id23 = args
   local _name4 = __id23[1]
-  local _args7 = __id23[2]
+  local _args6 = __id23[2]
   local _body8 = cut(__id23, 2)
-  return(add(hoist, {kind, _name4, _args7, lower_body(_body8, true)}))
+  return(add(hoist, {kind, _name4, _args6, lower_body(_body8, true)}))
 end
 local function lower_call(form, hoist)
   local _form2 = map(function (x)
@@ -924,11 +924,11 @@ local function lower_pairwise(form)
     local _e4 = {}
     local __id24 = form
     local _x126 = __id24[1]
-    local _args8 = cut(__id24, 1)
+    local _args7 = cut(__id24, 1)
     reduce(function (a, b)
       add(_e4, {_x126, a, b})
       return(a)
-    end, _args8)
+    end, _args7)
     return(join({"and"}, reverse(_e4)))
   else
     return(form)
@@ -941,10 +941,10 @@ local function lower_infix(form, hoist)
   local _form3 = lower_pairwise(form)
   local __id25 = _form3
   local _x129 = __id25[1]
-  local _args9 = cut(__id25, 1)
+  local _args8 = cut(__id25, 1)
   return(lower(reduce(function (a, b)
     return({_x129, b, a})
-  end, reverse(_args9)), hoist))
+  end, reverse(_args8)), hoist))
 end
 local function lower_special(form, hoist)
   local _e5 = lower_call(form, hoist)
@@ -967,33 +967,33 @@ function lower(form, hoist, stmt63, tail63)
         else
           local __id26 = form
           local _x132 = __id26[1]
-          local _args10 = cut(__id26, 1)
+          local _args9 = cut(__id26, 1)
           if _x132 == "do" then
-            return(lower_do(_args10, hoist, stmt63, tail63))
+            return(lower_do(_args9, hoist, stmt63, tail63))
           else
             if _x132 == "%set" then
-              return(lower_set(_args10, hoist, stmt63, tail63))
+              return(lower_set(_args9, hoist, stmt63, tail63))
             else
               if _x132 == "%if" then
-                return(lower_if(_args10, hoist, stmt63, tail63))
+                return(lower_if(_args9, hoist, stmt63, tail63))
               else
                 if _x132 == "%try" then
-                  return(lower_try(_args10, hoist, tail63))
+                  return(lower_try(_args9, hoist, tail63))
                 else
                   if _x132 == "while" then
-                    return(lower_while(_args10, hoist))
+                    return(lower_while(_args9, hoist))
                   else
                     if _x132 == "%for" then
-                      return(lower_for(_args10, hoist))
+                      return(lower_for(_args9, hoist))
                     else
                       if _x132 == "%function" then
-                        return(lower_function(_args10))
+                        return(lower_function(_args9))
                       else
                         if _x132 == "%local-function" or _x132 == "%global-function" then
-                          return(lower_definition(_x132, _args10, hoist))
+                          return(lower_definition(_x132, _args9, hoist))
                         else
                           if in63(_x132, {"and", "or"}) then
-                            return(lower_short(_x132, _args10, hoist))
+                            return(lower_short(_x132, _args9, hoist))
                           else
                             if statement63(_x132) then
                               return(lower_special(form, hoist))
@@ -1278,7 +1278,7 @@ setenv("%object", {_stash = true, special = function (...)
   return(_s9 .. "}")
 end})
 setenv("%literal", {_stash = true, special = function (...)
-  local _args12 = unstash({...})
-  return(apply(cat, map(compile, _args12)))
+  local _args111 = unstash({...})
+  return(apply(cat, map(compile, _args111)))
 end})
 return({run = run, eval = eval, expand = expand, compile = compile})

--- a/bin/reader.js
+++ b/bin/reader.js
@@ -104,28 +104,11 @@ var maybe_number = function (str) {
 var real63 = function (x) {
   return(number63(x) && ! nan63(x) && ! inf63(x));
 };
-var valid_access63 = function (str) {
-  return(_35(str) > 2 && !( "." === char(str, 0)) && !( "." === char(str, edge(str))) && ! search(str, ".."));
-};
-var parse_access = function (str) {
-  return(reduce(function (a, b) {
-    var _n = number(a);
-    if (is63(_n)) {
-      return(["at", b, _n]);
-    } else {
-      return(["get", b, ["quote", a]]);
-    }
-  }, reverse(split(str, "."))));
-};
 read_table[""] = function (s) {
   var _str = "";
-  var _dot63 = false;
   while (true) {
     var _c3 = peek_char(s);
     if (_c3 && (! whitespace[_c3] && ! delimiters[_c3])) {
-      if (_c3 === ".") {
-        _dot63 = true;
-      }
       _str = _str + read_char(s);
     } else {
       break;
@@ -149,15 +132,11 @@ read_table[""] = function (s) {
             if (_str === "-inf") {
               return(-inf);
             } else {
-              var _n1 = maybe_number(_str);
-              if (real63(_n1)) {
-                return(_n1);
+              var _n = maybe_number(_str);
+              if (real63(_n)) {
+                return(_n);
               } else {
-                if (_dot63 && valid_access63(_str)) {
-                  return(parse_access(_str));
-                } else {
-                  return(_str);
-                }
+                return(_str);
               }
             }
           }
@@ -168,49 +147,49 @@ read_table[""] = function (s) {
 };
 read_table["("] = function (s) {
   read_char(s);
-  var _r18 = undefined;
+  var _r15 = undefined;
   var _l1 = [];
-  while (nil63(_r18)) {
+  while (nil63(_r15)) {
     skip_non_code(s);
     var _c4 = peek_char(s);
     if (_c4 === ")") {
       read_char(s);
-      _r18 = _l1;
+      _r15 = _l1;
     } else {
       if (nil63(_c4)) {
-        _r18 = expected(s, ")");
+        _r15 = expected(s, ")");
       } else {
-        var _x5 = read(s);
-        if (key63(_x5)) {
-          var _k = clip(_x5, 0, edge(_x5));
+        var _x2 = read(s);
+        if (key63(_x2)) {
+          var _k = clip(_x2, 0, edge(_x2));
           var _v = read(s);
           _l1[_k] = _v;
         } else {
-          if (flag63(_x5)) {
-            _l1[clip(_x5, 1)] = true;
+          if (flag63(_x2)) {
+            _l1[clip(_x2, 1)] = true;
           } else {
-            add(_l1, _x5);
+            add(_l1, _x2);
           }
         }
       }
     }
   }
-  return(_r18);
+  return(_r15);
 };
 read_table[")"] = function (s) {
   throw new Error("Unexpected ) at " + s.pos);
 };
 read_table["\""] = function (s) {
   read_char(s);
-  var _r21 = undefined;
+  var _r18 = undefined;
   var _str1 = "\"";
-  while (nil63(_r21)) {
+  while (nil63(_r18)) {
     var _c5 = peek_char(s);
     if (_c5 === "\"") {
-      _r21 = _str1 + read_char(s);
+      _r18 = _str1 + read_char(s);
     } else {
       if (nil63(_c5)) {
-        _r21 = expected(s, "\"");
+        _r18 = expected(s, "\"");
       } else {
         if (_c5 === "\\") {
           _str1 = _str1 + read_char(s);
@@ -219,25 +198,25 @@ read_table["\""] = function (s) {
       }
     }
   }
-  return(_r21);
+  return(_r18);
 };
 read_table["|"] = function (s) {
   read_char(s);
-  var _r23 = undefined;
+  var _r20 = undefined;
   var _str2 = "|";
-  while (nil63(_r23)) {
+  while (nil63(_r20)) {
     var _c6 = peek_char(s);
     if (_c6 === "|") {
-      _r23 = _str2 + read_char(s);
+      _r20 = _str2 + read_char(s);
     } else {
       if (nil63(_c6)) {
-        _r23 = expected(s, "|");
+        _r20 = expected(s, "|");
       } else {
         _str2 = _str2 + read_char(s);
       }
     }
   }
-  return(_r23);
+  return(_r20);
 };
 read_table["'"] = function (s) {
   read_char(s);

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -104,28 +104,11 @@ end
 local function real63(x)
   return(number63(x) and not nan63(x) and not inf63(x))
 end
-local function valid_access63(str)
-  return(_35(str) > 2 and not( "." == char(str, 0)) and not( "." == char(str, edge(str))) and not search(str, ".."))
-end
-local function parse_access(str)
-  return(reduce(function (a, b)
-    local _n = number(a)
-    if is63(_n) then
-      return({"at", b, _n})
-    else
-      return({"get", b, {"quote", a}})
-    end
-  end, reverse(split(str, "."))))
-end
 read_table[""] = function (s)
   local _str = ""
-  local _dot63 = false
   while true do
     local _c3 = peek_char(s)
     if _c3 and (not whitespace[_c3] and not delimiters[_c3]) then
-      if _c3 == "." then
-        _dot63 = true
-      end
       _str = _str .. read_char(s)
     else
       break
@@ -149,15 +132,11 @@ read_table[""] = function (s)
             if _str == "-inf" then
               return(-inf)
             else
-              local _n1 = maybe_number(_str)
-              if real63(_n1) then
-                return(_n1)
+              local _n = maybe_number(_str)
+              if real63(_n) then
+                return(_n)
               else
-                if _dot63 and valid_access63(_str) then
-                  return(parse_access(_str))
-                else
-                  return(_str)
-                end
+                return(_str)
               end
             end
           end
@@ -168,49 +147,49 @@ read_table[""] = function (s)
 end
 read_table["("] = function (s)
   read_char(s)
-  local _r18 = nil
+  local _r15 = nil
   local _l1 = {}
-  while nil63(_r18) do
+  while nil63(_r15) do
     skip_non_code(s)
     local _c4 = peek_char(s)
     if _c4 == ")" then
       read_char(s)
-      _r18 = _l1
+      _r15 = _l1
     else
       if nil63(_c4) then
-        _r18 = expected(s, ")")
+        _r15 = expected(s, ")")
       else
-        local _x5 = read(s)
-        if key63(_x5) then
-          local _k = clip(_x5, 0, edge(_x5))
+        local _x2 = read(s)
+        if key63(_x2) then
+          local _k = clip(_x2, 0, edge(_x2))
           local _v = read(s)
           _l1[_k] = _v
         else
-          if flag63(_x5) then
-            _l1[clip(_x5, 1)] = true
+          if flag63(_x2) then
+            _l1[clip(_x2, 1)] = true
           else
-            add(_l1, _x5)
+            add(_l1, _x2)
           end
         end
       end
     end
   end
-  return(_r18)
+  return(_r15)
 end
 read_table[")"] = function (s)
   error("Unexpected ) at " .. s.pos)
 end
 read_table["\""] = function (s)
   read_char(s)
-  local _r21 = nil
+  local _r18 = nil
   local _str1 = "\""
-  while nil63(_r21) do
+  while nil63(_r18) do
     local _c5 = peek_char(s)
     if _c5 == "\"" then
-      _r21 = _str1 .. read_char(s)
+      _r18 = _str1 .. read_char(s)
     else
       if nil63(_c5) then
-        _r21 = expected(s, "\"")
+        _r18 = expected(s, "\"")
       else
         if _c5 == "\\" then
           _str1 = _str1 .. read_char(s)
@@ -219,25 +198,25 @@ read_table["\""] = function (s)
       end
     end
   end
-  return(_r21)
+  return(_r18)
 end
 read_table["|"] = function (s)
   read_char(s)
-  local _r23 = nil
+  local _r20 = nil
   local _str2 = "|"
-  while nil63(_r23) do
+  while nil63(_r20) do
     local _c6 = peek_char(s)
     if _c6 == "|" then
-      _r23 = _str2 .. read_char(s)
+      _r20 = _str2 .. read_char(s)
     else
       if nil63(_c6) then
-        _r23 = expected(s, "|")
+        _r20 = expected(s, "|")
       else
         _str2 = _str2 .. read_char(s)
       end
     end
   end
-  return(_r23)
+  return(_r20)
 end
 read_table["'"] = function (s)
   read_char(s)

--- a/reader.l
+++ b/reader.l
@@ -73,28 +73,13 @@
 (define real? (x)
   (and (number? x) (not (nan? x)) (not (inf? x))))
 
-(define valid-access? (str)
-  (and (> (# str) 2)
-       (not (= "." (char str 0)))
-       (not (= "." (char str (edge str))))
-       (not (search str ".."))))
-
-(define parse-access (str)
-  (reduce (fn (a b)
-            (let n (number a)
-              (if (is? n)
-                  `(at ,b ,n)
-                `(get ,b (quote ,a)))))
-          (reverse (split str "."))))
-
 (define-reader ("" s) ; atom
-  (let (str "" dot? false)
+  (let (str "")
     (while true
       (let c (peek-char s)
         (if (and c (and (not (get whitespace c))
                         (not (get delimiters c))))
-            (do (if (= c ".") (set dot? true))
-                (cat! str (read-char s)))
+            (cat! str (read-char s))
           (break))))
   (if (= str "true") true
       (= str "false") false
@@ -103,10 +88,7 @@
       (= str "inf") inf
       (= str "-inf") -inf
     (let n (maybe-number str)
-      (if (real? n) n
-          (and dot? (valid-access? str))
-          (parse-access str)
-        str)))))
+      (if (real? n) n str)))))
 
 (define-reader ("(" s)
   (read-char s)

--- a/test.l
+++ b/test.l
@@ -486,7 +486,6 @@ c"
 (define-test at
   (let l '(a b c d)
     (test= 'a (at l 0))
-    (test= 'a l.0)
     (test= 'b (at l 1))
     (set (at l 0) 9)
     (test= 9 (at l 0))
@@ -498,7 +497,6 @@ c"
     (set (get t 'foo) 'bar)
     (test= 'bar (get t 'foo))
     (test= 'bar (get t "foo"))
-    (test= 'bar t.foo)
     (let k 'foo
       (test= 'bar (get t k)))
     (test= 'bar (get t (cat "f" "oo")))))


### PR DESCRIPTION
I changed my mind. I agree that Lumen doesn't need dot syntax. It interferes with using Lumen to implement support for other Lisps that use dots in ways that aren't necessarily equivalent to `(get a 'b)`.

Instead, I think it would be better to modify `compile-file` so that it reads an expression, expands it, reads the next expression, expands that, etc. That way it would be possible to write a Lumen file that modifies Lumen's reader at compile time, at the top of the file, within a `when-compiling` block.

At that point it'd be straightforward to write a user library that enables dot syntax by modifying `read-table`'s atom reader.