### PR TITLE
Update DEFINE-MACRO/SPECIAL/SYMBOL

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -5,13 +5,13 @@ var getenv = function (k, p) {
     while (_i >= 0) {
       var _b = environment[_i][k];
       if (is63(_b)) {
-        var _e21;
+        var _e8;
         if (p) {
-          _e21 = _b[p];
+          _e8 = _b[p];
         } else {
-          _e21 = _b;
+          _e8 = _b;
         }
-        return(_e21);
+        return(_e8);
       } else {
         _i = _i - 1;
       }
@@ -84,13 +84,13 @@ var stash42 = function (args) {
     var _k = undefined;
     for (_k in __o) {
       var _v = __o[_k];
-      var _e22;
+      var _e9;
       if (numeric63(_k)) {
-        _e22 = parseInt(_k);
+        _e9 = parseInt(_k);
       } else {
-        _e22 = _k;
+        _e9 = _k;
       }
-      var _k1 = _e22;
+      var _k1 = _e9;
       if (! number63(_k1)) {
         add(_l, literal(_k1));
         add(_l, _v);
@@ -121,28 +121,28 @@ bind = function (lh, rh) {
     var _k2 = undefined;
     for (_k2 in __o1) {
       var _v1 = __o1[_k2];
-      var _e23;
+      var _e10;
       if (numeric63(_k2)) {
-        _e23 = parseInt(_k2);
+        _e10 = parseInt(_k2);
       } else {
-        _e23 = _k2;
+        _e10 = _k2;
       }
-      var _k3 = _e23;
-      var _e24;
+      var _k3 = _e10;
+      var _e11;
       if (_k3 === "rest") {
-        _e24 = ["cut", _id, _35(lh)];
+        _e11 = ["cut", _id, _35(lh)];
       } else {
-        _e24 = ["get", _id, ["quote", bias(_k3)]];
+        _e11 = ["get", _id, ["quote", bias(_k3)]];
       }
-      var _x5 = _e24;
+      var _x5 = _e11;
       if (is63(_k3)) {
-        var _e25;
+        var _e12;
         if (_v1 === true) {
-          _e25 = _k3;
+          _e12 = _k3;
         } else {
-          _e25 = _v1;
+          _e12 = _v1;
         }
-        var _k4 = _e25;
+        var _k4 = _e12;
         _bs = join(_bs, bind(_k4, _x5));
       }
     }
@@ -166,38 +166,38 @@ bind42 = function (args, body) {
     return([_args1, join(["let", [args, rest()]], body)]);
   } else {
     var _bs1 = [];
-    var _r21 = unique("r");
+    var _r20 = unique("r");
     var __o2 = args;
     var _k5 = undefined;
     for (_k5 in __o2) {
       var _v2 = __o2[_k5];
-      var _e26;
+      var _e13;
       if (numeric63(_k5)) {
-        _e26 = parseInt(_k5);
+        _e13 = parseInt(_k5);
       } else {
-        _e26 = _k5;
+        _e13 = _k5;
       }
-      var _k6 = _e26;
+      var _k6 = _e13;
       if (number63(_k6)) {
         if (atom63(_v2)) {
           add(_args1, _v2);
         } else {
-          var _x30 = unique("x");
-          add(_args1, _x30);
-          _bs1 = join(_bs1, [_v2, _x30]);
+          var _x23 = unique("x");
+          add(_args1, _x23);
+          _bs1 = join(_bs1, [_v2, _x23]);
         }
       }
     }
     if (keys63(args)) {
-      _bs1 = join(_bs1, [_r21, rest()]);
+      _bs1 = join(_bs1, [_r20, rest()]);
       var _n3 = _35(_args1);
       var _i5 = 0;
       while (_i5 < _n3) {
         var _v3 = _args1[_i5];
-        _bs1 = join(_bs1, [_v3, ["destash!", _v3, _r21]]);
+        _bs1 = join(_bs1, [_v3, ["destash!", _v3, _r20]]);
         _i5 = _i5 + 1;
       }
-      _bs1 = join(_bs1, [keys(args), _r21]);
+      _bs1 = join(_bs1, [keys(args), _r20]);
     }
     return([_args1, join(["let", _bs1], body)]);
   }
@@ -214,40 +214,40 @@ var can_unquote63 = function (depth) {
 var quasisplice63 = function (x, depth) {
   return(can_unquote63(depth) && ! atom63(x) && hd(x) === "unquote-splicing");
 };
-var expand_local = function (_x38) {
-  var __id1 = _x38;
-  var _x39 = __id1[0];
+var expand_local = function (_x31) {
+  var __id1 = _x31;
+  var _x32 = __id1[0];
   var _name = __id1[1];
   var _value = __id1[2];
   setenv(_name, {_stash: true, variable: true});
   return(["%local", _name, macroexpand(_value)]);
 };
-var expand_function = function (_x41) {
-  var __id2 = _x41;
-  var _x42 = __id2[0];
+var expand_function = function (_x34) {
+  var __id2 = _x34;
+  var _x35 = __id2[0];
   var _args = __id2[1];
   var _body = cut(__id2, 2);
   add(environment, {});
   var __o3 = _args;
   var __i6 = undefined;
   for (__i6 in __o3) {
-    var __x43 = __o3[__i6];
-    var _e27;
+    var __x36 = __o3[__i6];
+    var _e14;
     if (numeric63(__i6)) {
-      _e27 = parseInt(__i6);
+      _e14 = parseInt(__i6);
     } else {
-      _e27 = __i6;
+      _e14 = __i6;
     }
-    var __i61 = _e27;
-    setenv(__x43, {_stash: true, variable: true});
+    var __i61 = _e14;
+    setenv(__x36, {_stash: true, variable: true});
   }
-  var __x44 = join(["%function", _args], macroexpand(_body));
+  var __x37 = join(["%function", _args], macroexpand(_body));
   drop(environment);
-  return(__x44);
+  return(__x37);
 };
-var expand_definition = function (_x46) {
-  var __id3 = _x46;
-  var _x47 = __id3[0];
+var expand_definition = function (_x39) {
+  var __id3 = _x39;
+  var _x40 = __id3[0];
   var _name1 = __id3[1];
   var _args11 = __id3[2];
   var _body1 = cut(__id3, 3);
@@ -255,25 +255,25 @@ var expand_definition = function (_x46) {
   var __o4 = _args11;
   var __i7 = undefined;
   for (__i7 in __o4) {
-    var __x48 = __o4[__i7];
-    var _e28;
+    var __x41 = __o4[__i7];
+    var _e15;
     if (numeric63(__i7)) {
-      _e28 = parseInt(__i7);
+      _e15 = parseInt(__i7);
     } else {
-      _e28 = __i7;
+      _e15 = __i7;
     }
-    var __i71 = _e28;
-    setenv(__x48, {_stash: true, variable: true});
+    var __i71 = _e15;
+    setenv(__x41, {_stash: true, variable: true});
   }
-  var __x49 = join([_x47, _name1, _args11], macroexpand(_body1));
+  var __x42 = join([_x40, _name1, _args11], macroexpand(_body1));
   drop(environment);
-  return(__x49);
+  return(__x42);
 };
 var expand_macro = function (form) {
   return(macroexpand(expand1(form)));
 };
-expand1 = function (_x51) {
-  var __id4 = _x51;
+expand1 = function (_x44) {
+  var __id4 = _x44;
   var _name2 = __id4[0];
   var _body2 = cut(__id4, 1);
   return(apply(macro_function(_name2), _body2));
@@ -285,20 +285,20 @@ macroexpand = function (form) {
     if (atom63(form)) {
       return(form);
     } else {
-      var _x52 = hd(form);
-      if (_x52 === "%local") {
+      var _x45 = hd(form);
+      if (_x45 === "%local") {
         return(expand_local(form));
       } else {
-        if (_x52 === "%function") {
+        if (_x45 === "%function") {
           return(expand_function(form));
         } else {
-          if (_x52 === "%global-function") {
+          if (_x45 === "%global-function") {
             return(expand_definition(form));
           } else {
-            if (_x52 === "%local-function") {
+            if (_x45 === "%local-function") {
               return(expand_definition(form));
             } else {
-              if (macro63(_x52)) {
+              if (macro63(_x45)) {
                 return(expand_macro(form));
               } else {
                 return(map(macroexpand, form));
@@ -316,34 +316,34 @@ var quasiquote_list = function (form, depth) {
   var _k7 = undefined;
   for (_k7 in __o5) {
     var _v4 = __o5[_k7];
-    var _e29;
+    var _e16;
     if (numeric63(_k7)) {
-      _e29 = parseInt(_k7);
+      _e16 = parseInt(_k7);
     } else {
-      _e29 = _k7;
+      _e16 = _k7;
     }
-    var _k8 = _e29;
+    var _k8 = _e16;
     if (! number63(_k8)) {
-      var _e30;
+      var _e17;
       if (quasisplice63(_v4, depth)) {
-        _e30 = quasiexpand(_v4[1]);
+        _e17 = quasiexpand(_v4[1]);
       } else {
-        _e30 = quasiexpand(_v4, depth);
+        _e17 = quasiexpand(_v4, depth);
       }
-      var _v5 = _e30;
+      var _v5 = _e17;
       last(_xs)[_k8] = _v5;
     }
   }
-  var __x55 = form;
+  var __x48 = form;
   var __i9 = 0;
-  while (__i9 < _35(__x55)) {
-    var _x56 = __x55[__i9];
-    if (quasisplice63(_x56, depth)) {
-      var _x57 = quasiexpand(_x56[1]);
-      add(_xs, _x57);
+  while (__i9 < _35(__x48)) {
+    var _x49 = __x48[__i9];
+    if (quasisplice63(_x49, depth)) {
+      var _x50 = quasiexpand(_x49[1]);
+      add(_xs, _x50);
       add(_xs, ["list"]);
     } else {
-      add(last(_xs), quasiexpand(_x56, depth));
+      add(last(_xs), quasiexpand(_x49, depth));
     }
     __i9 = __i9 + 1;
   }
@@ -393,8 +393,8 @@ quasiexpand = function (form, depth) {
     }
   }
 };
-expand_if = function (_x61) {
-  var __id5 = _x61;
+expand_if = function (_x54) {
+  var __id5 = _x54;
   var _a = __id5[0];
   var _b2 = __id5[1];
   var _c = cut(__id5, 2);
@@ -455,59 +455,59 @@ mapo = function (f, t) {
   var _k9 = undefined;
   for (_k9 in __o7) {
     var _v6 = __o7[_k9];
-    var _e31;
+    var _e18;
     if (numeric63(_k9)) {
-      _e31 = parseInt(_k9);
+      _e18 = parseInt(_k9);
     } else {
-      _e31 = _k9;
+      _e18 = _k9;
     }
-    var _k10 = _e31;
-    var _x65 = f(_v6);
-    if (is63(_x65)) {
+    var _k10 = _e18;
+    var _x58 = f(_v6);
+    if (is63(_x58)) {
       add(_o6, literal(_k10));
-      add(_o6, _x65);
+      add(_o6, _x58);
     }
   }
   return(_o6);
 };
+var __x60 = [];
+var __x61 = [];
+__x61.js = "!";
+__x61.lua = "not";
+__x60["not"] = __x61;
+var __x62 = [];
+__x62["*"] = true;
+__x62["/"] = true;
+__x62["%"] = true;
+var __x63 = [];
+__x63["+"] = true;
+__x63["-"] = true;
+var __x64 = [];
+var __x65 = [];
+__x65.js = "+";
+__x65.lua = "..";
+__x64.cat = __x65;
+var __x66 = [];
+__x66["<"] = true;
+__x66[">"] = true;
+__x66["<="] = true;
+__x66[">="] = true;
 var __x67 = [];
 var __x68 = [];
-__x68.js = "!";
-__x68.lua = "not";
-__x67["not"] = __x68;
+__x68.js = "===";
+__x68.lua = "==";
+__x67["="] = __x68;
 var __x69 = [];
-__x69["*"] = true;
-__x69["/"] = true;
-__x69["%"] = true;
 var __x70 = [];
-__x70["+"] = true;
-__x70["-"] = true;
+__x70.js = "&&";
+__x70.lua = "and";
+__x69["and"] = __x70;
 var __x71 = [];
 var __x72 = [];
-__x72.js = "+";
-__x72.lua = "..";
-__x71.cat = __x72;
-var __x73 = [];
-__x73["<"] = true;
-__x73[">"] = true;
-__x73["<="] = true;
-__x73[">="] = true;
-var __x74 = [];
-var __x75 = [];
-__x75.js = "===";
-__x75.lua = "==";
-__x74["="] = __x75;
-var __x76 = [];
-var __x77 = [];
-__x77.js = "&&";
-__x77.lua = "and";
-__x76["and"] = __x77;
-var __x78 = [];
-var __x79 = [];
-__x79.js = "||";
-__x79.lua = "or";
-__x78["or"] = __x79;
-var infix = [__x67, __x69, __x70, __x71, __x73, __x74, __x76, __x78];
+__x72.js = "||";
+__x72.lua = "or";
+__x71["or"] = __x72;
+var infix = [__x60, __x62, __x63, __x64, __x66, __x67, __x69, __x71];
 var unary63 = function (form) {
   return(two63(form) && in63(hd(form), ["not", "-"]));
 };
@@ -520,13 +520,13 @@ var precedence = function (form) {
     var _k11 = undefined;
     for (_k11 in __o8) {
       var _v7 = __o8[_k11];
-      var _e32;
+      var _e19;
       if (numeric63(_k11)) {
-        _e32 = parseInt(_k11);
+        _e19 = parseInt(_k11);
       } else {
-        _e32 = _k11;
+        _e19 = _k11;
       }
-      var _k12 = _e32;
+      var _k12 = _e19;
       if (_v7[hd(form)]) {
         return(index(_k12));
       }
@@ -536,12 +536,12 @@ var precedence = function (form) {
 };
 var getop = function (op) {
   return(find(function (level) {
-    var _x81 = level[op];
-    if (_x81 === true) {
+    var _x74 = level[op];
+    if (_x74 === true) {
       return(op);
     } else {
-      if (is63(_x81)) {
-        return(_x81[target]);
+      if (is63(_x74)) {
+        return(_x74[target]);
       }
     }
   }, infix));
@@ -555,11 +555,11 @@ infix_operator63 = function (x) {
 var compile_args = function (args) {
   var _s1 = "(";
   var _c1 = "";
-  var __x82 = args;
+  var __x75 = args;
   var __i15 = 0;
-  while (__i15 < _35(__x82)) {
-    var _x83 = __x82[__i15];
-    _s1 = _s1 + _c1 + compile(_x83);
+  while (__i15 < _35(__x75)) {
+    var _x76 = __x75[__i15];
+    _s1 = _s1 + _c1 + compile(_x76);
     _c1 = ", ";
     __i15 = __i15 + 1;
   }
@@ -570,48 +570,48 @@ var escape_newlines = function (s) {
   var _i16 = 0;
   while (_i16 < _35(s)) {
     var _c2 = char(s, _i16);
-    var _e33;
+    var _e20;
     if (_c2 === "\n") {
-      _e33 = "\\n";
+      _e20 = "\\n";
     } else {
-      _e33 = _c2;
+      _e20 = _c2;
     }
-    _s11 = _s11 + _e33;
+    _s11 = _s11 + _e20;
     _i16 = _i16 + 1;
   }
   return(_s11);
 };
 var id = function (id) {
-  var _e34;
+  var _e21;
   if (number_code63(code(id, 0))) {
-    _e34 = "_";
+    _e21 = "_";
   } else {
-    _e34 = "";
+    _e21 = "";
   }
-  var _id11 = _e34;
+  var _id11 = _e21;
   var _i17 = 0;
   while (_i17 < _35(id)) {
     var _c3 = char(id, _i17);
     var _n9 = code(_c3);
-    var _e35;
+    var _e22;
     if (_c3 === "-" && !( id === "-")) {
-      _e35 = "_";
+      _e22 = "_";
     } else {
-      var _e36;
+      var _e23;
       if (valid_code63(_n9)) {
-        _e36 = _c3;
+        _e23 = _c3;
       } else {
-        var _e37;
+        var _e24;
         if (_i17 === 0) {
-          _e37 = "_" + _n9;
+          _e24 = "_" + _n9;
         } else {
-          _e37 = _n9;
+          _e24 = _n9;
         }
-        _e36 = _e37;
+        _e23 = _e24;
       }
-      _e35 = _e36;
+      _e22 = _e23;
     }
-    var _c11 = _e35;
+    var _c11 = _e22;
     _id11 = _id11 + _c11;
     _i17 = _i17 + 1;
   }
@@ -681,9 +681,9 @@ var terminator = function (stmt63) {
 };
 var compile_special = function (form, stmt63) {
   var __id6 = form;
-  var _x84 = __id6[0];
+  var _x77 = __id6[0];
   var _args2 = cut(__id6, 1);
-  var __id7 = getenv(_x84);
+  var __id7 = getenv(_x77);
   var _special = __id7.special;
   var _stmt = __id7.stmt;
   var _self_tr63 = __id7.tr;
@@ -704,18 +704,18 @@ var compile_call = function (form) {
   }
 };
 var op_delims = function (parent, child) {
-  var __r58 = unstash(Array.prototype.slice.call(arguments, 2));
-  var _parent = destash33(parent, __r58);
-  var _child = destash33(child, __r58);
-  var __id8 = __r58;
+  var __r57 = unstash(Array.prototype.slice.call(arguments, 2));
+  var _parent = destash33(parent, __r57);
+  var _child = destash33(child, __r57);
+  var __id8 = __r57;
   var _right = __id8.right;
-  var _e38;
+  var _e25;
   if (_right) {
-    _e38 = _6261;
+    _e25 = _6261;
   } else {
-    _e38 = _62;
+    _e25 = _62;
   }
-  if (_e38(precedence(_child), precedence(_parent))) {
+  if (_e25(precedence(_child), precedence(_parent))) {
     return(["(", ")"]);
   } else {
     return(["", ""]);
@@ -743,46 +743,46 @@ var compile_infix = function (form) {
   }
 };
 compile_function = function (args, body) {
-  var __r60 = unstash(Array.prototype.slice.call(arguments, 2));
-  var _args4 = destash33(args, __r60);
-  var _body3 = destash33(body, __r60);
-  var __id13 = __r60;
+  var __r59 = unstash(Array.prototype.slice.call(arguments, 2));
+  var _args4 = destash33(args, __r59);
+  var _body3 = destash33(body, __r59);
+  var __id13 = __r59;
   var _name3 = __id13.name;
   var _prefix = __id13.prefix;
-  var _e39;
+  var _e26;
   if (_name3) {
-    _e39 = compile(_name3);
+    _e26 = compile(_name3);
   } else {
-    _e39 = "";
+    _e26 = "";
   }
-  var _id14 = _e39;
-  var _e40;
+  var _id14 = _e26;
+  var _e27;
   if (target === "lua" && _args4.rest) {
-    _e40 = join(_args4, ["|...|"]);
+    _e27 = join(_args4, ["|...|"]);
   } else {
-    _e40 = _args4;
+    _e27 = _args4;
   }
-  var _args12 = _e40;
+  var _args12 = _e27;
   var _args5 = compile_args(_args12);
   indent_level = indent_level + 1;
-  var __x88 = compile(_body3, {_stash: true, stmt: true});
+  var __x81 = compile(_body3, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var _body4 = __x88;
+  var _body4 = __x81;
   var _ind = indentation();
-  var _e41;
+  var _e28;
   if (_prefix) {
-    _e41 = _prefix + " ";
+    _e28 = _prefix + " ";
   } else {
-    _e41 = "";
+    _e28 = "";
   }
-  var _p = _e41;
-  var _e42;
+  var _p = _e28;
+  var _e29;
   if (target === "js") {
-    _e42 = "";
+    _e29 = "";
   } else {
-    _e42 = "end";
+    _e29 = "end";
   }
-  var _tr1 = _e42;
+  var _tr1 = _e29;
   if (_name3) {
     _tr1 = _tr1 + "\n";
   }
@@ -796,9 +796,9 @@ var can_return63 = function (form) {
   return(is63(form) && (atom63(form) || !( hd(form) === "return") && ! statement63(hd(form))));
 };
 compile = function (form) {
-  var __r62 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _form = destash33(form, __r62);
-  var __id15 = __r62;
+  var __r61 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _form = destash33(form, __r61);
+  var __id15 = __r61;
   var _stmt1 = __id15.stmt;
   if (nil63(_form)) {
     return("");
@@ -807,26 +807,26 @@ compile = function (form) {
       return(compile_special(_form, _stmt1));
     } else {
       var _tr2 = terminator(_stmt1);
-      var _e43;
+      var _e30;
       if (_stmt1) {
-        _e43 = indentation();
+        _e30 = indentation();
       } else {
-        _e43 = "";
+        _e30 = "";
       }
-      var _ind1 = _e43;
-      var _e44;
+      var _ind1 = _e30;
+      var _e31;
       if (atom63(_form)) {
-        _e44 = compile_atom(_form);
+        _e31 = compile_atom(_form);
       } else {
-        var _e45;
+        var _e32;
         if (infix63(hd(_form))) {
-          _e45 = compile_infix(_form);
+          _e32 = compile_infix(_form);
         } else {
-          _e45 = compile_call(_form);
+          _e32 = compile_call(_form);
         }
-        _e44 = _e45;
+        _e31 = _e32;
       }
-      var _form1 = _e44;
+      var _form1 = _e31;
       return(_ind1 + _form1 + _tr2);
     }
   }
@@ -858,11 +858,11 @@ var standalone63 = function (form) {
   return(! atom63(form) && ! infix63(hd(form)) && ! literal63(form) && !( "get" === hd(form)) || id_literal63(form));
 };
 var lower_do = function (args, hoist, stmt63, tail63) {
-  var __x93 = almost(args);
+  var __x86 = almost(args);
   var __i18 = 0;
-  while (__i18 < _35(__x93)) {
-    var _x94 = __x93[__i18];
-    var __y = lower(_x94, hoist, stmt63);
+  while (__i18 < _35(__x86)) {
+    var _x87 = __x86[__i18];
+    var __y = lower(_x87, hoist, stmt63);
     if (yes(__y)) {
       var _e1 = __y;
       if (standalone63(_e1)) {
@@ -893,19 +893,19 @@ var lower_if = function (args, hoist, stmt63, tail63) {
   var _then = __id17[1];
   var _else = __id17[2];
   if (stmt63) {
-    var _e47;
+    var _e34;
     if (is63(_else)) {
-      _e47 = [lower_body([_else], tail63)];
+      _e34 = [lower_body([_else], tail63)];
     }
-    return(add(hoist, join(["%if", lower(_cond, hoist), lower_body([_then], tail63)], _e47)));
+    return(add(hoist, join(["%if", lower(_cond, hoist), lower_body([_then], tail63)], _e34)));
   } else {
     var _e3 = unique("e");
     add(hoist, ["%local", _e3]);
-    var _e46;
+    var _e33;
     if (is63(_else)) {
-      _e46 = [lower(["%set", _e3, _else])];
+      _e33 = [lower(["%set", _e3, _else])];
     }
-    add(hoist, join(["%if", lower(_cond, hoist), lower(["%set", _e3, _then])], _e46));
+    add(hoist, join(["%if", lower(_cond, hoist), lower(["%set", _e3, _then])], _e33));
     return(_e3);
   }
 };
@@ -917,13 +917,13 @@ var lower_short = function (x, args, hoist) {
   var _b11 = lower(_b5, _hoist1);
   if (some63(_hoist1)) {
     var _id19 = unique("id");
-    var _e48;
+    var _e35;
     if (x === "and") {
-      _e48 = ["%if", _id19, _b5, _id19];
+      _e35 = ["%if", _id19, _b5, _id19];
     } else {
-      _e48 = ["%if", _id19, _id19, _b5];
+      _e35 = ["%if", _id19, _id19, _b5];
     }
-    return(lower(["do", ["%local", _id19, _a3], _e48], hoist));
+    return(lower(["do", ["%local", _id19, _a3], _e35], hoist));
   } else {
     return([x, lower(_a3, hoist), _b11]);
   }
@@ -937,13 +937,13 @@ var lower_while = function (args, hoist) {
   var _body5 = cut(__id20, 1);
   var _pre = [];
   var _c5 = lower(_c4, _pre);
-  var _e49;
+  var _e36;
   if (none63(_pre)) {
-    _e49 = ["while", _c5, lower_body(_body5)];
+    _e36 = ["while", _c5, lower_body(_body5)];
   } else {
-    _e49 = ["while", true, join(["do"], _pre, [["%if", ["not", _c5], ["break"]], lower_body(_body5)])];
+    _e36 = ["while", true, join(["do"], _pre, [["%if", ["not", _c5], ["break"]], lower_body(_body5)])];
   }
-  return(add(hoist, _e49));
+  return(add(hoist, _e36));
 };
 var lower_for = function (args, hoist) {
   var __id21 = args;
@@ -980,10 +980,10 @@ var lower_pairwise = function (form) {
   if (pairwise63(form)) {
     var _e4 = [];
     var __id24 = form;
-    var _x123 = __id24[0];
+    var _x116 = __id24[0];
     var _args7 = cut(__id24, 1);
     reduce(function (a, b) {
-      add(_e4, [_x123, a, b]);
+      add(_e4, [_x116, a, b]);
       return(a);
     }, _args7);
     return(join(["and"], reverse(_e4)));
@@ -997,10 +997,10 @@ var lower_infix63 = function (form) {
 var lower_infix = function (form, hoist) {
   var _form3 = lower_pairwise(form);
   var __id25 = _form3;
-  var _x126 = __id25[0];
+  var _x119 = __id25[0];
   var _args8 = cut(__id25, 1);
   return(lower(reduce(function (a, b) {
-    return([_x126, b, a]);
+    return([_x119, b, a]);
   }, reverse(_args8)), hoist));
 };
 var lower_special = function (form, hoist) {
@@ -1023,36 +1023,36 @@ lower = function (form, hoist, stmt63, tail63) {
           return(lower_infix(form, hoist));
         } else {
           var __id26 = form;
-          var _x129 = __id26[0];
+          var _x122 = __id26[0];
           var _args9 = cut(__id26, 1);
-          if (_x129 === "do") {
+          if (_x122 === "do") {
             return(lower_do(_args9, hoist, stmt63, tail63));
           } else {
-            if (_x129 === "%set") {
+            if (_x122 === "%set") {
               return(lower_set(_args9, hoist, stmt63, tail63));
             } else {
-              if (_x129 === "%if") {
+              if (_x122 === "%if") {
                 return(lower_if(_args9, hoist, stmt63, tail63));
               } else {
-                if (_x129 === "%try") {
+                if (_x122 === "%try") {
                   return(lower_try(_args9, hoist, tail63));
                 } else {
-                  if (_x129 === "while") {
+                  if (_x122 === "while") {
                     return(lower_while(_args9, hoist));
                   } else {
-                    if (_x129 === "%for") {
+                    if (_x122 === "%for") {
                       return(lower_for(_args9, hoist));
                     } else {
-                      if (_x129 === "%function") {
+                      if (_x122 === "%function") {
                         return(lower_function(_args9));
                       } else {
-                        if (_x129 === "%local-function" || _x129 === "%global-function") {
-                          return(lower_definition(_x129, _args9, hoist));
+                        if (_x122 === "%local-function" || _x122 === "%global-function") {
+                          return(lower_definition(_x122, _args9, hoist));
                         } else {
-                          if (in63(_x129, ["and", "or"])) {
-                            return(lower_short(_x129, _args9, hoist));
+                          if (in63(_x122, ["and", "or"])) {
+                            return(lower_short(_x122, _args9, hoist));
                           } else {
-                            if (statement63(_x129)) {
+                            if (statement63(_x122)) {
                               return(lower_special(form, hoist));
                             } else {
                               return(lower_call(form, hoist));
@@ -1086,95 +1086,95 @@ eval = function (form) {
   return(_37result);
 };
 setenv("do", {_stash: true, special: function () {
-  var _forms1 = unstash(Array.prototype.slice.call(arguments, 0));
-  var _s3 = "";
-  var __x134 = _forms1;
-  var __i20 = 0;
-  while (__i20 < _35(__x134)) {
-    var _x135 = __x134[__i20];
-    _s3 = _s3 + compile(_x135, {_stash: true, stmt: true});
-    if (! atom63(_x135)) {
-      if (hd(_x135) === "return" || hd(_x135) === "break") {
+  var _forms = unstash(Array.prototype.slice.call(arguments, 0));
+  var _s2 = "";
+  var __x125 = _forms;
+  var __i19 = 0;
+  while (__i19 < _35(__x125)) {
+    var _x126 = __x125[__i19];
+    _s2 = _s2 + compile(_x126, {_stash: true, stmt: true});
+    if (! atom63(_x126)) {
+      if (hd(_x126) === "return" || hd(_x126) === "break") {
         break;
       }
     }
-    __i20 = __i20 + 1;
+    __i19 = __i19 + 1;
   }
-  return(_s3);
+  return(_s2);
 }, stmt: true, tr: true});
 setenv("%if", {_stash: true, special: function (cond, cons, alt) {
-  var _cond2 = compile(cond);
+  var _cond1 = compile(cond);
   indent_level = indent_level + 1;
-  var __x138 = compile(cons, {_stash: true, stmt: true});
+  var __x127 = compile(cons, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var _cons1 = __x138;
-  var _e50;
+  var _cons = __x127;
+  var _e37;
   if (alt) {
     indent_level = indent_level + 1;
-    var __x139 = compile(alt, {_stash: true, stmt: true});
+    var __x128 = compile(alt, {_stash: true, stmt: true});
     indent_level = indent_level - 1;
-    _e50 = __x139;
+    _e37 = __x128;
   }
-  var _alt1 = _e50;
-  var _ind3 = indentation();
-  var _s5 = "";
+  var _alt = _e37;
+  var _ind2 = indentation();
+  var _s3 = "";
   if (target === "js") {
-    _s5 = _s5 + _ind3 + "if (" + _cond2 + ") {\n" + _cons1 + _ind3 + "}";
+    _s3 = _s3 + _ind2 + "if (" + _cond1 + ") {\n" + _cons + _ind2 + "}";
   } else {
-    _s5 = _s5 + _ind3 + "if " + _cond2 + " then\n" + _cons1;
+    _s3 = _s3 + _ind2 + "if " + _cond1 + " then\n" + _cons;
   }
-  if (_alt1 && target === "js") {
-    _s5 = _s5 + " else {\n" + _alt1 + _ind3 + "}";
+  if (_alt && target === "js") {
+    _s3 = _s3 + " else {\n" + _alt + _ind2 + "}";
   } else {
-    if (_alt1) {
-      _s5 = _s5 + _ind3 + "else\n" + _alt1;
+    if (_alt) {
+      _s3 = _s3 + _ind2 + "else\n" + _alt;
     }
   }
   if (target === "lua") {
-    return(_s5 + _ind3 + "end\n");
+    return(_s3 + _ind2 + "end\n");
   } else {
-    return(_s5 + "\n");
+    return(_s3 + "\n");
   }
 }, stmt: true, tr: true});
 setenv("while", {_stash: true, special: function (cond, form) {
-  var _cond4 = compile(cond);
+  var _cond2 = compile(cond);
   indent_level = indent_level + 1;
-  var __x141 = compile(form, {_stash: true, stmt: true});
+  var __x129 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var _body10 = __x141;
-  var _ind5 = indentation();
+  var _body9 = __x129;
+  var _ind3 = indentation();
   if (target === "js") {
-    return(_ind5 + "while (" + _cond4 + ") {\n" + _body10 + _ind5 + "}\n");
+    return(_ind3 + "while (" + _cond2 + ") {\n" + _body9 + _ind3 + "}\n");
   } else {
-    return(_ind5 + "while " + _cond4 + " do\n" + _body10 + _ind5 + "end\n");
+    return(_ind3 + "while " + _cond2 + " do\n" + _body9 + _ind3 + "end\n");
   }
 }, stmt: true, tr: true});
 setenv("%for", {_stash: true, special: function (t, k, form) {
-  var _t2 = compile(t);
-  var _ind7 = indentation();
+  var _t1 = compile(t);
+  var _ind4 = indentation();
   indent_level = indent_level + 1;
-  var __x143 = compile(form, {_stash: true, stmt: true});
+  var __x130 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var _body12 = __x143;
+  var _body10 = __x130;
   if (target === "lua") {
-    return(_ind7 + "for " + k + " in next, " + _t2 + " do\n" + _body12 + _ind7 + "end\n");
+    return(_ind4 + "for " + k + " in next, " + _t1 + " do\n" + _body10 + _ind4 + "end\n");
   } else {
-    return(_ind7 + "for (" + k + " in " + _t2 + ") {\n" + _body12 + _ind7 + "}\n");
+    return(_ind4 + "for (" + k + " in " + _t1 + ") {\n" + _body10 + _ind4 + "}\n");
   }
 }, stmt: true, tr: true});
 setenv("%try", {_stash: true, special: function (form) {
-  var _e8 = unique("e");
-  var _ind9 = indentation();
+  var _e6 = unique("e");
+  var _ind5 = indentation();
   indent_level = indent_level + 1;
-  var __x148 = compile(form, {_stash: true, stmt: true});
+  var __x131 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var _body14 = __x148;
-  var _hf1 = ["return", ["%array", false, _e8]];
+  var _body11 = __x131;
+  var _hf = ["return", ["%array", false, _e6]];
   indent_level = indent_level + 1;
-  var __x151 = compile(_hf1, {_stash: true, stmt: true});
+  var __x134 = compile(_hf, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var _h1 = __x151;
-  return(_ind9 + "try {\n" + _body14 + _ind9 + "}\n" + _ind9 + "catch (" + _e8 + ") {\n" + _h1 + _ind9 + "}\n");
+  var _h = __x134;
+  return(_ind5 + "try {\n" + _body11 + _ind5 + "}\n" + _ind5 + "catch (" + _e6 + ") {\n" + _h + _ind5 + "}\n");
 }, stmt: true, tr: true});
 setenv("%delete", {_stash: true, special: function (place) {
   return(indentation() + "delete " + compile(place));
@@ -1187,29 +1187,29 @@ setenv("%function", {_stash: true, special: function (args, body) {
 }});
 setenv("%global-function", {_stash: true, special: function (name, args, body) {
   if (target === "lua") {
-    var _x155 = compile_function(args, body, {_stash: true, name: name});
-    return(indentation() + _x155);
+    var _x135 = compile_function(args, body, {_stash: true, name: name});
+    return(indentation() + _x135);
   } else {
     return(compile(["%set", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
 }, stmt: true, tr: true});
 setenv("%local-function", {_stash: true, special: function (name, args, body) {
   if (target === "lua") {
-    var _x161 = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
-    return(indentation() + _x161);
+    var _x138 = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
+    return(indentation() + _x138);
   } else {
     return(compile(["%local", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
 }, stmt: true, tr: true});
 setenv("return", {_stash: true, special: function (x) {
-  var _e51;
+  var _e38;
   if (nil63(x)) {
-    _e51 = "return";
+    _e38 = "return";
   } else {
-    _e51 = "return(" + compile(x) + ")";
+    _e38 = "return(" + compile(x) + ")";
   }
-  var _x165 = _e51;
-  return(indentation() + _x165);
+  var _x141 = _e38;
+  return(indentation() + _x141);
 }, stmt: true});
 setenv("new", {_stash: true, special: function (x) {
   return("new " + compile(x));
@@ -1218,132 +1218,132 @@ setenv("typeof", {_stash: true, special: function (x) {
   return("typeof(" + compile(x) + ")");
 }});
 setenv("error", {_stash: true, special: function (x) {
-  var _e52;
+  var _e39;
   if (target === "js") {
-    _e52 = "throw " + compile(["new", ["Error", x]]);
+    _e39 = "throw " + compile(["new", ["Error", x]]);
   } else {
-    _e52 = "error(" + compile(x) + ")";
+    _e39 = "error(" + compile(x) + ")";
   }
-  var _e12 = _e52;
-  return(indentation() + _e12);
+  var _e7 = _e39;
+  return(indentation() + _e7);
 }, stmt: true});
 setenv("%local", {_stash: true, special: function (name, value) {
-  var _id28 = compile(name);
-  var _value11 = compile(value);
-  var _e53;
+  var _id27 = compile(name);
+  var _value1 = compile(value);
+  var _e40;
   if (is63(value)) {
-    _e53 = " = " + _value11;
+    _e40 = " = " + _value1;
   } else {
-    _e53 = "";
+    _e40 = "";
   }
-  var _rh2 = _e53;
-  var _e54;
+  var _rh1 = _e40;
+  var _e41;
   if (target === "js") {
-    _e54 = "var ";
+    _e41 = "var ";
   } else {
-    _e54 = "local ";
+    _e41 = "local ";
   }
-  var _keyword1 = _e54;
-  var _ind11 = indentation();
-  return(_ind11 + _keyword1 + _id28 + _rh2);
+  var _keyword = _e41;
+  var _ind6 = indentation();
+  return(_ind6 + _keyword + _id27 + _rh1);
 }, stmt: true});
 setenv("%set", {_stash: true, special: function (lh, rh) {
-  var _lh2 = compile(lh);
-  var _e55;
+  var _lh1 = compile(lh);
+  var _e42;
   if (nil63(rh)) {
-    _e55 = "nil";
+    _e42 = "nil";
   } else {
-    _e55 = rh;
+    _e42 = rh;
   }
-  var _rh4 = compile(_e55);
-  return(indentation() + _lh2 + " = " + _rh4);
+  var _rh2 = compile(_e42);
+  return(indentation() + _lh1 + " = " + _rh2);
 }, stmt: true});
 setenv("get", {_stash: true, special: function (t, k) {
-  var _t12 = compile(t);
-  var _k121 = compile(k);
-  if (target === "lua" && char(_t12, 0) === "{" || infix_operator63(t)) {
-    _t12 = "(" + _t12 + ")";
+  var _t11 = compile(t);
+  var _k111 = compile(k);
+  if (target === "lua" && char(_t11, 0) === "{" || infix_operator63(t)) {
+    _t11 = "(" + _t11 + ")";
   }
   if (string_literal63(k) && valid_id63(inner(k))) {
-    return(_t12 + "." + inner(k));
+    return(_t11 + "." + inner(k));
   } else {
-    return(_t12 + "[" + _k121 + "]");
+    return(_t11 + "[" + _k111 + "]");
   }
 }});
 setenv("%array", {_stash: true, special: function () {
-  var _forms3 = unstash(Array.prototype.slice.call(arguments, 0));
-  var _e56;
+  var _forms1 = unstash(Array.prototype.slice.call(arguments, 0));
+  var _e43;
   if (target === "lua") {
-    _e56 = "{";
+    _e43 = "{";
   } else {
-    _e56 = "[";
+    _e43 = "[";
   }
-  var _open1 = _e56;
-  var _e57;
+  var _open = _e43;
+  var _e44;
   if (target === "lua") {
-    _e57 = "}";
+    _e44 = "}";
   } else {
-    _e57 = "]";
+    _e44 = "]";
   }
-  var _close1 = _e57;
-  var _s7 = "";
+  var _close = _e44;
+  var _s4 = "";
+  var _c6 = "";
+  var __o9 = _forms1;
+  var _k14 = undefined;
+  for (_k14 in __o9) {
+    var _v8 = __o9[_k14];
+    var _e45;
+    if (numeric63(_k14)) {
+      _e45 = parseInt(_k14);
+    } else {
+      _e45 = _k14;
+    }
+    var _k15 = _e45;
+    if (number63(_k15)) {
+      _s4 = _s4 + _c6 + compile(_v8);
+      _c6 = ", ";
+    }
+  }
+  return(_open + _s4 + _close);
+}});
+setenv("%object", {_stash: true, special: function () {
+  var _forms2 = unstash(Array.prototype.slice.call(arguments, 0));
+  var _s5 = "{";
   var _c7 = "";
-  var __o10 = _forms3;
+  var _e46;
+  if (target === "lua") {
+    _e46 = " = ";
+  } else {
+    _e46 = ": ";
+  }
+  var _sep = _e46;
+  var __o10 = pair(_forms2);
   var _k16 = undefined;
   for (_k16 in __o10) {
     var _v9 = __o10[_k16];
-    var _e58;
+    var _e47;
     if (numeric63(_k16)) {
-      _e58 = parseInt(_k16);
+      _e47 = parseInt(_k16);
     } else {
-      _e58 = _k16;
+      _e47 = _k16;
     }
-    var _k17 = _e58;
+    var _k17 = _e47;
     if (number63(_k17)) {
-      _s7 = _s7 + _c7 + compile(_v9);
+      var __id28 = _v9;
+      var _k18 = __id28[0];
+      var _v10 = __id28[1];
+      if (! string63(_k18)) {
+        throw new Error("Illegal key: " + str(_k18));
+      }
+      _s5 = _s5 + _c7 + key(_k18) + _sep + compile(_v10);
       _c7 = ", ";
     }
   }
-  return(_open1 + _s7 + _close1);
-}});
-setenv("%object", {_stash: true, special: function () {
-  var _forms5 = unstash(Array.prototype.slice.call(arguments, 0));
-  var _s9 = "{";
-  var _c9 = "";
-  var _e59;
-  if (target === "lua") {
-    _e59 = " = ";
-  } else {
-    _e59 = ": ";
-  }
-  var _sep1 = _e59;
-  var __o12 = pair(_forms5);
-  var _k21 = undefined;
-  for (_k21 in __o12) {
-    var _v12 = __o12[_k21];
-    var _e60;
-    if (numeric63(_k21)) {
-      _e60 = parseInt(_k21);
-    } else {
-      _e60 = _k21;
-    }
-    var _k22 = _e60;
-    if (number63(_k22)) {
-      var __id30 = _v12;
-      var _k23 = __id30[0];
-      var _v13 = __id30[1];
-      if (! string63(_k23)) {
-        throw new Error("Illegal key: " + str(_k23));
-      }
-      _s9 = _s9 + _c9 + key(_k23) + _sep1 + compile(_v13);
-      _c9 = ", ";
-    }
-  }
-  return(_s9 + "}");
+  return(_s5 + "}");
 }});
 setenv("%literal", {_stash: true, special: function () {
-  var _args111 = unstash(Array.prototype.slice.call(arguments, 0));
-  return(apply(cat, map(compile, _args111)));
+  var _args10 = unstash(Array.prototype.slice.call(arguments, 0));
+  return(apply(cat, map(compile, _args10)));
 }});
 exports.run = run;
 exports.eval = eval;

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -5,13 +5,13 @@ local function getenv(k, p)
     while _i >= 0 do
       local _b = environment[_i + 1][k]
       if is63(_b) then
-        local _e21
+        local _e8
         if p then
-          _e21 = _b[p]
+          _e8 = _b[p]
         else
-          _e21 = _b
+          _e8 = _b
         end
-        return(_e21)
+        return(_e8)
       else
         _i = _i - 1
       end
@@ -114,21 +114,21 @@ function bind(lh, rh)
     local _k1 = nil
     for _k1 in next, __o1 do
       local _v1 = __o1[_k1]
-      local _e22
+      local _e9
       if _k1 == "rest" then
-        _e22 = {"cut", _id, _35(lh)}
+        _e9 = {"cut", _id, _35(lh)}
       else
-        _e22 = {"get", _id, {"quote", bias(_k1)}}
+        _e9 = {"get", _id, {"quote", bias(_k1)}}
       end
-      local _x5 = _e22
+      local _x5 = _e9
       if is63(_k1) then
-        local _e23
+        local _e10
         if _v1 == true then
-          _e23 = _k1
+          _e10 = _k1
         else
-          _e23 = _v1
+          _e10 = _v1
         end
-        local _k2 = _e23
+        local _k2 = _e10
         _bs = join(_bs, bind(_k2, _x5))
       end
     end
@@ -152,7 +152,7 @@ function bind42(args, body)
     return({_args1, join({"let", {args, rest()}}, body)})
   else
     local _bs1 = {}
-    local _r21 = unique("r")
+    local _r20 = unique("r")
     local __o2 = args
     local _k3 = nil
     for _k3 in next, __o2 do
@@ -161,22 +161,22 @@ function bind42(args, body)
         if atom63(_v2) then
           add(_args1, _v2)
         else
-          local _x30 = unique("x")
-          add(_args1, _x30)
-          _bs1 = join(_bs1, {_v2, _x30})
+          local _x23 = unique("x")
+          add(_args1, _x23)
+          _bs1 = join(_bs1, {_v2, _x23})
         end
       end
     end
     if keys63(args) then
-      _bs1 = join(_bs1, {_r21, rest()})
+      _bs1 = join(_bs1, {_r20, rest()})
       local _n3 = _35(_args1)
       local _i5 = 0
       while _i5 < _n3 do
         local _v3 = _args1[_i5 + 1]
-        _bs1 = join(_bs1, {_v3, {"destash!", _v3, _r21}})
+        _bs1 = join(_bs1, {_v3, {"destash!", _v3, _r20}})
         _i5 = _i5 + 1
       end
-      _bs1 = join(_bs1, {keys(args), _r21})
+      _bs1 = join(_bs1, {keys(args), _r20})
     end
     return({_args1, join({"let", _bs1}, body)})
   end
@@ -193,33 +193,33 @@ end
 local function quasisplice63(x, depth)
   return(can_unquote63(depth) and not atom63(x) and hd(x) == "unquote-splicing")
 end
-local function expand_local(_x38)
-  local __id1 = _x38
-  local _x39 = __id1[1]
+local function expand_local(_x31)
+  local __id1 = _x31
+  local _x32 = __id1[1]
   local _name = __id1[2]
   local _value = __id1[3]
   setenv(_name, {_stash = true, variable = true})
   return({"%local", _name, macroexpand(_value)})
 end
-local function expand_function(_x41)
-  local __id2 = _x41
-  local _x42 = __id2[1]
+local function expand_function(_x34)
+  local __id2 = _x34
+  local _x35 = __id2[1]
   local _args = __id2[2]
   local _body = cut(__id2, 2)
   add(environment, {})
   local __o3 = _args
   local __i6 = nil
   for __i6 in next, __o3 do
-    local __x43 = __o3[__i6]
-    setenv(__x43, {_stash = true, variable = true})
+    local __x36 = __o3[__i6]
+    setenv(__x36, {_stash = true, variable = true})
   end
-  local __x44 = join({"%function", _args}, macroexpand(_body))
+  local __x37 = join({"%function", _args}, macroexpand(_body))
   drop(environment)
-  return(__x44)
+  return(__x37)
 end
-local function expand_definition(_x46)
-  local __id3 = _x46
-  local _x47 = __id3[1]
+local function expand_definition(_x39)
+  local __id3 = _x39
+  local _x40 = __id3[1]
   local _name1 = __id3[2]
   local _args11 = __id3[3]
   local _body1 = cut(__id3, 3)
@@ -227,18 +227,18 @@ local function expand_definition(_x46)
   local __o4 = _args11
   local __i7 = nil
   for __i7 in next, __o4 do
-    local __x48 = __o4[__i7]
-    setenv(__x48, {_stash = true, variable = true})
+    local __x41 = __o4[__i7]
+    setenv(__x41, {_stash = true, variable = true})
   end
-  local __x49 = join({_x47, _name1, _args11}, macroexpand(_body1))
+  local __x42 = join({_x40, _name1, _args11}, macroexpand(_body1))
   drop(environment)
-  return(__x49)
+  return(__x42)
 end
 local function expand_macro(form)
   return(macroexpand(expand1(form)))
 end
-function expand1(_x51)
-  local __id4 = _x51
+function expand1(_x44)
+  local __id4 = _x44
   local _name2 = __id4[1]
   local _body2 = cut(__id4, 1)
   return(apply(macro_function(_name2), _body2))
@@ -250,20 +250,20 @@ function macroexpand(form)
     if atom63(form) then
       return(form)
     else
-      local _x52 = hd(form)
-      if _x52 == "%local" then
+      local _x45 = hd(form)
+      if _x45 == "%local" then
         return(expand_local(form))
       else
-        if _x52 == "%function" then
+        if _x45 == "%function" then
           return(expand_function(form))
         else
-          if _x52 == "%global-function" then
+          if _x45 == "%global-function" then
             return(expand_definition(form))
           else
-            if _x52 == "%local-function" then
+            if _x45 == "%local-function" then
               return(expand_definition(form))
             else
-              if macro63(_x52) then
+              if macro63(_x45) then
                 return(expand_macro(form))
               else
                 return(map(macroexpand, form))
@@ -282,26 +282,26 @@ local function quasiquote_list(form, depth)
   for _k4 in next, __o5 do
     local _v4 = __o5[_k4]
     if not number63(_k4) then
-      local _e24
+      local _e11
       if quasisplice63(_v4, depth) then
-        _e24 = quasiexpand(_v4[2])
+        _e11 = quasiexpand(_v4[2])
       else
-        _e24 = quasiexpand(_v4, depth)
+        _e11 = quasiexpand(_v4, depth)
       end
-      local _v5 = _e24
+      local _v5 = _e11
       last(_xs)[_k4] = _v5
     end
   end
-  local __x55 = form
+  local __x48 = form
   local __i9 = 0
-  while __i9 < _35(__x55) do
-    local _x56 = __x55[__i9 + 1]
-    if quasisplice63(_x56, depth) then
-      local _x57 = quasiexpand(_x56[2])
-      add(_xs, _x57)
+  while __i9 < _35(__x48) do
+    local _x49 = __x48[__i9 + 1]
+    if quasisplice63(_x49, depth) then
+      local _x50 = quasiexpand(_x49[2])
+      add(_xs, _x50)
       add(_xs, {"list"})
     else
-      add(last(_xs), quasiexpand(_x56, depth))
+      add(last(_xs), quasiexpand(_x49, depth))
     end
     __i9 = __i9 + 1
   end
@@ -351,8 +351,8 @@ function quasiexpand(form, depth)
     end
   end
 end
-function expand_if(_x61)
-  local __id5 = _x61
+function expand_if(_x54)
+  local __id5 = _x54
   local _a = __id5[1]
   local _b2 = __id5[2]
   local _c = cut(__id5, 2)
@@ -413,52 +413,52 @@ function mapo(f, t)
   local _k5 = nil
   for _k5 in next, __o7 do
     local _v6 = __o7[_k5]
-    local _x65 = f(_v6)
-    if is63(_x65) then
+    local _x58 = f(_v6)
+    if is63(_x58) then
       add(_o6, literal(_k5))
-      add(_o6, _x65)
+      add(_o6, _x58)
     end
   end
   return(_o6)
 end
+local __x60 = {}
+local __x61 = {}
+__x61.js = "!"
+__x61.lua = "not"
+__x60["not"] = __x61
+local __x62 = {}
+__x62["*"] = true
+__x62["/"] = true
+__x62["%"] = true
+local __x63 = {}
+__x63["+"] = true
+__x63["-"] = true
+local __x64 = {}
+local __x65 = {}
+__x65.js = "+"
+__x65.lua = ".."
+__x64.cat = __x65
+local __x66 = {}
+__x66["<"] = true
+__x66[">"] = true
+__x66["<="] = true
+__x66[">="] = true
 local __x67 = {}
 local __x68 = {}
-__x68.js = "!"
-__x68.lua = "not"
-__x67["not"] = __x68
+__x68.js = "==="
+__x68.lua = "=="
+__x67["="] = __x68
 local __x69 = {}
-__x69["*"] = true
-__x69["/"] = true
-__x69["%"] = true
 local __x70 = {}
-__x70["+"] = true
-__x70["-"] = true
+__x70.js = "&&"
+__x70.lua = "and"
+__x69["and"] = __x70
 local __x71 = {}
 local __x72 = {}
-__x72.js = "+"
-__x72.lua = ".."
-__x71.cat = __x72
-local __x73 = {}
-__x73["<"] = true
-__x73[">"] = true
-__x73["<="] = true
-__x73[">="] = true
-local __x74 = {}
-local __x75 = {}
-__x75.js = "==="
-__x75.lua = "=="
-__x74["="] = __x75
-local __x76 = {}
-local __x77 = {}
-__x77.js = "&&"
-__x77.lua = "and"
-__x76["and"] = __x77
-local __x78 = {}
-local __x79 = {}
-__x79.js = "||"
-__x79.lua = "or"
-__x78["or"] = __x79
-local infix = {__x67, __x69, __x70, __x71, __x73, __x74, __x76, __x78}
+__x72.js = "||"
+__x72.lua = "or"
+__x71["or"] = __x72
+local infix = {__x60, __x62, __x63, __x64, __x66, __x67, __x69, __x71}
 local function unary63(form)
   return(two63(form) and in63(hd(form), {"not", "-"}))
 end
@@ -482,12 +482,12 @@ local function precedence(form)
 end
 local function getop(op)
   return(find(function (level)
-    local _x81 = level[op]
-    if _x81 == true then
+    local _x74 = level[op]
+    if _x74 == true then
       return(op)
     else
-      if is63(_x81) then
-        return(_x81[target])
+      if is63(_x74) then
+        return(_x74[target])
       end
     end
   end, infix))
@@ -501,11 +501,11 @@ end
 local function compile_args(args)
   local _s1 = "("
   local _c1 = ""
-  local __x82 = args
+  local __x75 = args
   local __i15 = 0
-  while __i15 < _35(__x82) do
-    local _x83 = __x82[__i15 + 1]
-    _s1 = _s1 .. _c1 .. compile(_x83)
+  while __i15 < _35(__x75) do
+    local _x76 = __x75[__i15 + 1]
+    _s1 = _s1 .. _c1 .. compile(_x76)
     _c1 = ", "
     __i15 = __i15 + 1
   end
@@ -516,48 +516,48 @@ local function escape_newlines(s)
   local _i16 = 0
   while _i16 < _35(s) do
     local _c2 = char(s, _i16)
-    local _e25
+    local _e12
     if _c2 == "\n" then
-      _e25 = "\\n"
+      _e12 = "\\n"
     else
-      _e25 = _c2
+      _e12 = _c2
     end
-    _s11 = _s11 .. _e25
+    _s11 = _s11 .. _e12
     _i16 = _i16 + 1
   end
   return(_s11)
 end
 local function id(id)
-  local _e26
+  local _e13
   if number_code63(code(id, 0)) then
-    _e26 = "_"
+    _e13 = "_"
   else
-    _e26 = ""
+    _e13 = ""
   end
-  local _id11 = _e26
+  local _id11 = _e13
   local _i17 = 0
   while _i17 < _35(id) do
     local _c3 = char(id, _i17)
     local _n9 = code(_c3)
-    local _e27
+    local _e14
     if _c3 == "-" and not( id == "-") then
-      _e27 = "_"
+      _e14 = "_"
     else
-      local _e28
+      local _e15
       if valid_code63(_n9) then
-        _e28 = _c3
+        _e15 = _c3
       else
-        local _e29
+        local _e16
         if _i17 == 0 then
-          _e29 = "_" .. _n9
+          _e16 = "_" .. _n9
         else
-          _e29 = _n9
+          _e16 = _n9
         end
-        _e28 = _e29
+        _e15 = _e16
       end
-      _e27 = _e28
+      _e14 = _e15
     end
-    local _c11 = _e27
+    local _c11 = _e14
     _id11 = _id11 .. _c11
     _i17 = _i17 + 1
   end
@@ -627,9 +627,9 @@ local function terminator(stmt63)
 end
 local function compile_special(form, stmt63)
   local __id6 = form
-  local _x84 = __id6[1]
+  local _x77 = __id6[1]
   local _args2 = cut(__id6, 1)
-  local __id7 = getenv(_x84)
+  local __id7 = getenv(_x77)
   local _special = __id7.special
   local _stmt = __id7.stmt
   local _self_tr63 = __id7.tr
@@ -650,18 +650,18 @@ local function compile_call(form)
   end
 end
 local function op_delims(parent, child, ...)
-  local __r58 = unstash({...})
-  local _parent = destash33(parent, __r58)
-  local _child = destash33(child, __r58)
-  local __id8 = __r58
+  local __r57 = unstash({...})
+  local _parent = destash33(parent, __r57)
+  local _child = destash33(child, __r57)
+  local __id8 = __r57
   local _right = __id8.right
-  local _e30
+  local _e17
   if _right then
-    _e30 = _6261
+    _e17 = _6261
   else
-    _e30 = _62
+    _e17 = _62
   end
-  if _e30(precedence(_child), precedence(_parent)) then
+  if _e17(precedence(_child), precedence(_parent)) then
     return({"(", ")"})
   else
     return({"", ""})
@@ -689,46 +689,46 @@ local function compile_infix(form)
   end
 end
 function compile_function(args, body, ...)
-  local __r60 = unstash({...})
-  local _args4 = destash33(args, __r60)
-  local _body3 = destash33(body, __r60)
-  local __id13 = __r60
+  local __r59 = unstash({...})
+  local _args4 = destash33(args, __r59)
+  local _body3 = destash33(body, __r59)
+  local __id13 = __r59
   local _name3 = __id13.name
   local _prefix = __id13.prefix
-  local _e31
+  local _e18
   if _name3 then
-    _e31 = compile(_name3)
+    _e18 = compile(_name3)
   else
-    _e31 = ""
+    _e18 = ""
   end
-  local _id14 = _e31
-  local _e32
+  local _id14 = _e18
+  local _e19
   if target == "lua" and _args4.rest then
-    _e32 = join(_args4, {"|...|"})
+    _e19 = join(_args4, {"|...|"})
   else
-    _e32 = _args4
+    _e19 = _args4
   end
-  local _args12 = _e32
+  local _args12 = _e19
   local _args5 = compile_args(_args12)
   indent_level = indent_level + 1
-  local __x90 = compile(_body3, {_stash = true, stmt = true})
+  local __x83 = compile(_body3, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local _body4 = __x90
+  local _body4 = __x83
   local _ind = indentation()
-  local _e33
+  local _e20
   if _prefix then
-    _e33 = _prefix .. " "
+    _e20 = _prefix .. " "
   else
-    _e33 = ""
+    _e20 = ""
   end
-  local _p = _e33
-  local _e34
+  local _p = _e20
+  local _e21
   if target == "js" then
-    _e34 = ""
+    _e21 = ""
   else
-    _e34 = "end"
+    _e21 = "end"
   end
-  local _tr1 = _e34
+  local _tr1 = _e21
   if _name3 then
     _tr1 = _tr1 .. "\n"
   end
@@ -742,9 +742,9 @@ local function can_return63(form)
   return(is63(form) and (atom63(form) or not( hd(form) == "return") and not statement63(hd(form))))
 end
 function compile(form, ...)
-  local __r62 = unstash({...})
-  local _form = destash33(form, __r62)
-  local __id15 = __r62
+  local __r61 = unstash({...})
+  local _form = destash33(form, __r61)
+  local __id15 = __r61
   local _stmt1 = __id15.stmt
   if nil63(_form) then
     return("")
@@ -753,26 +753,26 @@ function compile(form, ...)
       return(compile_special(_form, _stmt1))
     else
       local _tr2 = terminator(_stmt1)
-      local _e35
+      local _e22
       if _stmt1 then
-        _e35 = indentation()
+        _e22 = indentation()
       else
-        _e35 = ""
+        _e22 = ""
       end
-      local _ind1 = _e35
-      local _e36
+      local _ind1 = _e22
+      local _e23
       if atom63(_form) then
-        _e36 = compile_atom(_form)
+        _e23 = compile_atom(_form)
       else
-        local _e37
+        local _e24
         if infix63(hd(_form)) then
-          _e37 = compile_infix(_form)
+          _e24 = compile_infix(_form)
         else
-          _e37 = compile_call(_form)
+          _e24 = compile_call(_form)
         end
-        _e36 = _e37
+        _e23 = _e24
       end
-      local _form1 = _e36
+      local _form1 = _e23
       return(_ind1 .. _form1 .. _tr2)
     end
   end
@@ -804,11 +804,11 @@ local function standalone63(form)
   return(not atom63(form) and not infix63(hd(form)) and not literal63(form) and not( "get" == hd(form)) or id_literal63(form))
 end
 local function lower_do(args, hoist, stmt63, tail63)
-  local __x96 = almost(args)
+  local __x89 = almost(args)
   local __i18 = 0
-  while __i18 < _35(__x96) do
-    local _x97 = __x96[__i18 + 1]
-    local __y = lower(_x97, hoist, stmt63)
+  while __i18 < _35(__x89) do
+    local _x90 = __x89[__i18 + 1]
+    local __y = lower(_x90, hoist, stmt63)
     if yes(__y) then
       local _e1 = __y
       if standalone63(_e1) then
@@ -839,19 +839,19 @@ local function lower_if(args, hoist, stmt63, tail63)
   local _then = __id17[2]
   local _else = __id17[3]
   if stmt63 then
-    local _e39
+    local _e26
     if is63(_else) then
-      _e39 = {lower_body({_else}, tail63)}
+      _e26 = {lower_body({_else}, tail63)}
     end
-    return(add(hoist, join({"%if", lower(_cond, hoist), lower_body({_then}, tail63)}, _e39)))
+    return(add(hoist, join({"%if", lower(_cond, hoist), lower_body({_then}, tail63)}, _e26)))
   else
     local _e3 = unique("e")
     add(hoist, {"%local", _e3})
-    local _e38
+    local _e25
     if is63(_else) then
-      _e38 = {lower({"%set", _e3, _else})}
+      _e25 = {lower({"%set", _e3, _else})}
     end
-    add(hoist, join({"%if", lower(_cond, hoist), lower({"%set", _e3, _then})}, _e38))
+    add(hoist, join({"%if", lower(_cond, hoist), lower({"%set", _e3, _then})}, _e25))
     return(_e3)
   end
 end
@@ -863,13 +863,13 @@ local function lower_short(x, args, hoist)
   local _b11 = lower(_b5, _hoist1)
   if some63(_hoist1) then
     local _id19 = unique("id")
-    local _e40
+    local _e27
     if x == "and" then
-      _e40 = {"%if", _id19, _b5, _id19}
+      _e27 = {"%if", _id19, _b5, _id19}
     else
-      _e40 = {"%if", _id19, _id19, _b5}
+      _e27 = {"%if", _id19, _id19, _b5}
     end
-    return(lower({"do", {"%local", _id19, _a3}, _e40}, hoist))
+    return(lower({"do", {"%local", _id19, _a3}, _e27}, hoist))
   else
     return({x, lower(_a3, hoist), _b11})
   end
@@ -883,13 +883,13 @@ local function lower_while(args, hoist)
   local _body5 = cut(__id20, 1)
   local _pre = {}
   local _c5 = lower(_c4, _pre)
-  local _e41
+  local _e28
   if none63(_pre) then
-    _e41 = {"while", _c5, lower_body(_body5)}
+    _e28 = {"while", _c5, lower_body(_body5)}
   else
-    _e41 = {"while", true, join({"do"}, _pre, {{"%if", {"not", _c5}, {"break"}}, lower_body(_body5)})}
+    _e28 = {"while", true, join({"do"}, _pre, {{"%if", {"not", _c5}, {"break"}}, lower_body(_body5)})}
   end
-  return(add(hoist, _e41))
+  return(add(hoist, _e28))
 end
 local function lower_for(args, hoist)
   local __id21 = args
@@ -926,10 +926,10 @@ local function lower_pairwise(form)
   if pairwise63(form) then
     local _e4 = {}
     local __id24 = form
-    local _x126 = __id24[1]
+    local _x119 = __id24[1]
     local _args7 = cut(__id24, 1)
     reduce(function (a, b)
-      add(_e4, {_x126, a, b})
+      add(_e4, {_x119, a, b})
       return(a)
     end, _args7)
     return(join({"and"}, reverse(_e4)))
@@ -943,10 +943,10 @@ end
 local function lower_infix(form, hoist)
   local _form3 = lower_pairwise(form)
   local __id25 = _form3
-  local _x129 = __id25[1]
+  local _x122 = __id25[1]
   local _args8 = cut(__id25, 1)
   return(lower(reduce(function (a, b)
-    return({_x129, b, a})
+    return({_x122, b, a})
   end, reverse(_args8)), hoist))
 end
 local function lower_special(form, hoist)
@@ -969,36 +969,36 @@ function lower(form, hoist, stmt63, tail63)
           return(lower_infix(form, hoist))
         else
           local __id26 = form
-          local _x132 = __id26[1]
+          local _x125 = __id26[1]
           local _args9 = cut(__id26, 1)
-          if _x132 == "do" then
+          if _x125 == "do" then
             return(lower_do(_args9, hoist, stmt63, tail63))
           else
-            if _x132 == "%set" then
+            if _x125 == "%set" then
               return(lower_set(_args9, hoist, stmt63, tail63))
             else
-              if _x132 == "%if" then
+              if _x125 == "%if" then
                 return(lower_if(_args9, hoist, stmt63, tail63))
               else
-                if _x132 == "%try" then
+                if _x125 == "%try" then
                   return(lower_try(_args9, hoist, tail63))
                 else
-                  if _x132 == "while" then
+                  if _x125 == "while" then
                     return(lower_while(_args9, hoist))
                   else
-                    if _x132 == "%for" then
+                    if _x125 == "%for" then
                       return(lower_for(_args9, hoist))
                     else
-                      if _x132 == "%function" then
+                      if _x125 == "%function" then
                         return(lower_function(_args9))
                       else
-                        if _x132 == "%local-function" or _x132 == "%global-function" then
-                          return(lower_definition(_x132, _args9, hoist))
+                        if _x125 == "%local-function" or _x125 == "%global-function" then
+                          return(lower_definition(_x125, _args9, hoist))
                         else
-                          if in63(_x132, {"and", "or"}) then
-                            return(lower_short(_x132, _args9, hoist))
+                          if in63(_x125, {"and", "or"}) then
+                            return(lower_short(_x125, _args9, hoist))
                           else
-                            if statement63(_x132) then
+                            if statement63(_x125) then
                               return(lower_special(form, hoist))
                             else
                               return(lower_call(form, hoist))
@@ -1039,95 +1039,95 @@ function eval(form)
   return(_37result)
 end
 setenv("do", {_stash = true, special = function (...)
-  local _forms1 = unstash({...})
-  local _s3 = ""
-  local __x138 = _forms1
-  local __i20 = 0
-  while __i20 < _35(__x138) do
-    local _x139 = __x138[__i20 + 1]
-    _s3 = _s3 .. compile(_x139, {_stash = true, stmt = true})
-    if not atom63(_x139) then
-      if hd(_x139) == "return" or hd(_x139) == "break" then
+  local _forms = unstash({...})
+  local _s2 = ""
+  local __x129 = _forms
+  local __i19 = 0
+  while __i19 < _35(__x129) do
+    local _x130 = __x129[__i19 + 1]
+    _s2 = _s2 .. compile(_x130, {_stash = true, stmt = true})
+    if not atom63(_x130) then
+      if hd(_x130) == "return" or hd(_x130) == "break" then
         break
       end
     end
-    __i20 = __i20 + 1
+    __i19 = __i19 + 1
   end
-  return(_s3)
+  return(_s2)
 end, stmt = true, tr = true})
 setenv("%if", {_stash = true, special = function (cond, cons, alt)
-  local _cond2 = compile(cond)
+  local _cond1 = compile(cond)
   indent_level = indent_level + 1
-  local __x142 = compile(cons, {_stash = true, stmt = true})
+  local __x131 = compile(cons, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local _cons1 = __x142
-  local _e42
+  local _cons = __x131
+  local _e29
   if alt then
     indent_level = indent_level + 1
-    local __x143 = compile(alt, {_stash = true, stmt = true})
+    local __x132 = compile(alt, {_stash = true, stmt = true})
     indent_level = indent_level - 1
-    _e42 = __x143
+    _e29 = __x132
   end
-  local _alt1 = _e42
-  local _ind3 = indentation()
-  local _s5 = ""
+  local _alt = _e29
+  local _ind2 = indentation()
+  local _s3 = ""
   if target == "js" then
-    _s5 = _s5 .. _ind3 .. "if (" .. _cond2 .. ") {\n" .. _cons1 .. _ind3 .. "}"
+    _s3 = _s3 .. _ind2 .. "if (" .. _cond1 .. ") {\n" .. _cons .. _ind2 .. "}"
   else
-    _s5 = _s5 .. _ind3 .. "if " .. _cond2 .. " then\n" .. _cons1
+    _s3 = _s3 .. _ind2 .. "if " .. _cond1 .. " then\n" .. _cons
   end
-  if _alt1 and target == "js" then
-    _s5 = _s5 .. " else {\n" .. _alt1 .. _ind3 .. "}"
+  if _alt and target == "js" then
+    _s3 = _s3 .. " else {\n" .. _alt .. _ind2 .. "}"
   else
-    if _alt1 then
-      _s5 = _s5 .. _ind3 .. "else\n" .. _alt1
+    if _alt then
+      _s3 = _s3 .. _ind2 .. "else\n" .. _alt
     end
   end
   if target == "lua" then
-    return(_s5 .. _ind3 .. "end\n")
+    return(_s3 .. _ind2 .. "end\n")
   else
-    return(_s5 .. "\n")
+    return(_s3 .. "\n")
   end
 end, stmt = true, tr = true})
 setenv("while", {_stash = true, special = function (cond, form)
-  local _cond4 = compile(cond)
+  local _cond2 = compile(cond)
   indent_level = indent_level + 1
-  local __x145 = compile(form, {_stash = true, stmt = true})
+  local __x133 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local _body10 = __x145
-  local _ind5 = indentation()
+  local _body9 = __x133
+  local _ind3 = indentation()
   if target == "js" then
-    return(_ind5 .. "while (" .. _cond4 .. ") {\n" .. _body10 .. _ind5 .. "}\n")
+    return(_ind3 .. "while (" .. _cond2 .. ") {\n" .. _body9 .. _ind3 .. "}\n")
   else
-    return(_ind5 .. "while " .. _cond4 .. " do\n" .. _body10 .. _ind5 .. "end\n")
+    return(_ind3 .. "while " .. _cond2 .. " do\n" .. _body9 .. _ind3 .. "end\n")
   end
 end, stmt = true, tr = true})
 setenv("%for", {_stash = true, special = function (t, k, form)
-  local _t2 = compile(t)
-  local _ind7 = indentation()
+  local _t1 = compile(t)
+  local _ind4 = indentation()
   indent_level = indent_level + 1
-  local __x147 = compile(form, {_stash = true, stmt = true})
+  local __x134 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local _body12 = __x147
+  local _body10 = __x134
   if target == "lua" then
-    return(_ind7 .. "for " .. k .. " in next, " .. _t2 .. " do\n" .. _body12 .. _ind7 .. "end\n")
+    return(_ind4 .. "for " .. k .. " in next, " .. _t1 .. " do\n" .. _body10 .. _ind4 .. "end\n")
   else
-    return(_ind7 .. "for (" .. k .. " in " .. _t2 .. ") {\n" .. _body12 .. _ind7 .. "}\n")
+    return(_ind4 .. "for (" .. k .. " in " .. _t1 .. ") {\n" .. _body10 .. _ind4 .. "}\n")
   end
 end, stmt = true, tr = true})
 setenv("%try", {_stash = true, special = function (form)
-  local _e8 = unique("e")
-  local _ind9 = indentation()
+  local _e6 = unique("e")
+  local _ind5 = indentation()
   indent_level = indent_level + 1
-  local __x152 = compile(form, {_stash = true, stmt = true})
+  local __x135 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local _body14 = __x152
-  local _hf1 = {"return", {"%array", false, _e8}}
+  local _body11 = __x135
+  local _hf = {"return", {"%array", false, _e6}}
   indent_level = indent_level + 1
-  local __x155 = compile(_hf1, {_stash = true, stmt = true})
+  local __x138 = compile(_hf, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local _h1 = __x155
-  return(_ind9 .. "try {\n" .. _body14 .. _ind9 .. "}\n" .. _ind9 .. "catch (" .. _e8 .. ") {\n" .. _h1 .. _ind9 .. "}\n")
+  local _h = __x138
+  return(_ind5 .. "try {\n" .. _body11 .. _ind5 .. "}\n" .. _ind5 .. "catch (" .. _e6 .. ") {\n" .. _h .. _ind5 .. "}\n")
 end, stmt = true, tr = true})
 setenv("%delete", {_stash = true, special = function (place)
   return(indentation() .. "delete " .. compile(place))
@@ -1140,29 +1140,29 @@ setenv("%function", {_stash = true, special = function (args, body)
 end})
 setenv("%global-function", {_stash = true, special = function (name, args, body)
   if target == "lua" then
-    local _x159 = compile_function(args, body, {_stash = true, name = name})
-    return(indentation() .. _x159)
+    local _x139 = compile_function(args, body, {_stash = true, name = name})
+    return(indentation() .. _x139)
   else
     return(compile({"%set", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
 end, stmt = true, tr = true})
 setenv("%local-function", {_stash = true, special = function (name, args, body)
   if target == "lua" then
-    local _x165 = compile_function(args, body, {_stash = true, name = name, prefix = "local"})
-    return(indentation() .. _x165)
+    local _x142 = compile_function(args, body, {_stash = true, name = name, prefix = "local"})
+    return(indentation() .. _x142)
   else
     return(compile({"%local", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
 end, stmt = true, tr = true})
 setenv("return", {_stash = true, special = function (x)
-  local _e43
+  local _e30
   if nil63(x) then
-    _e43 = "return"
+    _e30 = "return"
   else
-    _e43 = "return(" .. compile(x) .. ")"
+    _e30 = "return(" .. compile(x) .. ")"
   end
-  local _x169 = _e43
-  return(indentation() .. _x169)
+  local _x145 = _e30
+  return(indentation() .. _x145)
 end, stmt = true})
 setenv("new", {_stash = true, special = function (x)
   return("new " .. compile(x))
@@ -1171,117 +1171,117 @@ setenv("typeof", {_stash = true, special = function (x)
   return("typeof(" .. compile(x) .. ")")
 end})
 setenv("error", {_stash = true, special = function (x)
-  local _e44
+  local _e31
   if target == "js" then
-    _e44 = "throw " .. compile({"new", {"Error", x}})
+    _e31 = "throw " .. compile({"new", {"Error", x}})
   else
-    _e44 = "error(" .. compile(x) .. ")"
+    _e31 = "error(" .. compile(x) .. ")"
   end
-  local _e12 = _e44
-  return(indentation() .. _e12)
+  local _e7 = _e31
+  return(indentation() .. _e7)
 end, stmt = true})
 setenv("%local", {_stash = true, special = function (name, value)
-  local _id28 = compile(name)
-  local _value11 = compile(value)
-  local _e45
+  local _id27 = compile(name)
+  local _value1 = compile(value)
+  local _e32
   if is63(value) then
-    _e45 = " = " .. _value11
+    _e32 = " = " .. _value1
   else
-    _e45 = ""
+    _e32 = ""
   end
-  local _rh2 = _e45
-  local _e46
+  local _rh1 = _e32
+  local _e33
   if target == "js" then
-    _e46 = "var "
+    _e33 = "var "
   else
-    _e46 = "local "
+    _e33 = "local "
   end
-  local _keyword1 = _e46
-  local _ind11 = indentation()
-  return(_ind11 .. _keyword1 .. _id28 .. _rh2)
+  local _keyword = _e33
+  local _ind6 = indentation()
+  return(_ind6 .. _keyword .. _id27 .. _rh1)
 end, stmt = true})
 setenv("%set", {_stash = true, special = function (lh, rh)
-  local _lh2 = compile(lh)
-  local _e47
+  local _lh1 = compile(lh)
+  local _e34
   if nil63(rh) then
-    _e47 = "nil"
+    _e34 = "nil"
   else
-    _e47 = rh
+    _e34 = rh
   end
-  local _rh4 = compile(_e47)
-  return(indentation() .. _lh2 .. " = " .. _rh4)
+  local _rh2 = compile(_e34)
+  return(indentation() .. _lh1 .. " = " .. _rh2)
 end, stmt = true})
 setenv("get", {_stash = true, special = function (t, k)
-  local _t12 = compile(t)
-  local _k12 = compile(k)
-  if target == "lua" and char(_t12, 0) == "{" or infix_operator63(t) then
-    _t12 = "(" .. _t12 .. ")"
+  local _t11 = compile(t)
+  local _k11 = compile(k)
+  if target == "lua" and char(_t11, 0) == "{" or infix_operator63(t) then
+    _t11 = "(" .. _t11 .. ")"
   end
   if string_literal63(k) and valid_id63(inner(k)) then
-    return(_t12 .. "." .. inner(k))
+    return(_t11 .. "." .. inner(k))
   else
-    return(_t12 .. "[" .. _k12 .. "]")
+    return(_t11 .. "[" .. _k11 .. "]")
   end
 end})
 setenv("%array", {_stash = true, special = function (...)
-  local _forms3 = unstash({...})
-  local _e48
+  local _forms1 = unstash({...})
+  local _e35
   if target == "lua" then
-    _e48 = "{"
+    _e35 = "{"
   else
-    _e48 = "["
+    _e35 = "["
   end
-  local _open1 = _e48
-  local _e49
+  local _open = _e35
+  local _e36
   if target == "lua" then
-    _e49 = "}"
+    _e36 = "}"
   else
-    _e49 = "]"
+    _e36 = "]"
   end
-  local _close1 = _e49
-  local _s7 = ""
+  local _close = _e36
+  local _s4 = ""
+  local _c6 = ""
+  local __o9 = _forms1
+  local _k8 = nil
+  for _k8 in next, __o9 do
+    local _v8 = __o9[_k8]
+    if number63(_k8) then
+      _s4 = _s4 .. _c6 .. compile(_v8)
+      _c6 = ", "
+    end
+  end
+  return(_open .. _s4 .. _close)
+end})
+setenv("%object", {_stash = true, special = function (...)
+  local _forms2 = unstash({...})
+  local _s5 = "{"
   local _c7 = ""
-  local __o10 = _forms3
-  local _k10 = nil
-  for _k10 in next, __o10 do
-    local _v9 = __o10[_k10]
-    if number63(_k10) then
-      _s7 = _s7 .. _c7 .. compile(_v9)
+  local _e37
+  if target == "lua" then
+    _e37 = " = "
+  else
+    _e37 = ": "
+  end
+  local _sep = _e37
+  local __o10 = pair(_forms2)
+  local _k9 = nil
+  for _k9 in next, __o10 do
+    local _v9 = __o10[_k9]
+    if number63(_k9) then
+      local __id28 = _v9
+      local _k10 = __id28[1]
+      local _v10 = __id28[2]
+      if not string63(_k10) then
+        error("Illegal key: " .. str(_k10))
+      end
+      _s5 = _s5 .. _c7 .. key(_k10) .. _sep .. compile(_v10)
       _c7 = ", "
     end
   end
-  return(_open1 .. _s7 .. _close1)
-end})
-setenv("%object", {_stash = true, special = function (...)
-  local _forms5 = unstash({...})
-  local _s9 = "{"
-  local _c9 = ""
-  local _e50
-  if target == "lua" then
-    _e50 = " = "
-  else
-    _e50 = ": "
-  end
-  local _sep1 = _e50
-  local __o12 = pair(_forms5)
-  local _k14 = nil
-  for _k14 in next, __o12 do
-    local _v12 = __o12[_k14]
-    if number63(_k14) then
-      local __id30 = _v12
-      local _k15 = __id30[1]
-      local _v13 = __id30[2]
-      if not string63(_k15) then
-        error("Illegal key: " .. str(_k15))
-      end
-      _s9 = _s9 .. _c9 .. key(_k15) .. _sep1 .. compile(_v13)
-      _c9 = ", "
-    end
-  end
-  return(_s9 .. "}")
+  return(_s5 .. "}")
 end})
 setenv("%literal", {_stash = true, special = function (...)
-  local _args111 = unstash({...})
-  return(apply(cat, map(compile, _args111)))
+  local _args10 = unstash({...})
+  return(apply(cat, map(compile, _args10)))
 end})
 return({run = run, eval = eval, expand = expand, compile = compile})

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -732,13 +732,13 @@ setenv("quasiquote", {_stash: true, macro: function (form) {
   return(quasiexpand(form, 1));
 }});
 setenv("set", {_stash: true, macro: function () {
-  var _args1 = unstash(Array.prototype.slice.call(arguments, 0));
-  return(join(["do"], map(function (_x4) {
-    var __id1 = _x4;
-    var _lh1 = __id1[0];
-    var _rh1 = __id1[1];
-    return(["%set", _lh1, _rh1]);
-  }, pair(_args1))));
+  var _args = unstash(Array.prototype.slice.call(arguments, 0));
+  return(join(["do"], map(function (_x1) {
+    var __id = _x1;
+    var _lh = __id[0];
+    var _rh = __id[1];
+    return(["%set", _lh, _rh]);
+  }, pair(_args))));
 }});
 setenv("at", {_stash: true, macro: function (l, i) {
   if (target === "lua" && number63(i)) {
@@ -758,427 +758,422 @@ setenv("wipe", {_stash: true, macro: function (place) {
   }
 }});
 setenv("list", {_stash: true, macro: function () {
-  var _body1 = unstash(Array.prototype.slice.call(arguments, 0));
-  var _x22 = unique("x");
-  var _l1 = [];
-  var _forms1 = [];
-  var __o1 = _body1;
-  var _k2 = undefined;
-  for (_k2 in __o1) {
-    var _v1 = __o1[_k2];
-    var _e8;
-    if (numeric63(_k2)) {
-      _e8 = parseInt(_k2);
+  var _body = unstash(Array.prototype.slice.call(arguments, 0));
+  var _x7 = unique("x");
+  var _l = [];
+  var _forms = [];
+  var __o = _body;
+  var _k = undefined;
+  for (_k in __o) {
+    var _v = __o[_k];
+    var _e;
+    if (numeric63(_k)) {
+      _e = parseInt(_k);
     } else {
-      _e8 = _k2;
+      _e = _k;
     }
-    var _k3 = _e8;
-    if (number63(_k3)) {
-      _l1[_k3] = _v1;
+    var _k1 = _e;
+    if (number63(_k1)) {
+      _l[_k1] = _v;
     } else {
-      add(_forms1, ["set", ["get", _x22, ["quote", _k3]], _v1]);
+      add(_forms, ["set", ["get", _x7, ["quote", _k1]], _v]);
     }
   }
-  if (some63(_forms1)) {
-    return(join(["let", _x22, join(["%array"], _l1)], _forms1, [_x22]));
+  if (some63(_forms)) {
+    return(join(["let", _x7, join(["%array"], _l)], _forms, [_x7]));
   } else {
-    return(join(["%array"], _l1));
+    return(join(["%array"], _l));
   }
 }});
 setenv("if", {_stash: true, macro: function () {
-  var _branches1 = unstash(Array.prototype.slice.call(arguments, 0));
-  return(hd(expand_if(_branches1)));
+  var _branches = unstash(Array.prototype.slice.call(arguments, 0));
+  return(hd(expand_if(_branches)));
 }});
 setenv("case", {_stash: true, macro: function (expr) {
-  var __r13 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _expr1 = destash33(expr, __r13);
-  var __id4 = __r13;
-  var _clauses1 = cut(__id4, 0);
-  var _x41 = unique("x");
-  var _eq1 = function (_) {
-    return(["=", ["quote", _], _x41]);
+  var __r5 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _expr = destash33(expr, __r5);
+  var __id1 = __r5;
+  var _clauses = cut(__id1, 0);
+  var _x15 = unique("x");
+  var _eq = function (_) {
+    return(["=", ["quote", _], _x15]);
   };
-  var _cl1 = function (_x44) {
-    var __id5 = _x44;
-    var _a1 = __id5[0];
-    var _b1 = __id5[1];
-    if (nil63(_b1)) {
-      return([_a1]);
+  var _cl = function (_x18) {
+    var __id2 = _x18;
+    var _a = __id2[0];
+    var _b = __id2[1];
+    if (nil63(_b)) {
+      return([_a]);
     } else {
-      if (string63(_a1) || number63(_a1)) {
-        return([_eq1(_a1), _b1]);
+      if (string63(_a) || number63(_a)) {
+        return([_eq(_a), _b]);
       } else {
-        if (one63(_a1)) {
-          return([_eq1(hd(_a1)), _b1]);
+        if (one63(_a)) {
+          return([_eq(hd(_a)), _b]);
         } else {
-          if (_35(_a1) > 1) {
-            return([join(["or"], map(_eq1, _a1)), _b1]);
+          if (_35(_a) > 1) {
+            return([join(["or"], map(_eq, _a)), _b]);
           }
         }
       }
     }
   };
-  return(["let", _x41, _expr1, join(["if"], apply(join, map(_cl1, pair(_clauses1))))]);
+  return(["let", _x15, _expr, join(["if"], apply(join, map(_cl, pair(_clauses))))]);
 }});
 setenv("when", {_stash: true, macro: function (cond) {
-  var __r17 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _cond1 = destash33(cond, __r17);
-  var __id7 = __r17;
-  var _body3 = cut(__id7, 0);
-  return(["if", _cond1, join(["do"], _body3)]);
+  var __r8 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _cond = destash33(cond, __r8);
+  var __id3 = __r8;
+  var _body1 = cut(__id3, 0);
+  return(["if", _cond, join(["do"], _body1)]);
 }});
 setenv("unless", {_stash: true, macro: function (cond) {
-  var __r19 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _cond3 = destash33(cond, __r19);
-  var __id9 = __r19;
-  var _body5 = cut(__id9, 0);
-  return(["if", ["not", _cond3], join(["do"], _body5)]);
+  var __r9 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _cond1 = destash33(cond, __r9);
+  var __id4 = __r9;
+  var _body2 = cut(__id4, 0);
+  return(["if", ["not", _cond1], join(["do"], _body2)]);
 }});
 setenv("obj", {_stash: true, macro: function () {
-  var _body7 = unstash(Array.prototype.slice.call(arguments, 0));
+  var _body3 = unstash(Array.prototype.slice.call(arguments, 0));
   return(join(["%object"], mapo(function (x) {
     return(x);
-  }, _body7)));
+  }, _body3)));
 }});
 setenv("let", {_stash: true, macro: function (bs) {
-  var __r23 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _bs11 = destash33(bs, __r23);
-  var __id14 = __r23;
-  var _body9 = cut(__id14, 0);
-  if (atom63(_bs11)) {
-    return(join(["let", [_bs11, hd(_body9)]], tl(_body9)));
+  var __r11 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _bs = destash33(bs, __r11);
+  var __id5 = __r11;
+  var _body4 = cut(__id5, 0);
+  if (atom63(_bs)) {
+    return(join(["let", [_bs, hd(_body4)]], tl(_body4)));
   } else {
-    if (none63(_bs11)) {
-      return(join(["do"], _body9));
+    if (none63(_bs)) {
+      return(join(["do"], _body4));
     } else {
-      var __id15 = _bs11;
-      var _lh3 = __id15[0];
-      var _rh3 = __id15[1];
-      var _bs21 = cut(__id15, 2);
-      var __id16 = bind(_lh3, _rh3);
-      var _id17 = __id16[0];
-      var _val1 = __id16[1];
-      var _bs12 = cut(__id16, 2);
-      var _renames1 = [];
-      if (! id_literal63(_id17)) {
-        var _id121 = unique(_id17);
-        _renames1 = [_id17, _id121];
-        _id17 = _id121;
+      var __id6 = _bs;
+      var _lh1 = __id6[0];
+      var _rh1 = __id6[1];
+      var _bs2 = cut(__id6, 2);
+      var __id7 = bind(_lh1, _rh1);
+      var _id8 = __id7[0];
+      var _val = __id7[1];
+      var _bs1 = cut(__id7, 2);
+      var _renames = [];
+      if (! id_literal63(_id8)) {
+        var _id11 = unique(_id8);
+        _renames = [_id8, _id11];
+        _id8 = _id11;
       }
-      return(["do", ["%local", _id17, _val1], ["let-symbol", _renames1, join(["let", join(_bs12, _bs21)], _body9)]]);
+      return(["do", ["%local", _id8, _val], ["let-symbol", _renames, join(["let", join(_bs1, _bs2)], _body4)]]);
     }
   }
 }});
 setenv("with", {_stash: true, macro: function (x, v) {
-  var __r25 = unstash(Array.prototype.slice.call(arguments, 2));
-  var _x84 = destash33(x, __r25);
-  var _v3 = destash33(v, __r25);
-  var __id19 = __r25;
-  var _body11 = cut(__id19, 0);
-  return(join(["let", [_x84, _v3]], _body11, [_x84]));
+  var __r12 = unstash(Array.prototype.slice.call(arguments, 2));
+  var _x40 = destash33(x, __r12);
+  var _v1 = destash33(v, __r12);
+  var __id9 = __r12;
+  var _body5 = cut(__id9, 0);
+  return(join(["let", [_x40, _v1]], _body5, [_x40]));
 }});
 setenv("let-when", {_stash: true, macro: function (x, v) {
-  var __r27 = unstash(Array.prototype.slice.call(arguments, 2));
-  var _x94 = destash33(x, __r27);
-  var _v5 = destash33(v, __r27);
-  var __id21 = __r27;
-  var _body13 = cut(__id21, 0);
-  var _y1 = unique("y");
-  return(["let", _y1, _v5, ["when", ["yes", _y1], join(["let", [_x94, _y1]], _body13)]]);
+  var __r13 = unstash(Array.prototype.slice.call(arguments, 2));
+  var _x44 = destash33(x, __r13);
+  var _v2 = destash33(v, __r13);
+  var __id10 = __r13;
+  var _body6 = cut(__id10, 0);
+  var _y = unique("y");
+  return(["let", _y, _v2, ["when", ["yes", _y], join(["let", [_x44, _y]], _body6)]]);
 }});
 setenv("define-macro", {_stash: true, macro: function (name, args) {
-  var __r29 = unstash(Array.prototype.slice.call(arguments, 2));
-  var _name1 = destash33(name, __r29);
-  var _args3 = destash33(args, __r29);
-  var __id23 = __r29;
-  var _body15 = cut(__id23, 0);
-  var __x103 = ["setenv", ["quote", _name1]];
-  __x103.macro = join(["fn", _args3], _body15);
-  var _form1 = __x103;
-  eval(_form1);
-  return(_form1);
+  var __r14 = unstash(Array.prototype.slice.call(arguments, 2));
+  var _name = destash33(name, __r14);
+  var _args1 = destash33(args, __r14);
+  var __id111 = __r14;
+  var _body7 = cut(__id111, 0);
+  var __x50 = ["setenv", ["quote", _name]];
+  __x50.macro = join(["fn", _args1], _body7);
+  return(__x50);
 }});
 setenv("define-special", {_stash: true, macro: function (name, args) {
-  var __r31 = unstash(Array.prototype.slice.call(arguments, 2));
-  var _name3 = destash33(name, __r31);
-  var _args5 = destash33(args, __r31);
-  var __id25 = __r31;
-  var _body17 = cut(__id25, 0);
-  var __x109 = ["setenv", ["quote", _name3]];
-  __x109.special = join(["fn", _args5], _body17);
-  var _form3 = join(__x109, keys(_body17));
-  eval(_form3);
-  return(_form3);
+  var __r15 = unstash(Array.prototype.slice.call(arguments, 2));
+  var _name1 = destash33(name, __r15);
+  var _args2 = destash33(args, __r15);
+  var __id12 = __r15;
+  var _body8 = cut(__id12, 0);
+  var __x53 = ["setenv", ["quote", _name1]];
+  __x53.special = join(["fn", _args2], _body8);
+  return(join(__x53, keys(_body8)));
 }});
 setenv("define-symbol", {_stash: true, macro: function (name, expansion) {
-  setenv(name, {_stash: true, symbol: expansion});
-  var __x115 = ["setenv", ["quote", name]];
-  __x115.symbol = ["quote", expansion];
-  return(__x115);
+  var __x56 = ["setenv", ["quote", name]];
+  __x56.symbol = ["quote", expansion];
+  return(__x56);
 }});
-setenv("define-reader", {_stash: true, macro: function (_x123) {
-  var __id28 = _x123;
-  var _char1 = __id28[0];
-  var _s1 = __id28[1];
-  var __r35 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __x123 = destash33(_x123, __r35);
-  var __id29 = __r35;
-  var _body19 = cut(__id29, 0);
-  return(["set", ["get", "read-table", _char1], join(["fn", [_s1]], _body19)]);
+setenv("define-reader", {_stash: true, macro: function (_x59) {
+  var __id13 = _x59;
+  var _char = __id13[0];
+  var _s = __id13[1];
+  var __r17 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __x59 = destash33(_x59, __r17);
+  var __id14 = __r17;
+  var _body9 = cut(__id14, 0);
+  return(["set", ["get", "read-table", _char], join(["fn", [_s]], _body9)]);
 }});
 setenv("define", {_stash: true, macro: function (name, x) {
-  var __r37 = unstash(Array.prototype.slice.call(arguments, 2));
-  var _name5 = destash33(name, __r37);
-  var _x131 = destash33(x, __r37);
-  var __id31 = __r37;
-  var _body21 = cut(__id31, 0);
-  setenv(_name5, {_stash: true, variable: true});
-  if (some63(_body21)) {
-    return(join(["%local-function", _name5], bind42(_x131, _body21)));
+  var __r18 = unstash(Array.prototype.slice.call(arguments, 2));
+  var _name2 = destash33(name, __r18);
+  var _x64 = destash33(x, __r18);
+  var __id15 = __r18;
+  var _body10 = cut(__id15, 0);
+  setenv(_name2, {_stash: true, variable: true});
+  if (some63(_body10)) {
+    return(join(["%local-function", _name2], bind42(_x64, _body10)));
   } else {
-    return(["%local", _name5, _x131]);
+    return(["%local", _name2, _x64]);
   }
 }});
 setenv("define-global", {_stash: true, macro: function (name, x) {
-  var __r39 = unstash(Array.prototype.slice.call(arguments, 2));
-  var _name7 = destash33(name, __r39);
-  var _x137 = destash33(x, __r39);
-  var __id33 = __r39;
-  var _body23 = cut(__id33, 0);
-  setenv(_name7, {_stash: true, toplevel: true, variable: true});
-  if (some63(_body23)) {
-    return(join(["%global-function", _name7], bind42(_x137, _body23)));
+  var __r19 = unstash(Array.prototype.slice.call(arguments, 2));
+  var _name3 = destash33(name, __r19);
+  var _x67 = destash33(x, __r19);
+  var __id16 = __r19;
+  var _body11 = cut(__id16, 0);
+  setenv(_name3, {_stash: true, toplevel: true, variable: true});
+  if (some63(_body11)) {
+    return(join(["%global-function", _name3], bind42(_x67, _body11)));
   } else {
-    return(["set", _name7, _x137]);
+    return(["set", _name3, _x67]);
   }
 }});
 setenv("with-frame", {_stash: true, macro: function () {
-  var _body25 = unstash(Array.prototype.slice.call(arguments, 0));
-  var _x147 = unique("x");
-  return(["do", ["add", "environment", ["obj"]], ["with", _x147, join(["do"], _body25), ["drop", "environment"]]]);
+  var _body12 = unstash(Array.prototype.slice.call(arguments, 0));
+  var _x70 = unique("x");
+  return(["do", ["add", "environment", ["obj"]], ["with", _x70, join(["do"], _body12), ["drop", "environment"]]]);
 }});
-setenv("with-bindings", {_stash: true, macro: function (_x159) {
-  var __id36 = _x159;
-  var _names1 = __id36[0];
-  var __r41 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __x159 = destash33(_x159, __r41);
-  var __id37 = __r41;
-  var _body27 = cut(__id37, 0);
-  var _x160 = unique("x");
-  var __x163 = ["setenv", _x160];
-  __x163.variable = true;
-  return(join(["with-frame", ["each", _x160, _names1, __x163]], _body27));
+setenv("with-bindings", {_stash: true, macro: function (_x77) {
+  var __id17 = _x77;
+  var _names = __id17[0];
+  var __r20 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __x77 = destash33(_x77, __r20);
+  var __id18 = __r20;
+  var _body13 = cut(__id18, 0);
+  var _x78 = unique("x");
+  var __x81 = ["setenv", _x78];
+  __x81.variable = true;
+  return(join(["with-frame", ["each", _x78, _names, __x81]], _body13));
 }});
 setenv("let-macro", {_stash: true, macro: function (definitions) {
-  var __r44 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _definitions1 = destash33(definitions, __r44);
-  var __id39 = __r44;
-  var _body29 = cut(__id39, 0);
+  var __r21 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _definitions = destash33(definitions, __r21);
+  var __id19 = __r21;
+  var _body14 = cut(__id19, 0);
   add(environment, {});
   map(function (m) {
-    return(macroexpand(join(["define-macro"], m)));
-  }, _definitions1);
-  var __x167 = join(["do"], macroexpand(_body29));
+    return(eval(join(["define-macro"], m)));
+  }, _definitions);
+  var __x82 = join(["do"], macroexpand(_body14));
   drop(environment);
-  return(__x167);
+  return(__x82);
 }});
 setenv("let-symbol", {_stash: true, macro: function (expansions) {
-  var __r48 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _expansions1 = destash33(expansions, __r48);
-  var __id42 = __r48;
-  var _body31 = cut(__id42, 0);
+  var __r23 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _expansions = destash33(expansions, __r23);
+  var __id20 = __r23;
+  var _body15 = cut(__id20, 0);
   add(environment, {});
-  map(function (_x175) {
-    var __id43 = _x175;
-    var _name9 = __id43[0];
-    var _exp1 = __id43[1];
-    return(macroexpand(["define-symbol", _name9, _exp1]));
-  }, pair(_expansions1));
-  var __x174 = join(["do"], macroexpand(_body31));
+  map(function (_x86) {
+    var __id21 = _x86;
+    var _name4 = __id21[0];
+    var _exp = __id21[1];
+    return(setenv(_name4, {_stash: true, symbol: _exp}));
+  }, pair(_expansions));
+  var __x85 = join(["do"], macroexpand(_body15));
   drop(environment);
-  return(__x174);
+  return(__x85);
 }});
 setenv("let-unique", {_stash: true, macro: function (names) {
-  var __r52 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _names3 = destash33(names, __r52);
-  var __id45 = __r52;
-  var _body33 = cut(__id45, 0);
-  var _bs3 = map(function (n) {
+  var __r25 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _names1 = destash33(names, __r25);
+  var __id22 = __r25;
+  var _body16 = cut(__id22, 0);
+  var _bs11 = map(function (n) {
     return([n, ["unique", ["quote", n]]]);
-  }, _names3);
-  return(join(["let", apply(join, _bs3)], _body33));
+  }, _names1);
+  return(join(["let", apply(join, _bs11)], _body16));
 }});
 setenv("fn", {_stash: true, macro: function (args) {
-  var __r55 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _args7 = destash33(args, __r55);
-  var __id47 = __r55;
-  var _body35 = cut(__id47, 0);
-  return(join(["%function"], bind42(_args7, _body35)));
+  var __r27 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _args3 = destash33(args, __r27);
+  var __id23 = __r27;
+  var _body17 = cut(__id23, 0);
+  return(join(["%function"], bind42(_args3, _body17)));
 }});
 setenv("apply", {_stash: true, macro: function (f) {
-  var __r57 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _f1 = destash33(f, __r57);
-  var __id49 = __r57;
-  var _args9 = cut(__id49, 0);
-  if (_35(_args9) > 1) {
-    return([["do", "apply"], _f1, ["join", join(["list"], almost(_args9)), last(_args9)]]);
+  var __r28 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _f = destash33(f, __r28);
+  var __id24 = __r28;
+  var _args4 = cut(__id24, 0);
+  if (_35(_args4) > 1) {
+    return([["do", "apply"], _f, ["join", join(["list"], almost(_args4)), last(_args4)]]);
   } else {
-    return(join([["do", "apply"], _f1], _args9));
+    return(join([["do", "apply"], _f], _args4));
   }
 }});
 setenv("guard", {_stash: true, macro: function (expr) {
   if (target === "js") {
     return([["fn", join(), ["%try", ["list", true, expr]]]]);
   } else {
-    var _x231 = unique("x");
-    var _msg1 = unique("msg");
-    var _trace1 = unique("trace");
-    var __x253 = ["obj"];
-    __x253.message = _msg1;
-    __x253.stack = _trace1;
-    return(["let", [_x231, "nil", _msg1, "nil", _trace1, "nil"], ["if", ["xpcall", ["fn", join(), ["set", _x231, expr]], ["fn", ["m"], ["set", _trace1, [["get", "debug", ["quote", "traceback"]]], _msg1, ["if", ["string?", "m"], ["clip", "m", ["+", ["search", "m", "\": \""], 2]], ["nil?", "m"], "\"\"", ["str", "m"]]]]], ["list", true, _x231], ["list", false, __x253]]]);
+    var _x103 = unique("x");
+    var _msg = unique("msg");
+    var _trace = unique("trace");
+    var __x125 = ["obj"];
+    __x125.message = _msg;
+    __x125.stack = _trace;
+    return(["let", [_x103, "nil", _msg, "nil", _trace, "nil"], ["if", ["xpcall", ["fn", join(), ["set", _x103, expr]], ["fn", ["m"], ["set", _trace, [["get", "debug", ["quote", "traceback"]]], _msg, ["if", ["string?", "m"], ["clip", "m", ["+", ["search", "m", "\": \""], 2]], ["nil?", "m"], "\"\"", ["str", "m"]]]]], ["list", true, _x103], ["list", false, __x125]]]);
   }
 }});
 setenv("each", {_stash: true, macro: function (x, t) {
-  var __r61 = unstash(Array.prototype.slice.call(arguments, 2));
-  var _x268 = destash33(x, __r61);
-  var _t1 = destash33(t, __r61);
-  var __id52 = __r61;
-  var _body37 = cut(__id52, 0);
-  var _o3 = unique("o");
-  var _n3 = unique("n");
-  var _i3 = unique("i");
-  var _e9;
-  if (atom63(_x268)) {
-    _e9 = [_i3, _x268];
+  var __r30 = unstash(Array.prototype.slice.call(arguments, 2));
+  var _x126 = destash33(x, __r30);
+  var _t = destash33(t, __r30);
+  var __id25 = __r30;
+  var _body18 = cut(__id25, 0);
+  var _o1 = unique("o");
+  var _n1 = unique("n");
+  var _i1 = unique("i");
+  var _e1;
+  if (atom63(_x126)) {
+    _e1 = [_i1, _x126];
   } else {
-    var _e10;
-    if (_35(_x268) > 1) {
-      _e10 = _x268;
+    var _e2;
+    if (_35(_x126) > 1) {
+      _e2 = _x126;
     } else {
-      _e10 = [_i3, hd(_x268)];
+      _e2 = [_i1, hd(_x126)];
     }
-    _e9 = _e10;
+    _e1 = _e2;
   }
-  var __id53 = _e9;
-  var _k5 = __id53[0];
-  var _v7 = __id53[1];
-  var _e11;
+  var __id26 = _e1;
+  var _k2 = __id26[0];
+  var _v3 = __id26[1];
+  var _e3;
   if (target === "lua") {
-    _e11 = _body37;
+    _e3 = _body18;
   } else {
-    _e11 = [join(["let", _k5, ["if", ["numeric?", _k5], ["parseInt", _k5], _k5]], _body37)];
+    _e3 = [join(["let", _k2, ["if", ["numeric?", _k2], ["parseInt", _k2], _k2]], _body18)];
   }
-  return(["let", [_o3, _t1, _k5, "nil"], ["%for", _o3, _k5, join(["let", [_v7, ["get", _o3, _k5]]], _e11)]]);
+  return(["let", [_o1, _t, _k2, "nil"], ["%for", _o1, _k2, join(["let", [_v3, ["get", _o1, _k2]]], _e3)]]);
 }});
 setenv("for", {_stash: true, macro: function (i, to) {
-  var __r63 = unstash(Array.prototype.slice.call(arguments, 2));
-  var _i5 = destash33(i, __r63);
-  var _to1 = destash33(to, __r63);
-  var __id55 = __r63;
-  var _body39 = cut(__id55, 0);
-  return(["let", _i5, 0, join(["while", ["<", _i5, _to1]], _body39, [["inc", _i5]])]);
+  var __r31 = unstash(Array.prototype.slice.call(arguments, 2));
+  var _i2 = destash33(i, __r31);
+  var _to = destash33(to, __r31);
+  var __id27 = __r31;
+  var _body19 = cut(__id27, 0);
+  return(["let", _i2, 0, join(["while", ["<", _i2, _to]], _body19, [["inc", _i2]])]);
 }});
 setenv("step", {_stash: true, macro: function (v, t) {
-  var __r65 = unstash(Array.prototype.slice.call(arguments, 2));
-  var _v9 = destash33(v, __r65);
-  var _t3 = destash33(t, __r65);
-  var __id57 = __r65;
-  var _body41 = cut(__id57, 0);
-  var _x300 = unique("x");
-  var _i7 = unique("i");
-  return(["let", [_x300, _t3], ["for", _i7, ["#", _x300], join(["let", [_v9, ["at", _x300, _i7]]], _body41)]]);
+  var __r32 = unstash(Array.prototype.slice.call(arguments, 2));
+  var _v4 = destash33(v, __r32);
+  var _t1 = destash33(t, __r32);
+  var __id28 = __r32;
+  var _body20 = cut(__id28, 0);
+  var _x145 = unique("x");
+  var _i3 = unique("i");
+  return(["let", [_x145, _t1], ["for", _i3, ["#", _x145], join(["let", [_v4, ["at", _x145, _i3]]], _body20)]]);
 }});
 setenv("set-of", {_stash: true, macro: function () {
-  var _xs1 = unstash(Array.prototype.slice.call(arguments, 0));
-  var _l3 = [];
-  var __o5 = _xs1;
-  var __i9 = undefined;
-  for (__i9 in __o5) {
-    var _x310 = __o5[__i9];
-    var _e12;
-    if (numeric63(__i9)) {
-      _e12 = parseInt(__i9);
+  var _xs = unstash(Array.prototype.slice.call(arguments, 0));
+  var _l1 = [];
+  var __o2 = _xs;
+  var __i4 = undefined;
+  for (__i4 in __o2) {
+    var _x153 = __o2[__i4];
+    var _e4;
+    if (numeric63(__i4)) {
+      _e4 = parseInt(__i4);
     } else {
-      _e12 = __i9;
+      _e4 = __i4;
     }
-    var __i91 = _e12;
-    _l3[_x310] = true;
+    var __i41 = _e4;
+    _l1[_x153] = true;
   }
-  return(join(["obj"], _l3));
+  return(join(["obj"], _l1));
 }});
 setenv("language", {_stash: true, macro: function () {
   return(["quote", target]);
 }});
 setenv("target", {_stash: true, macro: function () {
-  var _clauses3 = unstash(Array.prototype.slice.call(arguments, 0));
-  return(_clauses3[target]);
+  var _clauses1 = unstash(Array.prototype.slice.call(arguments, 0));
+  return(_clauses1[target]);
 }});
 setenv("join!", {_stash: true, macro: function (a) {
-  var __r69 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _a3 = destash33(a, __r69);
-  var __id59 = __r69;
-  var _bs5 = cut(__id59, 0);
-  return(["set", _a3, join(["join", _a3], _bs5)]);
+  var __r34 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _a1 = destash33(a, __r34);
+  var __id29 = __r34;
+  var _bs21 = cut(__id29, 0);
+  return(["set", _a1, join(["join", _a1], _bs21)]);
 }});
 setenv("cat!", {_stash: true, macro: function (a) {
-  var __r71 = unstash(Array.prototype.slice.call(arguments, 1));
-  var _a5 = destash33(a, __r71);
-  var __id61 = __r71;
-  var _bs7 = cut(__id61, 0);
-  return(["set", _a5, join(["cat", _a5], _bs7)]);
+  var __r35 = unstash(Array.prototype.slice.call(arguments, 1));
+  var _a2 = destash33(a, __r35);
+  var __id30 = __r35;
+  var _bs3 = cut(__id30, 0);
+  return(["set", _a2, join(["cat", _a2], _bs3)]);
 }});
 setenv("inc", {_stash: true, macro: function (n, by) {
-  var _e13;
+  var _e5;
   if (nil63(by)) {
-    _e13 = 1;
+    _e5 = 1;
   } else {
-    _e13 = by;
+    _e5 = by;
   }
-  return(["set", n, ["+", n, _e13]]);
+  return(["set", n, ["+", n, _e5]]);
 }});
 setenv("dec", {_stash: true, macro: function (n, by) {
-  var _e14;
+  var _e6;
   if (nil63(by)) {
-    _e14 = 1;
+    _e6 = 1;
   } else {
-    _e14 = by;
+    _e6 = by;
   }
-  return(["set", n, ["-", n, _e14]]);
+  return(["set", n, ["-", n, _e6]]);
 }});
 setenv("with-indent", {_stash: true, macro: function (form) {
-  var _x335 = unique("x");
-  return(["do", ["inc", "indent-level"], ["with", _x335, form, ["dec", "indent-level"]]]);
+  var _x164 = unique("x");
+  return(["do", ["inc", "indent-level"], ["with", _x164, form, ["dec", "indent-level"]]]);
 }});
 setenv("export", {_stash: true, macro: function () {
-  var _names5 = unstash(Array.prototype.slice.call(arguments, 0));
+  var _names2 = unstash(Array.prototype.slice.call(arguments, 0));
   if (target === "js") {
     return(join(["do"], map(function (k) {
       return(["set", ["get", "exports", ["quote", k]], k]);
-    }, _names5)));
+    }, _names2)));
   } else {
-    var _x351 = {};
-    var __o7 = _names5;
-    var __i11 = undefined;
-    for (__i11 in __o7) {
-      var _k7 = __o7[__i11];
-      var _e15;
-      if (numeric63(__i11)) {
-        _e15 = parseInt(__i11);
+    var _x173 = {};
+    var __o3 = _names2;
+    var __i5 = undefined;
+    for (__i5 in __o3) {
+      var _k3 = __o3[__i5];
+      var _e7;
+      if (numeric63(__i5)) {
+        _e7 = parseInt(__i5);
       } else {
-        _e15 = __i11;
+        _e7 = __i5;
       }
-      var __i111 = _e15;
-      _x351[_k7] = _k7;
+      var __i51 = _e7;
+      _x173[_k3] = _k3;
     }
     return(["return", join(["%object"], mapo(function (x) {
       return(x);
-    }, _x351))]);
+    }, _x173))]);
   }
 }});
 setenv("when-compiling", {_stash: true, macro: function () {
-  var _body43 = unstash(Array.prototype.slice.call(arguments, 0));
-  return(eval(join(["do"], _body43)));
+  var _body21 = unstash(Array.prototype.slice.call(arguments, 0));
+  return(eval(join(["do"], _body21)));
 }});
 var reader = require("reader");
 var compiler = require("compiler");

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -630,13 +630,13 @@ setenv("quasiquote", {_stash = true, macro = function (form)
   return(quasiexpand(form, 1))
 end})
 setenv("set", {_stash = true, macro = function (...)
-  local _args1 = unstash({...})
-  return(join({"do"}, map(function (_x5)
-    local __id1 = _x5
-    local _lh1 = __id1[1]
-    local _rh1 = __id1[2]
-    return({"%set", _lh1, _rh1})
-  end, pair(_args1))))
+  local _args = unstash({...})
+  return(join({"do"}, map(function (_x2)
+    local __id = _x2
+    local _lh = __id[1]
+    local _rh = __id[2]
+    return({"%set", _lh, _rh})
+  end, pair(_args))))
 end})
 setenv("at", {_stash = true, macro = function (l, i)
   if target == "lua" and number63(i) then
@@ -656,406 +656,401 @@ setenv("wipe", {_stash = true, macro = function (place)
   end
 end})
 setenv("list", {_stash = true, macro = function (...)
-  local _body1 = unstash({...})
-  local _x24 = unique("x")
-  local _l1 = {}
-  local _forms1 = {}
-  local __o1 = _body1
-  local _k2 = nil
-  for _k2 in next, __o1 do
-    local _v1 = __o1[_k2]
-    if number63(_k2) then
-      _l1[_k2] = _v1
+  local _body = unstash({...})
+  local _x9 = unique("x")
+  local _l = {}
+  local _forms = {}
+  local __o = _body
+  local _k = nil
+  for _k in next, __o do
+    local _v = __o[_k]
+    if number63(_k) then
+      _l[_k] = _v
     else
-      add(_forms1, {"set", {"get", _x24, {"quote", _k2}}, _v1})
+      add(_forms, {"set", {"get", _x9, {"quote", _k}}, _v})
     end
   end
-  if some63(_forms1) then
-    return(join({"let", _x24, join({"%array"}, _l1)}, _forms1, {_x24}))
+  if some63(_forms) then
+    return(join({"let", _x9, join({"%array"}, _l)}, _forms, {_x9}))
   else
-    return(join({"%array"}, _l1))
+    return(join({"%array"}, _l))
   end
 end})
 setenv("if", {_stash = true, macro = function (...)
-  local _branches1 = unstash({...})
-  return(hd(expand_if(_branches1)))
+  local _branches = unstash({...})
+  return(hd(expand_if(_branches)))
 end})
 setenv("case", {_stash = true, macro = function (expr, ...)
-  local __r13 = unstash({...})
-  local _expr1 = destash33(expr, __r13)
-  local __id4 = __r13
-  local _clauses1 = cut(__id4, 0)
-  local _x45 = unique("x")
-  local _eq1 = function (_)
-    return({"=", {"quote", _}, _x45})
+  local __r5 = unstash({...})
+  local _expr = destash33(expr, __r5)
+  local __id1 = __r5
+  local _clauses = cut(__id1, 0)
+  local _x19 = unique("x")
+  local _eq = function (_)
+    return({"=", {"quote", _}, _x19})
   end
-  local _cl1 = function (_x48)
-    local __id5 = _x48
-    local _a1 = __id5[1]
-    local _b1 = __id5[2]
-    if nil63(_b1) then
-      return({_a1})
+  local _cl = function (_x22)
+    local __id2 = _x22
+    local _a = __id2[1]
+    local _b = __id2[2]
+    if nil63(_b) then
+      return({_a})
     else
-      if string63(_a1) or number63(_a1) then
-        return({_eq1(_a1), _b1})
+      if string63(_a) or number63(_a) then
+        return({_eq(_a), _b})
       else
-        if one63(_a1) then
-          return({_eq1(hd(_a1)), _b1})
+        if one63(_a) then
+          return({_eq(hd(_a)), _b})
         else
-          if _35(_a1) > 1 then
-            return({join({"or"}, map(_eq1, _a1)), _b1})
+          if _35(_a) > 1 then
+            return({join({"or"}, map(_eq, _a)), _b})
           end
         end
       end
     end
   end
-  return({"let", _x45, _expr1, join({"if"}, apply(join, map(_cl1, pair(_clauses1))))})
+  return({"let", _x19, _expr, join({"if"}, apply(join, map(_cl, pair(_clauses))))})
 end})
 setenv("when", {_stash = true, macro = function (cond, ...)
-  local __r17 = unstash({...})
-  local _cond1 = destash33(cond, __r17)
-  local __id7 = __r17
-  local _body3 = cut(__id7, 0)
-  return({"if", _cond1, join({"do"}, _body3)})
+  local __r8 = unstash({...})
+  local _cond = destash33(cond, __r8)
+  local __id3 = __r8
+  local _body1 = cut(__id3, 0)
+  return({"if", _cond, join({"do"}, _body1)})
 end})
 setenv("unless", {_stash = true, macro = function (cond, ...)
-  local __r19 = unstash({...})
-  local _cond3 = destash33(cond, __r19)
-  local __id9 = __r19
-  local _body5 = cut(__id9, 0)
-  return({"if", {"not", _cond3}, join({"do"}, _body5)})
+  local __r9 = unstash({...})
+  local _cond1 = destash33(cond, __r9)
+  local __id4 = __r9
+  local _body2 = cut(__id4, 0)
+  return({"if", {"not", _cond1}, join({"do"}, _body2)})
 end})
 setenv("obj", {_stash = true, macro = function (...)
-  local _body7 = unstash({...})
+  local _body3 = unstash({...})
   return(join({"%object"}, mapo(function (x)
     return(x)
-  end, _body7)))
+  end, _body3)))
 end})
 setenv("let", {_stash = true, macro = function (bs, ...)
-  local __r23 = unstash({...})
-  local _bs11 = destash33(bs, __r23)
-  local __id14 = __r23
-  local _body9 = cut(__id14, 0)
-  if atom63(_bs11) then
-    return(join({"let", {_bs11, hd(_body9)}}, tl(_body9)))
+  local __r11 = unstash({...})
+  local _bs = destash33(bs, __r11)
+  local __id5 = __r11
+  local _body4 = cut(__id5, 0)
+  if atom63(_bs) then
+    return(join({"let", {_bs, hd(_body4)}}, tl(_body4)))
   else
-    if none63(_bs11) then
-      return(join({"do"}, _body9))
+    if none63(_bs) then
+      return(join({"do"}, _body4))
     else
-      local __id15 = _bs11
-      local _lh3 = __id15[1]
-      local _rh3 = __id15[2]
-      local _bs21 = cut(__id15, 2)
-      local __id16 = bind(_lh3, _rh3)
-      local _id17 = __id16[1]
-      local _val1 = __id16[2]
-      local _bs12 = cut(__id16, 2)
-      local _renames1 = {}
-      if not id_literal63(_id17) then
-        local _id121 = unique(_id17)
-        _renames1 = {_id17, _id121}
-        _id17 = _id121
+      local __id6 = _bs
+      local _lh1 = __id6[1]
+      local _rh1 = __id6[2]
+      local _bs2 = cut(__id6, 2)
+      local __id7 = bind(_lh1, _rh1)
+      local _id8 = __id7[1]
+      local _val = __id7[2]
+      local _bs1 = cut(__id7, 2)
+      local _renames = {}
+      if not id_literal63(_id8) then
+        local _id11 = unique(_id8)
+        _renames = {_id8, _id11}
+        _id8 = _id11
       end
-      return({"do", {"%local", _id17, _val1}, {"let-symbol", _renames1, join({"let", join(_bs12, _bs21)}, _body9)}})
+      return({"do", {"%local", _id8, _val}, {"let-symbol", _renames, join({"let", join(_bs1, _bs2)}, _body4)}})
     end
   end
 end})
 setenv("with", {_stash = true, macro = function (x, v, ...)
-  local __r25 = unstash({...})
-  local _x93 = destash33(x, __r25)
-  local _v3 = destash33(v, __r25)
-  local __id19 = __r25
-  local _body11 = cut(__id19, 0)
-  return(join({"let", {_x93, _v3}}, _body11, {_x93}))
+  local __r12 = unstash({...})
+  local _x49 = destash33(x, __r12)
+  local _v1 = destash33(v, __r12)
+  local __id9 = __r12
+  local _body5 = cut(__id9, 0)
+  return(join({"let", {_x49, _v1}}, _body5, {_x49}))
 end})
 setenv("let-when", {_stash = true, macro = function (x, v, ...)
-  local __r27 = unstash({...})
-  local _x104 = destash33(x, __r27)
-  local _v5 = destash33(v, __r27)
-  local __id21 = __r27
-  local _body13 = cut(__id21, 0)
-  local _y1 = unique("y")
-  return({"let", _y1, _v5, {"when", {"yes", _y1}, join({"let", {_x104, _y1}}, _body13)}})
+  local __r13 = unstash({...})
+  local _x54 = destash33(x, __r13)
+  local _v2 = destash33(v, __r13)
+  local __id10 = __r13
+  local _body6 = cut(__id10, 0)
+  local _y = unique("y")
+  return({"let", _y, _v2, {"when", {"yes", _y}, join({"let", {_x54, _y}}, _body6)}})
 end})
 setenv("define-macro", {_stash = true, macro = function (name, args, ...)
-  local __r29 = unstash({...})
-  local _name1 = destash33(name, __r29)
-  local _args3 = destash33(args, __r29)
-  local __id23 = __r29
-  local _body15 = cut(__id23, 0)
-  local __x114 = {"setenv", {"quote", _name1}}
-  __x114.macro = join({"fn", _args3}, _body15)
-  local _form1 = __x114
-  eval(_form1)
-  return(_form1)
+  local __r14 = unstash({...})
+  local _name = destash33(name, __r14)
+  local _args1 = destash33(args, __r14)
+  local __id111 = __r14
+  local _body7 = cut(__id111, 0)
+  local __x61 = {"setenv", {"quote", _name}}
+  __x61.macro = join({"fn", _args1}, _body7)
+  return(__x61)
 end})
 setenv("define-special", {_stash = true, macro = function (name, args, ...)
-  local __r31 = unstash({...})
-  local _name3 = destash33(name, __r31)
-  local _args5 = destash33(args, __r31)
-  local __id25 = __r31
-  local _body17 = cut(__id25, 0)
-  local __x121 = {"setenv", {"quote", _name3}}
-  __x121.special = join({"fn", _args5}, _body17)
-  local _form3 = join(__x121, keys(_body17))
-  eval(_form3)
-  return(_form3)
+  local __r15 = unstash({...})
+  local _name1 = destash33(name, __r15)
+  local _args2 = destash33(args, __r15)
+  local __id12 = __r15
+  local _body8 = cut(__id12, 0)
+  local __x65 = {"setenv", {"quote", _name1}}
+  __x65.special = join({"fn", _args2}, _body8)
+  return(join(__x65, keys(_body8)))
 end})
 setenv("define-symbol", {_stash = true, macro = function (name, expansion)
-  setenv(name, {_stash = true, symbol = expansion})
-  local __x127 = {"setenv", {"quote", name}}
-  __x127.symbol = {"quote", expansion}
-  return(__x127)
+  local __x68 = {"setenv", {"quote", name}}
+  __x68.symbol = {"quote", expansion}
+  return(__x68)
 end})
-setenv("define-reader", {_stash = true, macro = function (_x135, ...)
-  local __id28 = _x135
-  local _char1 = __id28[1]
-  local _s1 = __id28[2]
-  local __r35 = unstash({...})
-  local __x135 = destash33(_x135, __r35)
-  local __id29 = __r35
-  local _body19 = cut(__id29, 0)
-  return({"set", {"get", "read-table", _char1}, join({"fn", {_s1}}, _body19)})
+setenv("define-reader", {_stash = true, macro = function (_x71, ...)
+  local __id13 = _x71
+  local _char = __id13[1]
+  local _s = __id13[2]
+  local __r17 = unstash({...})
+  local __x71 = destash33(_x71, __r17)
+  local __id14 = __r17
+  local _body9 = cut(__id14, 0)
+  return({"set", {"get", "read-table", _char}, join({"fn", {_s}}, _body9)})
 end})
 setenv("define", {_stash = true, macro = function (name, x, ...)
-  local __r37 = unstash({...})
-  local _name5 = destash33(name, __r37)
-  local _x145 = destash33(x, __r37)
-  local __id31 = __r37
-  local _body21 = cut(__id31, 0)
-  setenv(_name5, {_stash = true, variable = true})
-  if some63(_body21) then
-    return(join({"%local-function", _name5}, bind42(_x145, _body21)))
+  local __r18 = unstash({...})
+  local _name2 = destash33(name, __r18)
+  local _x78 = destash33(x, __r18)
+  local __id15 = __r18
+  local _body10 = cut(__id15, 0)
+  setenv(_name2, {_stash = true, variable = true})
+  if some63(_body10) then
+    return(join({"%local-function", _name2}, bind42(_x78, _body10)))
   else
-    return({"%local", _name5, _x145})
+    return({"%local", _name2, _x78})
   end
 end})
 setenv("define-global", {_stash = true, macro = function (name, x, ...)
-  local __r39 = unstash({...})
-  local _name7 = destash33(name, __r39)
-  local _x152 = destash33(x, __r39)
-  local __id33 = __r39
-  local _body23 = cut(__id33, 0)
-  setenv(_name7, {_stash = true, toplevel = true, variable = true})
-  if some63(_body23) then
-    return(join({"%global-function", _name7}, bind42(_x152, _body23)))
+  local __r19 = unstash({...})
+  local _name3 = destash33(name, __r19)
+  local _x82 = destash33(x, __r19)
+  local __id16 = __r19
+  local _body11 = cut(__id16, 0)
+  setenv(_name3, {_stash = true, toplevel = true, variable = true})
+  if some63(_body11) then
+    return(join({"%global-function", _name3}, bind42(_x82, _body11)))
   else
-    return({"set", _name7, _x152})
+    return({"set", _name3, _x82})
   end
 end})
 setenv("with-frame", {_stash = true, macro = function (...)
-  local _body25 = unstash({...})
-  local _x163 = unique("x")
-  return({"do", {"add", "environment", {"obj"}}, {"with", _x163, join({"do"}, _body25), {"drop", "environment"}}})
+  local _body12 = unstash({...})
+  local _x86 = unique("x")
+  return({"do", {"add", "environment", {"obj"}}, {"with", _x86, join({"do"}, _body12), {"drop", "environment"}}})
 end})
-setenv("with-bindings", {_stash = true, macro = function (_x175, ...)
-  local __id36 = _x175
-  local _names1 = __id36[1]
-  local __r41 = unstash({...})
-  local __x175 = destash33(_x175, __r41)
-  local __id37 = __r41
-  local _body27 = cut(__id37, 0)
-  local _x177 = unique("x")
-  local __x180 = {"setenv", _x177}
-  __x180.variable = true
-  return(join({"with-frame", {"each", _x177, _names1, __x180}}, _body27))
+setenv("with-bindings", {_stash = true, macro = function (_x93, ...)
+  local __id17 = _x93
+  local _names = __id17[1]
+  local __r20 = unstash({...})
+  local __x93 = destash33(_x93, __r20)
+  local __id18 = __r20
+  local _body13 = cut(__id18, 0)
+  local _x95 = unique("x")
+  local __x98 = {"setenv", _x95}
+  __x98.variable = true
+  return(join({"with-frame", {"each", _x95, _names, __x98}}, _body13))
 end})
 setenv("let-macro", {_stash = true, macro = function (definitions, ...)
-  local __r44 = unstash({...})
-  local _definitions1 = destash33(definitions, __r44)
-  local __id39 = __r44
-  local _body29 = cut(__id39, 0)
+  local __r21 = unstash({...})
+  local _definitions = destash33(definitions, __r21)
+  local __id19 = __r21
+  local _body14 = cut(__id19, 0)
   add(environment, {})
   map(function (m)
-    return(macroexpand(join({"define-macro"}, m)))
-  end, _definitions1)
-  local __x185 = join({"do"}, macroexpand(_body29))
+    return(eval(join({"define-macro"}, m)))
+  end, _definitions)
+  local __x100 = join({"do"}, macroexpand(_body14))
   drop(environment)
-  return(__x185)
+  return(__x100)
 end})
 setenv("let-symbol", {_stash = true, macro = function (expansions, ...)
-  local __r48 = unstash({...})
-  local _expansions1 = destash33(expansions, __r48)
-  local __id42 = __r48
-  local _body31 = cut(__id42, 0)
+  local __r23 = unstash({...})
+  local _expansions = destash33(expansions, __r23)
+  local __id20 = __r23
+  local _body15 = cut(__id20, 0)
   add(environment, {})
-  map(function (_x194)
-    local __id43 = _x194
-    local _name9 = __id43[1]
-    local _exp1 = __id43[2]
-    return(macroexpand({"define-symbol", _name9, _exp1}))
-  end, pair(_expansions1))
-  local __x193 = join({"do"}, macroexpand(_body31))
+  map(function (_x105)
+    local __id21 = _x105
+    local _name4 = __id21[1]
+    local _exp = __id21[2]
+    return(setenv(_name4, {_stash = true, symbol = _exp}))
+  end, pair(_expansions))
+  local __x104 = join({"do"}, macroexpand(_body15))
   drop(environment)
-  return(__x193)
+  return(__x104)
 end})
 setenv("let-unique", {_stash = true, macro = function (names, ...)
-  local __r52 = unstash({...})
-  local _names3 = destash33(names, __r52)
-  local __id45 = __r52
-  local _body33 = cut(__id45, 0)
-  local _bs3 = map(function (n)
+  local __r25 = unstash({...})
+  local _names1 = destash33(names, __r25)
+  local __id22 = __r25
+  local _body16 = cut(__id22, 0)
+  local _bs11 = map(function (n)
     return({n, {"unique", {"quote", n}}})
-  end, _names3)
-  return(join({"let", apply(join, _bs3)}, _body33))
+  end, _names1)
+  return(join({"let", apply(join, _bs11)}, _body16))
 end})
 setenv("fn", {_stash = true, macro = function (args, ...)
-  local __r55 = unstash({...})
-  local _args7 = destash33(args, __r55)
-  local __id47 = __r55
-  local _body35 = cut(__id47, 0)
-  return(join({"%function"}, bind42(_args7, _body35)))
+  local __r27 = unstash({...})
+  local _args3 = destash33(args, __r27)
+  local __id23 = __r27
+  local _body17 = cut(__id23, 0)
+  return(join({"%function"}, bind42(_args3, _body17)))
 end})
 setenv("apply", {_stash = true, macro = function (f, ...)
-  local __r57 = unstash({...})
-  local _f1 = destash33(f, __r57)
-  local __id49 = __r57
-  local _args9 = cut(__id49, 0)
-  if _35(_args9) > 1 then
-    return({{"do", "apply"}, _f1, {"join", join({"list"}, almost(_args9)), last(_args9)}})
+  local __r28 = unstash({...})
+  local _f = destash33(f, __r28)
+  local __id24 = __r28
+  local _args4 = cut(__id24, 0)
+  if _35(_args4) > 1 then
+    return({{"do", "apply"}, _f, {"join", join({"list"}, almost(_args4)), last(_args4)}})
   else
-    return(join({{"do", "apply"}, _f1}, _args9))
+    return(join({{"do", "apply"}, _f}, _args4))
   end
 end})
 setenv("guard", {_stash = true, macro = function (expr)
   if target == "js" then
     return({{"fn", join(), {"%try", {"list", true, expr}}}})
   else
-    local _x253 = unique("x")
-    local _msg1 = unique("msg")
-    local _trace1 = unique("trace")
-    local __x275 = {"obj"}
-    __x275.message = _msg1
-    __x275.stack = _trace1
-    return({"let", {_x253, "nil", _msg1, "nil", _trace1, "nil"}, {"if", {"xpcall", {"fn", join(), {"set", _x253, expr}}, {"fn", {"m"}, {"set", _trace1, {{"get", "debug", {"quote", "traceback"}}}, _msg1, {"if", {"string?", "m"}, {"clip", "m", {"+", {"search", "m", "\": \""}, 2}}, {"nil?", "m"}, "\"\"", {"str", "m"}}}}}, {"list", true, _x253}, {"list", false, __x275}}})
+    local _x125 = unique("x")
+    local _msg = unique("msg")
+    local _trace = unique("trace")
+    local __x147 = {"obj"}
+    __x147.message = _msg
+    __x147.stack = _trace
+    return({"let", {_x125, "nil", _msg, "nil", _trace, "nil"}, {"if", {"xpcall", {"fn", join(), {"set", _x125, expr}}, {"fn", {"m"}, {"set", _trace, {{"get", "debug", {"quote", "traceback"}}}, _msg, {"if", {"string?", "m"}, {"clip", "m", {"+", {"search", "m", "\": \""}, 2}}, {"nil?", "m"}, "\"\"", {"str", "m"}}}}}, {"list", true, _x125}, {"list", false, __x147}}})
   end
 end})
 setenv("each", {_stash = true, macro = function (x, t, ...)
-  local __r61 = unstash({...})
-  local _x291 = destash33(x, __r61)
-  local _t1 = destash33(t, __r61)
-  local __id52 = __r61
-  local _body37 = cut(__id52, 0)
-  local _o3 = unique("o")
-  local _n3 = unique("n")
-  local _i3 = unique("i")
-  local _e8
-  if atom63(_x291) then
-    _e8 = {_i3, _x291}
+  local __r30 = unstash({...})
+  local _x149 = destash33(x, __r30)
+  local _t = destash33(t, __r30)
+  local __id25 = __r30
+  local _body18 = cut(__id25, 0)
+  local _o1 = unique("o")
+  local _n1 = unique("n")
+  local _i1 = unique("i")
+  local _e
+  if atom63(_x149) then
+    _e = {_i1, _x149}
   else
-    local _e9
-    if _35(_x291) > 1 then
-      _e9 = _x291
+    local _e1
+    if _35(_x149) > 1 then
+      _e1 = _x149
     else
-      _e9 = {_i3, hd(_x291)}
+      _e1 = {_i1, hd(_x149)}
     end
-    _e8 = _e9
+    _e = _e1
   end
-  local __id53 = _e8
-  local _k4 = __id53[1]
-  local _v7 = __id53[2]
-  local _e10
+  local __id26 = _e
+  local _k1 = __id26[1]
+  local _v3 = __id26[2]
+  local _e2
   if target == "lua" then
-    _e10 = _body37
+    _e2 = _body18
   else
-    _e10 = {join({"let", _k4, {"if", {"numeric?", _k4}, {"parseInt", _k4}, _k4}}, _body37)}
+    _e2 = {join({"let", _k1, {"if", {"numeric?", _k1}, {"parseInt", _k1}, _k1}}, _body18)}
   end
-  return({"let", {_o3, _t1, _k4, "nil"}, {"%for", _o3, _k4, join({"let", {_v7, {"get", _o3, _k4}}}, _e10)}})
+  return({"let", {_o1, _t, _k1, "nil"}, {"%for", _o1, _k1, join({"let", {_v3, {"get", _o1, _k1}}}, _e2)}})
 end})
 setenv("for", {_stash = true, macro = function (i, to, ...)
-  local __r63 = unstash({...})
-  local _i5 = destash33(i, __r63)
-  local _to1 = destash33(to, __r63)
-  local __id55 = __r63
-  local _body39 = cut(__id55, 0)
-  return({"let", _i5, 0, join({"while", {"<", _i5, _to1}}, _body39, {{"inc", _i5}})})
+  local __r31 = unstash({...})
+  local _i2 = destash33(i, __r31)
+  local _to = destash33(to, __r31)
+  local __id27 = __r31
+  local _body19 = cut(__id27, 0)
+  return({"let", _i2, 0, join({"while", {"<", _i2, _to}}, _body19, {{"inc", _i2}})})
 end})
 setenv("step", {_stash = true, macro = function (v, t, ...)
-  local __r65 = unstash({...})
-  local _v9 = destash33(v, __r65)
-  local _t3 = destash33(t, __r65)
-  local __id57 = __r65
-  local _body41 = cut(__id57, 0)
-  local _x325 = unique("x")
-  local _i7 = unique("i")
-  return({"let", {_x325, _t3}, {"for", _i7, {"#", _x325}, join({"let", {_v9, {"at", _x325, _i7}}}, _body41)}})
+  local __r32 = unstash({...})
+  local _v4 = destash33(v, __r32)
+  local _t1 = destash33(t, __r32)
+  local __id28 = __r32
+  local _body20 = cut(__id28, 0)
+  local _x170 = unique("x")
+  local _i3 = unique("i")
+  return({"let", {_x170, _t1}, {"for", _i3, {"#", _x170}, join({"let", {_v4, {"at", _x170, _i3}}}, _body20)}})
 end})
 setenv("set-of", {_stash = true, macro = function (...)
-  local _xs1 = unstash({...})
-  local _l3 = {}
-  local __o5 = _xs1
-  local __i9 = nil
-  for __i9 in next, __o5 do
-    local _x336 = __o5[__i9]
-    _l3[_x336] = true
+  local _xs = unstash({...})
+  local _l1 = {}
+  local __o2 = _xs
+  local __i4 = nil
+  for __i4 in next, __o2 do
+    local _x179 = __o2[__i4]
+    _l1[_x179] = true
   end
-  return(join({"obj"}, _l3))
+  return(join({"obj"}, _l1))
 end})
 setenv("language", {_stash = true, macro = function ()
   return({"quote", target})
 end})
 setenv("target", {_stash = true, macro = function (...)
-  local _clauses3 = unstash({...})
-  return(_clauses3[target])
+  local _clauses1 = unstash({...})
+  return(_clauses1[target])
 end})
 setenv("join!", {_stash = true, macro = function (a, ...)
-  local __r69 = unstash({...})
-  local _a3 = destash33(a, __r69)
-  local __id59 = __r69
-  local _bs5 = cut(__id59, 0)
-  return({"set", _a3, join({"join", _a3}, _bs5)})
+  local __r34 = unstash({...})
+  local _a1 = destash33(a, __r34)
+  local __id29 = __r34
+  local _bs21 = cut(__id29, 0)
+  return({"set", _a1, join({"join", _a1}, _bs21)})
 end})
 setenv("cat!", {_stash = true, macro = function (a, ...)
-  local __r71 = unstash({...})
-  local _a5 = destash33(a, __r71)
-  local __id61 = __r71
-  local _bs7 = cut(__id61, 0)
-  return({"set", _a5, join({"cat", _a5}, _bs7)})
+  local __r35 = unstash({...})
+  local _a2 = destash33(a, __r35)
+  local __id30 = __r35
+  local _bs3 = cut(__id30, 0)
+  return({"set", _a2, join({"cat", _a2}, _bs3)})
 end})
 setenv("inc", {_stash = true, macro = function (n, by)
-  local _e11
+  local _e3
   if nil63(by) then
-    _e11 = 1
+    _e3 = 1
   else
-    _e11 = by
+    _e3 = by
   end
-  return({"set", n, {"+", n, _e11}})
+  return({"set", n, {"+", n, _e3}})
 end})
 setenv("dec", {_stash = true, macro = function (n, by)
-  local _e12
+  local _e4
   if nil63(by) then
-    _e12 = 1
+    _e4 = 1
   else
-    _e12 = by
+    _e4 = by
   end
-  return({"set", n, {"-", n, _e12}})
+  return({"set", n, {"-", n, _e4}})
 end})
 setenv("with-indent", {_stash = true, macro = function (form)
-  local _x364 = unique("x")
-  return({"do", {"inc", "indent-level"}, {"with", _x364, form, {"dec", "indent-level"}}})
+  local _x193 = unique("x")
+  return({"do", {"inc", "indent-level"}, {"with", _x193, form, {"dec", "indent-level"}}})
 end})
 setenv("export", {_stash = true, macro = function (...)
-  local _names5 = unstash({...})
+  local _names2 = unstash({...})
   if target == "js" then
     return(join({"do"}, map(function (k)
       return({"set", {"get", "exports", {"quote", k}}, k})
-    end, _names5)))
+    end, _names2)))
   else
-    local _x381 = {}
-    local __o7 = _names5
-    local __i11 = nil
-    for __i11 in next, __o7 do
-      local _k6 = __o7[__i11]
-      _x381[_k6] = _k6
+    local _x203 = {}
+    local __o3 = _names2
+    local __i5 = nil
+    for __i5 in next, __o3 do
+      local _k2 = __o3[__i5]
+      _x203[_k2] = _k2
     end
     return({"return", join({"%object"}, mapo(function (x)
       return(x)
-    end, _x381))})
+    end, _x203))})
   end
 end})
 setenv("when-compiling", {_stash = true, macro = function (...)
-  local _body43 = unstash({...})
-  return(eval(join({"do"}, _body43)))
+  local _body21 = unstash({...})
+  return(eval(join({"do"}, _body21)))
 end})
 local reader = require("reader")
 local compiler = require("compiler")

--- a/macros.l
+++ b/macros.l
@@ -79,17 +79,12 @@
            ,@body)))))
 
 (define-macro define-macro (name args rest: body)
-  (let form `(setenv ',name macro: (fn ,args ,@body))
-    (eval form)
-    form))
+  `(setenv ',name macro: (fn ,args ,@body)))
 
 (define-macro define-special (name args rest: body)
-  (let form `(setenv ',name special: (fn ,args ,@body) ,@(keys body))
-    (eval form)
-    form))
+  `(setenv ',name special: (fn ,args ,@body) ,@(keys body)))
 
 (define-macro define-symbol (name expansion)
-  (setenv name symbol: expansion)
   `(setenv ',name symbol: ',expansion))
 
 (define-macro define-reader ((char s) rest: body)
@@ -123,14 +118,14 @@
 (define-macro let-macro (definitions rest: body)
   (with-frame
     (map (fn (m)
-           (macroexpand `(define-macro ,@m)))
+           (eval `(define-macro ,@m)))
          definitions)
     `(do ,@(macroexpand body))))
 
 (define-macro let-symbol (expansions rest: body)
   (with-frame
     (map (fn ((name exp))
-           (macroexpand `(define-symbol ,name ,exp)))
+           (setenv name symbol: exp))
          (pair expansions))
     `(do ,@(macroexpand body))))
 

--- a/test.l
+++ b/test.l
@@ -1,5 +1,23 @@
 #!/usr/bin/env bin/lumen
 
+(when-compiling
+  (define-macro test (x msg)
+    `(if (not ,x)
+         (do (set failed (+ failed 1))
+             (return ,msg))
+       (inc passed)))
+
+  (define-macro test= (a b)
+    (let-unique (x y)
+      `(let (,x ,a ,y ,b)
+         (test (equal? ,x ,y)
+               (cat "failed: expected " (str ,x) ", was " (str ,y))))))
+
+  (define-macro define-test (name rest: body)
+    `(add tests (list ',name (fn () ,@body))))
+
+  nil)
+
 (define passed 0)
 (define failed 0)
 (define tests ())
@@ -7,24 +25,9 @@
 (define reader (require 'reader))
 (define compiler (require 'compiler))
 
-(define-macro test (x msg)
-  `(if (not ,x)
-       (do (set failed (+ failed 1))
-           (return ,msg))
-     (inc passed)))
-
 (define equal? (a b)
   (if (atom? a) (= a b)
     (= (str a) (str b))))
-
-(define-macro test= (a b)
-  (let-unique (x y)
-    `(let (,x ,a ,y ,b)
-       (test (equal? ,x ,y)
-             (cat "failed: expected " (str ,x) ", was " (str ,y))))))
-
-(define-macro define-test (name rest: body)
-  `(add tests (list ',name (fn () ,@body))))
 
 (define-global run ()
   (each ((name f)) tests
@@ -767,7 +770,9 @@ c"
       (test= 20 b))))
 
 (define-test define-symbol
-  (define-symbol zzz 42)
+  (when-compiling
+    (define-symbol zzz 42)
+    nil)
   (test= zzz 42))
 
 (define-test macros-and-symbols


### PR DESCRIPTION
These forms no longer evaluate at compile time. In addition to speeding up total compile time by 8%, this allows macros and specials to use functions that were defined outside of its body.

I wanted to submit this PR to see what you thought of this idea. It seems to solve the problem of "How can I write a macro that uses locally-defined functions?" while also speeding up overall compile time.

The tradeoff is that macros and specials no longer evaluate immediately at compile time. I think this is a plus: I've often tried to make changes to `define-macro` or `define-special` in ways that cause bootstrapping issues. I.e. currently, if you change the definition of `define-macro`, then `macros.l` will use the old definition in one half of the file and the new definition in the second half.

If you look at `test.l`, you can see an example of a file that defines local macros. The trick is to wrap the definitions in a `when-compiling` form, which evaluates the forms without emitting any compiled output.

What would some of your concerns be with this approach?