### PR TITLE
Improve reader error messages

### DIFF
--- a/bin/reader.js
+++ b/bin/reader.js
@@ -1,21 +1,44 @@
 var delimiters = {"(": true, ")": true, ";": true, "\n": true};
 var whitespace = {" ": true, "\t": true, "\n": true};
+var marker = function (s) {
+  if (s) {
+    return(cut(s.point));
+  } else {
+    return({pos: 0, row: 0, col: 0});
+  }
+};
 var stream = function (str, more) {
-  return({pos: 0, string: str, len: _35(str), more: more});
+  return({point: marker(), string: str, len: _35(str), more: more});
+};
+var message = function (str, pt) {
+  var __id = pt;
+  var _pos = __id.pos;
+  var _row = __id.row;
+  var _col = __id.col;
+  var _line = _row + 1;
+  return(str + _pos + " line " + _line + ":" + _col);
 };
 var peek_char = function (s) {
-  var __id = s;
-  var _pos = __id.pos;
-  var _len = __id.len;
-  var _string = __id.string;
-  if (_pos < _len) {
-    return(char(_string, _pos));
+  var __id1 = s;
+  var __id2 = __id1.point;
+  var _pos1 = __id2.pos;
+  var _len = __id1.len;
+  var _string = __id1.string;
+  if (_pos1 < _len) {
+    return(char(_string, _pos1));
   }
 };
 var read_char = function (s) {
-  var _c = peek_char(s);
-  if (_c) {
-    s.pos = s.pos + 1;
+  var __y = peek_char(s);
+  if (yes(__y)) {
+    var _c = __y;
+    var _pt = s.point;
+    _pt.pos = _pt.pos + 1;
+    _pt.col = _pt.col + 1;
+    if (_c === "\n") {
+      _pt.row = _pt.row + 1;
+      _pt.col = 0;
+    }
     return(_c);
   }
 };
@@ -74,26 +97,29 @@ var key63 = function (atom) {
 var flag63 = function (atom) {
   return(string63(atom) && _35(atom) > 1 && char(atom, 0) === ":");
 };
-var expected = function (s, c) {
-  var __id1 = s;
-  var _more = __id1.more;
-  var _pos1 = __id1.pos;
-  var _id2 = _more;
-  var _e;
-  if (_id2) {
-    _e = _id2;
+var expected = function (s, c, from) {
+  var _id3 = s.more;
+  var _e1;
+  if (_id3) {
+    _e1 = _id3;
   } else {
-    throw new Error("Expected " + c + " at " + _pos1);
-    _e = undefined;
+    var _e2;
+    if (from) {
+      _e2 = " after ";
+    } else {
+      _e2 = " at ";
+    }
+    throw new Error(message("Expected " + c + _e2, from || s.point));
+    _e1 = undefined;
   }
-  return(_e);
+  return(_e1);
 };
 var wrap = function (s, x) {
-  var _y = read(s);
-  if (_y === s.more) {
-    return(_y);
+  var _y1 = read(s);
+  if (_y1 === s.more) {
+    return(_y1);
   } else {
-    return([x, _y]);
+    return([x, _y1]);
   }
 };
 var maybe_number = function (str) {
@@ -146,18 +172,19 @@ read_table[""] = function (s) {
   }
 };
 read_table["("] = function (s) {
+  var _from = marker(s);
   read_char(s);
-  var _r15 = undefined;
+  var _r17 = undefined;
   var _l1 = [];
-  while (nil63(_r15)) {
+  while (nil63(_r17)) {
     skip_non_code(s);
     var _c4 = peek_char(s);
     if (_c4 === ")") {
       read_char(s);
-      _r15 = _l1;
+      _r17 = _l1;
     } else {
       if (nil63(_c4)) {
-        _r15 = expected(s, ")");
+        _r17 = expected(s, ")", _from);
       } else {
         var _x2 = read(s);
         if (key63(_x2)) {
@@ -174,22 +201,23 @@ read_table["("] = function (s) {
       }
     }
   }
-  return(_r15);
+  return(_r17);
 };
 read_table[")"] = function (s) {
-  throw new Error("Unexpected ) at " + s.pos);
+  throw new Error(message("Unexpected ) at ", s.point));
 };
 read_table["\""] = function (s) {
+  var _from1 = marker(s);
   read_char(s);
-  var _r18 = undefined;
+  var _r20 = undefined;
   var _str1 = "\"";
-  while (nil63(_r18)) {
+  while (nil63(_r20)) {
     var _c5 = peek_char(s);
     if (_c5 === "\"") {
-      _r18 = _str1 + read_char(s);
+      _r20 = _str1 + read_char(s);
     } else {
       if (nil63(_c5)) {
-        _r18 = expected(s, "\"");
+        _r20 = expected(s, "\"", _from1);
       } else {
         if (_c5 === "\\") {
           _str1 = _str1 + read_char(s);
@@ -198,25 +226,26 @@ read_table["\""] = function (s) {
       }
     }
   }
-  return(_r18);
+  return(_r20);
 };
 read_table["|"] = function (s) {
+  var _from2 = marker(s);
   read_char(s);
-  var _r20 = undefined;
+  var _r22 = undefined;
   var _str2 = "|";
-  while (nil63(_r20)) {
+  while (nil63(_r22)) {
     var _c6 = peek_char(s);
     if (_c6 === "|") {
-      _r20 = _str2 + read_char(s);
+      _r22 = _str2 + read_char(s);
     } else {
       if (nil63(_c6)) {
-        _r20 = expected(s, "|");
+        _r22 = expected(s, "|", _from2);
       } else {
         _str2 = _str2 + read_char(s);
       }
     }
   }
-  return(_r20);
+  return(_r22);
 };
 read_table["'"] = function (s) {
   read_char(s);

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -1,21 +1,44 @@
 local delimiters = {["("] = true, [")"] = true, [";"] = true, ["\n"] = true}
 local whitespace = {[" "] = true, ["\t"] = true, ["\n"] = true}
+local function marker(s)
+  if s then
+    return(cut(s.point))
+  else
+    return({pos = 0, row = 0, col = 0})
+  end
+end
 local function stream(str, more)
-  return({pos = 0, string = str, len = _35(str), more = more})
+  return({point = marker(), string = str, len = _35(str), more = more})
+end
+local function message(str, pt)
+  local __id = pt
+  local _pos = __id.pos
+  local _row = __id.row
+  local _col = __id.col
+  local _line = _row + 1
+  return(str .. _pos .. " line " .. _line .. ":" .. _col)
 end
 local function peek_char(s)
-  local __id = s
-  local _pos = __id.pos
-  local _len = __id.len
-  local _string = __id.string
-  if _pos < _len then
-    return(char(_string, _pos))
+  local __id1 = s
+  local __id2 = __id1.point
+  local _pos1 = __id2.pos
+  local _len = __id1.len
+  local _string = __id1.string
+  if _pos1 < _len then
+    return(char(_string, _pos1))
   end
 end
 local function read_char(s)
-  local _c = peek_char(s)
-  if _c then
-    s.pos = s.pos + 1
+  local __y = peek_char(s)
+  if yes(__y) then
+    local _c = __y
+    local _pt = s.point
+    _pt.pos = _pt.pos + 1
+    _pt.col = _pt.col + 1
+    if _c == "\n" then
+      _pt.row = _pt.row + 1
+      _pt.col = 0
+    end
     return(_c)
   end
 end
@@ -74,26 +97,29 @@ end
 local function flag63(atom)
   return(string63(atom) and _35(atom) > 1 and char(atom, 0) == ":")
 end
-local function expected(s, c)
-  local __id1 = s
-  local _more = __id1.more
-  local _pos1 = __id1.pos
-  local _id2 = _more
-  local _e
-  if _id2 then
-    _e = _id2
+local function expected(s, c, from)
+  local _id3 = s.more
+  local _e1
+  if _id3 then
+    _e1 = _id3
   else
-    error("Expected " .. c .. " at " .. _pos1)
-    _e = nil
+    local _e2
+    if from then
+      _e2 = " after "
+    else
+      _e2 = " at "
+    end
+    error(message("Expected " .. c .. _e2, from or s.point))
+    _e1 = nil
   end
-  return(_e)
+  return(_e1)
 end
 local function wrap(s, x)
-  local _y = read(s)
-  if _y == s.more then
-    return(_y)
+  local _y1 = read(s)
+  if _y1 == s.more then
+    return(_y1)
   else
-    return({x, _y})
+    return({x, _y1})
   end
 end
 local function maybe_number(str)
@@ -146,18 +172,19 @@ read_table[""] = function (s)
   end
 end
 read_table["("] = function (s)
+  local _from = marker(s)
   read_char(s)
-  local _r15 = nil
+  local _r17 = nil
   local _l1 = {}
-  while nil63(_r15) do
+  while nil63(_r17) do
     skip_non_code(s)
     local _c4 = peek_char(s)
     if _c4 == ")" then
       read_char(s)
-      _r15 = _l1
+      _r17 = _l1
     else
       if nil63(_c4) then
-        _r15 = expected(s, ")")
+        _r17 = expected(s, ")", _from)
       else
         local _x2 = read(s)
         if key63(_x2) then
@@ -174,22 +201,23 @@ read_table["("] = function (s)
       end
     end
   end
-  return(_r15)
+  return(_r17)
 end
 read_table[")"] = function (s)
-  error("Unexpected ) at " .. s.pos)
+  error(message("Unexpected ) at ", s.point))
 end
 read_table["\""] = function (s)
+  local _from1 = marker(s)
   read_char(s)
-  local _r18 = nil
+  local _r20 = nil
   local _str1 = "\""
-  while nil63(_r18) do
+  while nil63(_r20) do
     local _c5 = peek_char(s)
     if _c5 == "\"" then
-      _r18 = _str1 .. read_char(s)
+      _r20 = _str1 .. read_char(s)
     else
       if nil63(_c5) then
-        _r18 = expected(s, "\"")
+        _r20 = expected(s, "\"", _from1)
       else
         if _c5 == "\\" then
           _str1 = _str1 .. read_char(s)
@@ -198,25 +226,26 @@ read_table["\""] = function (s)
       end
     end
   end
-  return(_r18)
+  return(_r20)
 end
 read_table["|"] = function (s)
+  local _from2 = marker(s)
   read_char(s)
-  local _r20 = nil
+  local _r22 = nil
   local _str2 = "|"
-  while nil63(_r20) do
+  while nil63(_r22) do
     local _c6 = peek_char(s)
     if _c6 == "|" then
-      _r20 = _str2 .. read_char(s)
+      _r22 = _str2 .. read_char(s)
     else
       if nil63(_c6) then
-        _r20 = expected(s, "|")
+        _r22 = expected(s, "|", _from2)
       else
         _str2 = _str2 .. read_char(s)
       end
     end
   end
-  return(_r20)
+  return(_r22)
 end
 read_table["'"] = function (s)
   read_char(s)

--- a/reader.l
+++ b/reader.l
@@ -1,17 +1,32 @@
 (define delimiters (set-of "(" ")" ";" "\n"))
 (define whitespace (set-of " " "\t" "\n"))
 
+(define marker (s)
+  (if s (cut (get s 'point))
+    (obj pos: 0 row: 0 col: 0)))
+
 (define stream (str more)
-  (obj pos: 0 string: str len: (# str) more: more))
+  (obj point: (marker) string: str len: (# str) more: more))
+
+(define message (str pt)
+  (let ((:pos :row :col) pt
+        line (+ row 1))
+    (cat str pos " line " line ":" col)))
 
 (define peek-char (s)
-  (let ((:pos :len :string) s)
+  (let ((point: (:pos) :len :string) s)
     (when (< pos len)
       (char string pos))))
 
 (define read-char (s)
-  (let c (peek-char s)
-    (if c (do (inc (get s 'pos)) c))))
+  (let-when c (peek-char s)
+    (let pt (get s 'point)
+      (inc (get pt 'pos))
+      (inc (get pt 'col))
+      (when (= c "\n")
+        (inc (get pt 'row))
+        (set (get pt 'col) 0))
+      c)))
 
 (define skip-non-code (s)
   (while true
@@ -57,9 +72,10 @@
        (> (# atom) 1)
        (= (char atom 0) ":")))
 
-(define expected (s c)
-  (let ((:more :pos) s)
-    (or more (error (cat "Expected " c " at " pos)))))
+(define expected (s c from)
+  (or (get s 'more)
+      (error (message (cat "Expected " c (if from " after " " at "))
+                      (or from (get s 'point))))))
 
 (define wrap (s x)
   (let y (read s)
@@ -91,46 +107,49 @@
       (if (real? n) n str)))))
 
 (define-reader ("(" s)
-  (read-char s)
-  (with r nil
-    (let l ()
-      (while (nil? r)
-        (skip-non-code s)
-        (let c (peek-char s)
-          (if (= c ")") (do (read-char s) (set r l))
-              (nil? c) (set r (expected s ")"))
-            (let x (read s)
-              (if (key? x)
-                  (let (k (clip x 0 (edge x))
-                        v (read s))
-                    (set (get l k) v))
-                  (flag? x) (set (get l (clip x 1)) true)
-                (add l x)))))))))
+  (let from (marker s)
+    (read-char s)
+    (with r nil
+      (let l ()
+        (while (nil? r)
+          (skip-non-code s)
+          (let c (peek-char s)
+            (if (= c ")") (do (read-char s) (set r l))
+                (nil? c) (set r (expected s ")" from))
+              (let x (read s)
+                (if (key? x)
+                    (let (k (clip x 0 (edge x))
+                          v (read s))
+                      (set (get l k) v))
+                    (flag? x) (set (get l (clip x 1)) true)
+                  (add l x))))))))))
 
 (define-reader (")" s)
-  (error (cat "Unexpected ) at " (get s 'pos))))
+  (error (message "Unexpected ) at " (get s 'point))))
 
 (define-reader ("\"" s)
-  (read-char s)
-  (with r nil
-    (let str "\""
-      (while (nil? r)
-        (let c (peek-char s)
-          (if (= c "\"") (set r (cat str (read-char s)))
-              (nil? c) (set r (expected s "\""))
-            (do (when (= c "\\")
-                  (cat! str (read-char s)))
-                (cat! str (read-char s)))))))))
+  (let from (marker s)
+    (read-char s)
+    (with r nil
+      (let str "\""
+        (while (nil? r)
+          (let c (peek-char s)
+            (if (= c "\"") (set r (cat str (read-char s)))
+                (nil? c) (set r (expected s "\"" from))
+              (do (when (= c "\\")
+                    (cat! str (read-char s)))
+                  (cat! str (read-char s))))))))))
 
 (define-reader ("|" s)
-  (read-char s)
-  (with r nil
-    (let str "|"
-      (while (nil? r)
-        (let c (peek-char s)
-          (if (= c "|") (set r (cat str (read-char s)))
-              (nil? c) (set r (expected s "|"))
-            (cat! str (read-char s))))))))
+  (let from (marker s)
+    (read-char s)
+    (with r nil
+      (let str "|"
+        (while (nil? r)
+          (let c (peek-char s)
+            (if (= c "|") (set r (cat str (read-char s)))
+                (nil? c) (set r (expected s "|" from))
+              (cat! str (read-char s)))))))))
 
 (define-reader ("'" s)
   (read-char s)

--- a/test.l
+++ b/test.l
@@ -76,7 +76,7 @@
       (test= more (read "'\"boz" more)))
     (let ((ok e) (guard (read "(open")))
       (test= false ok)
-      (test= "Expected ) at 5" (get e 'message)))))
+      (test= 0 (search (get e 'message) "Expected ) after 0")))))
 
 (define-test nil?
   (test= true (nil? nil))


### PR DESCRIPTION
Reader error messages now display the position, line, and column of
the character that caused the error. In the case of an unmatched
character, the error will show the position of the opening character.

This PR is a tossup as to whether you'll like it. Let me know if it needs to be reworked.