### PR TITLE
Minor fix in VALID-ID?

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -424,7 +424,7 @@ var valid_code63 = function (n) {
   return(number_code63(n) || n > 64 && n < 91 || n > 96 && n < 123 || n === 95);
 };
 valid_id63 = function (id) {
-  if (none63(id) || reserved63(id)) {
+  if (none63(id) || reserved63(id) || number_code63(code(id, 0))) {
     return(false);
   } else {
     var _i11 = 0;

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -382,7 +382,7 @@ local function valid_code63(n)
   return(number_code63(n) or n > 64 and n < 91 or n > 96 and n < 123 or n == 95)
 end
 function valid_id63(id)
-  if none63(id) or reserved63(id) then
+  if none63(id) or reserved63(id) or number_code63(code(id, 0)) then
     return(false)
   else
     local _i11 = 0

--- a/compiler.l
+++ b/compiler.l
@@ -243,7 +243,7 @@
       (= n 95)))               ; _
 
 (define-global valid-id? (id)
-  (if (or (none? id) (reserved? id))
+  (if (or (none? id) (reserved? id) (number-code? (code id 0)))
       false
     (do (for i (# id)
           (unless (valid-code? (code id i))

--- a/test.l
+++ b/test.l
@@ -231,9 +231,10 @@ c"
   (test= (quote unquote) 'unquote)
   (test= (quote (unquote)) '(unquote))
   (test= (quote (unquote a)) '(unquote a))
-  (let x '(10 20 a: 33)
+  (let x '(10 20 a: 33 1a: 44)
     (test= 20 (at x 1))
-    (test= 33 (get x 'a))))
+    (test= 33 (get x 'a))
+    (test= 44 (get x '1a))))
 
 (define-test list
   (test= '() (list))


### PR DESCRIPTION
Closes #129.

Update `valid-id?` to reflect the fact that identifiers which start with numbers aren't valid.