### PR TITLE
Minor fix in LOWER-STATEMENT

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -849,7 +849,7 @@ var lower_statement = function (form, tail63) {
   }
 };
 var lower_body = function (body, tail63) {
-  return(lower_statement(join(["do"], body), tail63));
+  return(either(lower_statement(join(["do"], body), tail63), ["do"]));
 };
 var literal63 = function (form) {
   return(atom63(form) || hd(form) === "%array" || hd(form) === "%object");

--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -834,22 +834,28 @@ compile = function (form) {
 var lower_statement = function (form, tail63) {
   var _hoist = [];
   var _e = lower(form, _hoist, true, tail63);
+  var _e46;
   if (some63(_hoist) && is63(_e)) {
-    return(join(["do"], _hoist, [_e]));
+    _e46 = join(["do"], _hoist, [_e]);
   } else {
+    var _e47;
     if (is63(_e)) {
-      return(_e);
+      _e47 = _e;
     } else {
+      var _e48;
       if (_35(_hoist) > 1) {
-        return(join(["do"], _hoist));
+        _e48 = join(["do"], _hoist);
       } else {
-        return(hd(_hoist));
+        _e48 = hd(_hoist);
       }
+      _e47 = _e48;
     }
+    _e46 = _e47;
   }
+  return(either(_e46, ["do"]));
 };
 var lower_body = function (body, tail63) {
-  return(either(lower_statement(join(["do"], body), tail63), ["do"]));
+  return(lower_statement(join(["do"], body), tail63));
 };
 var literal63 = function (form) {
   return(atom63(form) || hd(form) === "%array" || hd(form) === "%object");

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -780,22 +780,28 @@ end
 local function lower_statement(form, tail63)
   local _hoist = {}
   local _e = lower(form, _hoist, true, tail63)
+  local _e38
   if some63(_hoist) and is63(_e) then
-    return(join({"do"}, _hoist, {_e}))
+    _e38 = join({"do"}, _hoist, {_e})
   else
+    local _e39
     if is63(_e) then
-      return(_e)
+      _e39 = _e
     else
+      local _e40
       if _35(_hoist) > 1 then
-        return(join({"do"}, _hoist))
+        _e40 = join({"do"}, _hoist)
       else
-        return(hd(_hoist))
+        _e40 = hd(_hoist)
       end
+      _e39 = _e40
     end
+    _e38 = _e39
   end
+  return(either(_e38, {"do"}))
 end
 local function lower_body(body, tail63)
-  return(either(lower_statement(join({"do"}, body), tail63), {"do"}))
+  return(lower_statement(join({"do"}, body), tail63))
 end
 local function literal63(form)
   return(atom63(form) or hd(form) == "%array" or hd(form) == "%object")

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -795,7 +795,7 @@ local function lower_statement(form, tail63)
   end
 end
 local function lower_body(body, tail63)
-  return(lower_statement(join({"do"}, body), tail63))
+  return(either(lower_statement(join({"do"}, body), tail63), {"do"}))
 end
 local function literal63(form)
   return(atom63(form) or hd(form) == "%array" or hd(form) == "%object")

--- a/compiler.l
+++ b/compiler.l
@@ -417,16 +417,17 @@
       (cat ind form tr))))
 
 (define lower-statement (form tail?)
-  (let (hoist () e (lower form hoist true tail?))
-    (if (and (some? hoist) (is? e))
-        `(do ,@hoist ,e)
-        (is? e) e
-        (> (# hoist) 1) `(do ,@hoist)
-      (hd hoist))))
+  (either
+    (let (hoist () e (lower form hoist true tail?))
+      (if (and (some? hoist) (is? e))
+          `(do ,@hoist ,e)
+          (is? e) e
+          (> (# hoist) 1) `(do ,@hoist)
+        (hd hoist)))
+    '(do)))
 
 (define lower-body (body tail?)
-  (either (lower-statement `(do ,@body) tail?)
-          '(do)))
+  (lower-statement `(do ,@body) tail?))
 
 (define literal? (form)
   (or (atom? form)

--- a/compiler.l
+++ b/compiler.l
@@ -425,7 +425,8 @@
       (hd hoist))))
 
 (define lower-body (body tail?)
-  (lower-statement `(do ,@body) tail?))
+  (either (lower-statement `(do ,@body) tail?)
+          '(do)))
 
 (define literal? (form)
   (or (atom? form)

--- a/test.l
+++ b/test.l
@@ -438,7 +438,8 @@ c"
     (test= 2 (case x a 1 (z) 2 7))
     (test= 2 (case x a 1 (b z) 2 7)))
   (let (n 0 f (fn () (inc n))) ; no multiple eval
-    (test= 'b (case (f) 0 'a 1 'b 'c))))
+    (test= 'b (case (f) 0 'a 1 'b 'c)))
+  (test= 'b ((fn () (case 2 0 (do) 1 'a 2 'b)))))
 
 (define-test while
   (let i 0

--- a/test.l
+++ b/test.l
@@ -396,7 +396,8 @@ c"
         (do (set a 20)
             (test= 20 a)))
     (test= 20 (do (set a 10)
-                  (do (set a 20) a)))))
+                  (do (set a 20) a))))
+  (test= '(do) (expand '(do))))
 
 (define-test if
   (test= 'a (macroexpand '(if a)))


### PR DESCRIPTION
Closes #118.

This PR fixes the following test case on Lua hosts:

```
(test= 'b ((fn () (case 2 0 (do) 1 'a 2 'b))))
```

(Without this PR, `((fn () (case 2 0 (do) 1 'a 2 'b)))` incorrectly evaluates to `nil` on Lua.)