### PR TITLE
Make "load" a reserved word; get rid of HOST

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -402,7 +402,7 @@ indentation = function () {
   }
   return(__s);
 };
-var reserved = {"=": true, "==": true, "+": true, "-": true, "%": true, "*": true, "/": true, "<": true, ">": true, "<=": true, ">=": true, "break": true, "case": true, "catch": true, "class": true, "const": true, "continue": true, "debugger": true, "default": true, "delete": true, "do": true, "else": true, "eval": true, "finally": true, "for": true, "function": true, "if": true, "import": true, "in": true, "instanceof": true, "let": true, "new": true, "return": true, "switch": true, "throw": true, "try": true, "typeof": true, "var": true, "void": true, "with": true, "and": true, "end": true, "repeat": true, "while": true, "false": true, "local": true, "nil": true, "then": true, "not": true, "true": true, "elseif": true, "or": true, "until": true};
+var reserved = {"=": true, "==": true, "+": true, "-": true, "%": true, "*": true, "/": true, "<": true, ">": true, "<=": true, ">=": true, "break": true, "case": true, "catch": true, "class": true, "const": true, "continue": true, "debugger": true, "default": true, "delete": true, "do": true, "else": true, "eval": true, "finally": true, "for": true, "function": true, "if": true, "import": true, "in": true, "instanceof": true, "let": true, "new": true, "return": true, "switch": true, "throw": true, "try": true, "typeof": true, "var": true, "void": true, "with": true, "and": true, "end": true, "load": true, "repeat": true, "while": true, "false": true, "local": true, "nil": true, "then": true, "not": true, "true": true, "elseif": true, "or": true, "until": true};
 reserved63 = function (x) {
   return(has63(reserved, x));
 };

--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -1074,7 +1074,7 @@ expand = function (form) {
   return(lower(macroexpand(form)));
 };
 global.require = require;
