### PR TITLE
Update EXPECTED

### DIFF
--- a/bin/reader.js
+++ b/bin/reader.js
@@ -82,7 +82,7 @@ var expected = function (s, c, pos) {
   if (_id2) {
     _e = _id2;
   } else {
-    throw new Error("Expected " + c + " at " + pos);
+    throw new Error("Expected " + c + " after " + pos);
     _e = undefined;
   }
   return(_e);

--- a/bin/reader.js
+++ b/bin/reader.js
@@ -74,16 +74,15 @@ var key63 = function (atom) {
 var flag63 = function (atom) {
   return(string63(atom) && _35(atom) > 1 && char(atom, 0) === ":");
 };
-var expected = function (s, c) {
+var expected = function (s, c, pos) {
   var __id1 = s;
   var _more = __id1.more;
-  var _pos1 = __id1.pos;
   var _id2 = _more;
   var _e;
   if (_id2) {
     _e = _id2;
   } else {
-    throw new Error("Expected " + c + " at " + _pos1);
+    throw new Error("Expected " + c + " at " + pos);
     _e = undefined;
   }
   return(_e);
@@ -146,6 +145,7 @@ read_table[""] = function (s) {
   }
 };
 read_table["("] = function (s) {
+  var _pos1 = s.pos;
   read_char(s);
   var _r15 = undefined;
   var _l1 = [];
@@ -157,7 +157,7 @@ read_table["("] = function (s) {
       _r15 = _l1;
     } else {
       if (nil63(_c4)) {
-        _r15 = expected(s, ")");
+        _r15 = expected(s, ")", _pos1);
       } else {
         var _x2 = read(s);
         if (key63(_x2)) {
@@ -180,6 +180,7 @@ read_table[")"] = function (s) {
   throw new Error("Unexpected ) at " + s.pos);
 };
 read_table["\""] = function (s) {
+  var _pos2 = s.pos;
   read_char(s);
   var _r18 = undefined;
   var _str1 = "\"";
@@ -189,7 +190,7 @@ read_table["\""] = function (s) {
       _r18 = _str1 + read_char(s);
     } else {
       if (nil63(_c5)) {
-        _r18 = expected(s, "\"");
+        _r18 = expected(s, "\"", _pos2);
       } else {
         if (_c5 === "\\") {
           _str1 = _str1 + read_char(s);
@@ -201,6 +202,7 @@ read_table["\""] = function (s) {
   return(_r18);
 };
 read_table["|"] = function (s) {
+  var _pos3 = s.pos;
   read_char(s);
   var _r20 = undefined;
   var _str2 = "|";
@@ -210,7 +212,7 @@ read_table["|"] = function (s) {
       _r20 = _str2 + read_char(s);
     } else {
       if (nil63(_c6)) {
-        _r20 = expected(s, "|");
+        _r20 = expected(s, "|", _pos3);
       } else {
         _str2 = _str2 + read_char(s);
       }

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -82,7 +82,7 @@ local function expected(s, c, pos)
   if _id2 then
     _e = _id2
   else
-    error("Expected " .. c .. " at " .. pos)
+    error("Expected " .. c .. " after " .. pos)
     _e = nil
   end
   return(_e)

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -74,16 +74,15 @@ end
 local function flag63(atom)
   return(string63(atom) and _35(atom) > 1 and char(atom, 0) == ":")
 end
-local function expected(s, c)
+local function expected(s, c, pos)
   local __id1 = s
   local _more = __id1.more
-  local _pos1 = __id1.pos
   local _id2 = _more
   local _e
   if _id2 then
     _e = _id2
   else
-    error("Expected " .. c .. " at " .. _pos1)
+    error("Expected " .. c .. " at " .. pos)
     _e = nil
   end
   return(_e)
@@ -146,6 +145,7 @@ read_table[""] = function (s)
   end
 end
 read_table["("] = function (s)
+  local _pos1 = s.pos
   read_char(s)
   local _r15 = nil
   local _l1 = {}
@@ -157,7 +157,7 @@ read_table["("] = function (s)
       _r15 = _l1
     else
       if nil63(_c4) then
-        _r15 = expected(s, ")")
+        _r15 = expected(s, ")", _pos1)
       else
         local _x2 = read(s)
         if key63(_x2) then
@@ -180,6 +180,7 @@ read_table[")"] = function (s)
   error("Unexpected ) at " .. s.pos)
 end
 read_table["\""] = function (s)
+  local _pos2 = s.pos
   read_char(s)
   local _r18 = nil
   local _str1 = "\""
@@ -189,7 +190,7 @@ read_table["\""] = function (s)
       _r18 = _str1 .. read_char(s)
     else
       if nil63(_c5) then
-        _r18 = expected(s, "\"")
+        _r18 = expected(s, "\"", _pos2)
       else
         if _c5 == "\\" then
           _str1 = _str1 .. read_char(s)
@@ -201,6 +202,7 @@ read_table["\""] = function (s)
   return(_r18)
 end
 read_table["|"] = function (s)
+  local _pos3 = s.pos
   read_char(s)
   local _r20 = nil
   local _str2 = "|"
@@ -210,7 +212,7 @@ read_table["|"] = function (s)
       _r20 = _str2 .. read_char(s)
     else
       if nil63(_c6) then
-        _r20 = expected(s, "|")
+        _r20 = expected(s, "|", _pos3)
       else
         _str2 = _str2 .. read_char(s)
       end

--- a/reader.l
+++ b/reader.l
@@ -59,7 +59,7 @@
 
 (define expected (s c pos)
   (let ((:more) s)
-    (or more (error (cat "Expected " c " at " pos)))))
+    (or more (error (cat "Expected " c " after " pos)))))
 
 (define wrap (s x)
   (let y (read s)

--- a/reader.l
+++ b/reader.l
@@ -57,8 +57,8 @@
        (> (# atom) 1)
        (= (char atom 0) ":")))
 
-(define expected (s c)
-  (let ((:more :pos) s)
+(define expected (s c pos)
+  (let ((:more) s)
     (or more (error (cat "Expected " c " at " pos)))))
 
 (define wrap (s x)
@@ -91,46 +91,49 @@
       (if (real? n) n str)))))
 
 (define-reader ("(" s)
-  (read-char s)
-  (with r nil
-    (let l ()
-      (while (nil? r)
-        (skip-non-code s)
-        (let c (peek-char s)
-          (if (= c ")") (do (read-char s) (set r l))
-              (nil? c) (set r (expected s ")"))
-            (let x (read s)
-              (if (key? x)
-                  (let (k (clip x 0 (edge x))
-                        v (read s))
-                    (set (get l k) v))
-                  (flag? x) (set (get l (clip x 1)) true)
-                (add l x)))))))))
+  (let pos (get s 'pos)
+    (read-char s)
+    (with r nil
+      (let l ()
+        (while (nil? r)
+          (skip-non-code s)
+          (let c (peek-char s)
+            (if (= c ")") (do (read-char s) (set r l))
+                (nil? c) (set r (expected s ")" pos))
+              (let x (read s)
+                (if (key? x)
+                    (let (k (clip x 0 (edge x))
+                          v (read s))
+                      (set (get l k) v))
+                    (flag? x) (set (get l (clip x 1)) true)
+                  (add l x))))))))))
 
 (define-reader (")" s)
   (error (cat "Unexpected ) at " (get s 'pos))))
 
 (define-reader ("\"" s)
-  (read-char s)
-  (with r nil
-    (let str "\""
-      (while (nil? r)
-        (let c (peek-char s)
-          (if (= c "\"") (set r (cat str (read-char s)))
-              (nil? c) (set r (expected s "\""))
-            (do (when (= c "\\")
-                  (cat! str (read-char s)))
-                (cat! str (read-char s)))))))))
+  (let pos (get s 'pos)
+    (read-char s)
+    (with r nil
+      (let str "\""
+        (while (nil? r)
+          (let c (peek-char s)
+            (if (= c "\"") (set r (cat str (read-char s)))
+                (nil? c) (set r (expected s "\"" pos))
+              (do (when (= c "\\")
+                    (cat! str (read-char s)))
+                  (cat! str (read-char s))))))))))
 
 (define-reader ("|" s)
-  (read-char s)
-  (with r nil
-    (let str "|"
-      (while (nil? r)
-        (let c (peek-char s)
-          (if (= c "|") (set r (cat str (read-char s)))
-              (nil? c) (set r (expected s "|"))
-            (cat! str (read-char s))))))))
+  (let pos (get s 'pos)
+    (read-char s)
+    (with r nil
+      (let str "|"
+        (while (nil? r)
+          (let c (peek-char s)
+            (if (= c "|") (set r (cat str (read-char s)))
+                (nil? c) (set r (expected s "|" pos))
+              (cat! str (read-char s)))))))))
 
 (define-reader ("'" s)
   (read-char s)

--- a/test.l
+++ b/test.l
@@ -76,7 +76,7 @@
       (test= more (read "'\"boz" more)))
     (let ((ok e) (guard (read "(open")))
       (test= false ok)
-      (test= "Expected ) at 0" (get e 'message)))))
+      (test= "Expected ) after 0" (get e 'message)))))
 
 (define-test nil?
   (test= true (nil? nil))

--- a/test.l
+++ b/test.l
@@ -76,7 +76,7 @@
       (test= more (read "'\"boz" more)))
     (let ((ok e) (guard (read "(open")))
       (test= false ok)
-      (test= "Expected ) at 5" (get e 'message)))))
+      (test= "Expected ) at 0" (get e 'message)))))
 
 (define-test nil?
   (test= true (nil? nil))


### PR DESCRIPTION
Error messages caused by unmatched delimiters will now report the position of the opening delimiter, not the end of file.

E.g. `(read-string "(open"))` will report "Expected ) after 0" rather than "Expected ) at 5".

Seeing the position of the opening delimiter in the error message is typically more useful than the end of file position.