### PR TITLE
Minor fix in LOWER-SET

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -888,7 +888,7 @@ var lower_set = function (args, hoist, stmt63, tail63) {
   var __id16 = args;
   var _lh = __id16[0];
   var _rh = __id16[1];
-  add(hoist, ["%set", _lh, lower(_rh, hoist)]);
+  add(hoist, ["%set", lower(_lh, hoist), lower(_rh, hoist)]);
   if (!( stmt63 && ! tail63)) {
     return(_lh);
   }

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -834,7 +834,7 @@ local function lower_set(args, hoist, stmt63, tail63)
   local __id16 = args
   local _lh = __id16[1]
   local _rh = __id16[2]
-  add(hoist, {"%set", _lh, lower(_rh, hoist)})
+  add(hoist, {"%set", lower(_lh, hoist), lower(_rh, hoist)})
   if not( stmt63 and not tail63) then
     return(_lh)
   end

--- a/compiler.l
+++ b/compiler.l
@@ -453,7 +453,7 @@
 
 (define lower-set (args hoist stmt? tail?)
   (let ((lh rh) args)
-    (add hoist `(%set ,lh ,(lower rh hoist)))
+    (add hoist `(%set ,(lower lh hoist) ,(lower rh hoist)))
     (unless (and stmt? (not tail?))
       lh)))
 


### PR DESCRIPTION
This PR fixes the following bug:

```
> (print (compile (expand '(set (get l (cat "a" "b" "c")) 42))))
l["a" .. "b"] = 42
```

Previously, the first argument to `%set` wasn't being lowered, causing `(cat "a" "b" "c")` to be skipped rather than lowering it as `(cat (cat "a" "b") "c")`.