-var run = host["eval"];
+var run = eval;
 _37result = undefined;
 _eval = function (form) {
   var __previous = target;

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -1019,7 +1019,7 @@ end
 function expand(form)
   return(lower(macroexpand(form)))
 end
-local load1 = loadstring or host["load"]
+local load1 = loadstring or load
 local function run(code)
   local f,e = load1(code)
   if f then

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -360,7 +360,7 @@ function indentation()
   end
   return(__s)
 end
-local reserved = {["="] = true, ["=="] = true, ["+"] = true, ["-"] = true, ["%"] = true, ["*"] = true, ["/"] = true, ["<"] = true, [">"] = true, ["<="] = true, [">="] = true, ["break"] = true, ["case"] = true, ["catch"] = true, ["class"] = true, ["const"] = true, ["continue"] = true, ["debugger"] = true, ["default"] = true, ["delete"] = true, ["do"] = true, ["else"] = true, ["eval"] = true, ["finally"] = true, ["for"] = true, ["function"] = true, ["if"] = true, ["import"] = true, ["in"] = true, ["instanceof"] = true, ["let"] = true, ["new"] = true, ["return"] = true, ["switch"] = true, ["throw"] = true, ["try"] = true, ["typeof"] = true, ["var"] = true, ["void"] = true, ["with"] = true, ["and"] = true, ["end"] = true, ["repeat"] = true, ["while"] = true, ["false"] = true, ["local"] = true, ["nil"] = true, ["then"] = true, ["not"] = true, ["true"] = true, ["elseif"] = true, ["or"] = true, ["until"] = true}
+local reserved = {["="] = true, ["=="] = true, ["+"] = true, ["-"] = true, ["%"] = true, ["*"] = true, ["/"] = true, ["<"] = true, [">"] = true, ["<="] = true, [">="] = true, ["break"] = true, ["case"] = true, ["catch"] = true, ["class"] = true, ["const"] = true, ["continue"] = true, ["debugger"] = true, ["default"] = true, ["delete"] = true, ["do"] = true, ["else"] = true, ["eval"] = true, ["finally"] = true, ["for"] = true, ["function"] = true, ["if"] = true, ["import"] = true, ["in"] = true, ["instanceof"] = true, ["let"] = true, ["new"] = true, ["return"] = true, ["switch"] = true, ["throw"] = true, ["try"] = true, ["typeof"] = true, ["var"] = true, ["void"] = true, ["with"] = true, ["and"] = true, ["end"] = true, ["load"] = true, ["repeat"] = true, ["while"] = true, ["false"] = true, ["local"] = true, ["nil"] = true, ["then"] = true, ["not"] = true, ["true"] = true, ["elseif"] = true, ["or"] = true, ["until"] = true}
 function reserved63(x)
   return(has63(reserved, x))
 end
@@ -1019,7 +1019,7 @@ end
 function expand(form)
   return(lower(macroexpand(form)))
 end
-local load1 = loadstring or host.load
+local load1 = loadstring or host["load"]
 local function run(code)
   local f,e = load1(code)
   if f then

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -1,4 +1,3 @@
-host = {"eval": eval};
 environment = [{}];
 target = "js";
 nil63 = function (x) {

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -1236,7 +1236,7 @@ compile_file = function (path) {
   var __form1 = compiler.expand(join(["do"], __body));
   return(compiler.compile(__form1, {_stash: true, stmt: true}));
 };
-load = function (path) {
+_load = function (path) {
   var __previous = target;
   target = "js";
   var __code = compile_file(path);
@@ -1263,7 +1263,7 @@ var usage = function () {
 var main = function () {
   var __arg = hd(system.argv);
   if (__arg && script_file63(__arg)) {
-    return(load(__arg));
+    return(_load(__arg));
   } else {
     if (__arg === "-h" || __arg === "--help") {
       return(usage());

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -1,4 +1,3 @@
-host = {["load"] = load}
 environment = {{}}
 target = "lua"
 function nil63(x)

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -1,4 +1,4 @@
-host = {load = load}
+host = {["load"] = load}
 environment = {{}}
 target = "lua"
 function nil63(x)
@@ -1139,7 +1139,7 @@ function compile_file(path)
   local __form1 = compiler.expand(join({"do"}, __body))
   return(compiler.compile(__form1, {_stash = true, stmt = true}))
 end
-function load(path)
+function _load(path)
   local __previous = target
   target = "lua"
   local __code = compile_file(path)
@@ -1166,7 +1166,7 @@ end
 local function main()
   local __arg = hd(system.argv)
   if __arg and script_file63(__arg) then
-    return(load(__arg))
+    return(_load(__arg))
   else
     if __arg == "-h" or __arg == "--help" then
       return(usage())

--- a/compiler.l
+++ b/compiler.l
@@ -218,9 +218,10 @@
           "instanceof" "let" "new" "return" "switch" "throw"
           "try" "typeof" "var" "void" "with"
           ;; lua
-          "and" "end" "in" "repeat" "while" "break" "false"
-          "local" "return" "do" "for" "nil" "then" "else"
-          "function" "not" "true" "elseif" "if" "or" "until"))
+          "and" "end" "in" "load" "repeat" "while" "break"
+          "false" "local" "return" "do" "for" "nil" "then"
+          "else" "function" "not" "true" "elseif" "if" "or"
+          "until"))
 
 (define-global reserved? (x)
   (has? reserved x))

--- a/compiler.l
+++ b/compiler.l
@@ -568,10 +568,10 @@
 (define-global expand (form)
   (lower (macroexpand form)))
 
-(target js: (set (get global 'require) require))
-(target js: (define run (get host 'eval)))
+(target js: (set (get global 'require) |require|))
+(target js: (define run |eval|))
 
-(target lua: (define load1 (or loadstring (get host 'load))))
+(target lua: (define load1 (or |loadstring| |load|)))
 (target lua:
   (define run (code)
     (let |f,e| (load1 code)

--- a/runtime.l
+++ b/runtime.l
@@ -1,4 +1,3 @@
-(define-global host (target js: (obj eval: |eval|) lua: (obj load: |load|)))
 (define-global environment (list (obj)))
 (define-global target (language))
 


### PR DESCRIPTION
Since `eval` is now a reserved word, `host` is no longer needed on JS. This PR makes `host` no longer needed at all.

Alternatively, I could remove `host.eval` and leave `host.load` alone.