### PR TITLE
Update DEFINE-MACRO to take a :ONCE option

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -256,13 +256,22 @@ var expand_definition = function (__x46) {
   return(____x49);
 };
 var expand_macro = function (form) {
-  return(macroexpand(expand1(form)));
+  return(expand1(form, true));
 };
-expand1 = function (__x51) {
+expand1 = function (__x51, expand63) {
   var ____id4 = __x51;
   var __name2 = ____id4[0];
   var __body2 = cut(____id4, 1);
-  return(apply(macro_function(__name2), __body2));
+  var ____id5 = getenv(__name2);
+  var __macro = ____id5.macro;
+  var __once = ____id5.once;
+  var __form = apply(__macro, __body2);
+  if (expand63) {
+    if (! __once) {
+      __form = macroexpand(__form);
+    }
+  }
+  return(__form);
 };
 macroexpand = function (form) {
   if (symbol63(form)) {
@@ -380,10 +389,10 @@ quasiexpand = function (form, depth) {
   }
 };
 expand_if = function (__x61) {
-  var ____id5 = __x61;
-  var __a = ____id5[0];
-  var __b1 = ____id5[1];
-  var __c = cut(____id5, 2);
+  var ____id6 = __x61;
+  var __a = ____id6[0];
+  var __b1 = ____id6[1];
+  var __c = cut(____id6, 2);
   if (is63(__b1)) {
     return([join(["%if", __a, __b1], expand_if(__c))]);
   } else {
@@ -673,13 +682,13 @@ var terminator = function (stmt63) {
   }
 };
 var compile_special = function (form, stmt63) {
-  var ____id6 = form;
-  var __x85 = ____id6[0];
-  var __args2 = cut(____id6, 1);
-  var ____id7 = getenv(__x85);
-  var __special = ____id7.special;
-  var __stmt = ____id7.stmt;
-  var __self_tr63 = ____id7.tr;
+  var ____id7 = form;
+  var __x85 = ____id7[0];
+  var __args2 = cut(____id7, 1);
+  var ____id8 = getenv(__x85);
+  var __special = ____id8.special;
+  var __stmt = ____id8.stmt;
+  var __self_tr63 = ____id8.tr;
   var __tr = terminator(stmt63 && ! __self_tr63);
   return(apply(__special, __args2) + __tr);
 };
@@ -700,8 +709,8 @@ var op_delims = function (parent, child) {
   var ____r57 = unstash(Array.prototype.slice.call(arguments, 2));
   var __parent = destash33(parent, ____r57);
   var __child = destash33(child, ____r57);
-  var ____id8 = ____r57;
-  var __right = ____id8.right;
+  var ____id9 = ____r57;
+  var __right = ____id9.right;
   var __e39;
   if (__right) {
     __e39 = _6261;
@@ -715,17 +724,17 @@ var op_delims = function (parent, child) {
   }
 };
 var compile_infix = function (form) {
-  var ____id9 = form;
-  var __op = ____id9[0];
-  var ____id10 = cut(____id9, 1);
-  var __a1 = ____id10[0];
-  var __b2 = ____id10[1];
-  var ____id111 = op_delims(form, __a1);
-  var __ao = ____id111[0];
-  var __ac = ____id111[1];
-  var ____id12 = op_delims(form, __b2, {_stash: true, right: true});
-  var __bo = ____id12[0];
-  var __bc = ____id12[1];
+  var ____id10 = form;
+  var __op = ____id10[0];
+  var ____id111 = cut(____id10, 1);
+  var __a1 = ____id111[0];
+  var __b2 = ____id111[1];
+  var ____id12 = op_delims(form, __a1);
+  var __ao = ____id12[0];
+  var __ac = ____id12[1];
+  var ____id13 = op_delims(form, __b2, {_stash: true, right: true});
+  var __bo = ____id13[0];
+  var __bc = ____id13[1];
   var __a2 = compile(__a1);
   var __b3 = compile(__b2);
   var __op1 = getop(__op);
@@ -739,16 +748,16 @@ compile_function = function (args, body) {
   var ____r59 = unstash(Array.prototype.slice.call(arguments, 2));
   var __args4 = destash33(args, ____r59);
   var __body3 = destash33(body, ____r59);
-  var ____id13 = ____r59;
-  var __name3 = ____id13.name;
-  var __prefix = ____id13.prefix;
+  var ____id14 = ____r59;
+  var __name3 = ____id14.name;
+  var __prefix = ____id14.prefix;
   var __e40;
   if (__name3) {
     __e40 = compile(__name3);
   } else {
     __e40 = "";
   }
-  var __id14 = __e40;
+  var __id15 = __e40;
   var __e41;
   if (target === "lua" && __args4.rest) {
     __e41 = join(__args4, ["|...|"]);
@@ -780,9 +789,9 @@ compile_function = function (args, body) {
     __tr1 = __tr1 + "\n";
   }
   if (target === "js") {
-    return("function " + __id14 + __args5 + " {\n" + __body4 + __ind + "}" + __tr1);
+    return("function " + __id15 + __args5 + " {\n" + __body4 + __ind + "}" + __tr1);
   } else {
-    return(__p + "function " + __id14 + __args5 + "\n" + __body4 + __ind + __tr1);
+    return(__p + "function " + __id15 + __args5 + "\n" + __body4 + __ind + __tr1);
   }
 };
 var can_return63 = function (form) {
@@ -790,14 +799,14 @@ var can_return63 = function (form) {
 };
 compile = function (form) {
   var ____r61 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __form = destash33(form, ____r61);
-  var ____id15 = ____r61;
-  var __stmt1 = ____id15.stmt;
-  if (nil63(__form)) {
+  var __form1 = destash33(form, ____r61);
+  var ____id16 = ____r61;
+  var __stmt1 = ____id16.stmt;
+  if (nil63(__form1)) {
     return("");
   } else {
-    if (special_form63(__form)) {
-      return(compile_special(__form, __stmt1));
+    if (special_form63(__form1)) {
+      return(compile_special(__form1, __stmt1));
     } else {
       var __tr2 = terminator(__stmt1);
       var __e44;
@@ -808,19 +817,19 @@ compile = function (form) {
       }
       var __ind1 = __e44;
       var __e45;
-      if (atom63(__form)) {
-        __e45 = compile_atom(__form);
+      if (atom63(__form1)) {
+        __e45 = compile_atom(__form1);
       } else {
         var __e46;
-        if (infix63(hd(__form))) {
-          __e46 = compile_infix(__form);
+        if (infix63(hd(__form1))) {
+          __e46 = compile_infix(__form1);
         } else {
-          __e46 = compile_call(__form);
+          __e46 = compile_call(__form1);
         }
         __e45 = __e46;
       }
-      var __form1 = __e45;
-      return(__ind1 + __form1 + __tr2);
+      var __form2 = __e45;
+      return(__ind1 + __form2 + __tr2);
     }
   }
 };
@@ -878,19 +887,19 @@ var lower_do = function (args, hoist, stmt63, tail63) {
   }
 };
 var lower_set = function (args, hoist, stmt63, tail63) {
-  var ____id16 = args;
-  var __lh = ____id16[0];
-  var __rh = ____id16[1];
+  var ____id17 = args;
+  var __lh = ____id17[0];
+  var __rh = ____id17[1];
   add(hoist, ["%set", lower(__lh, hoist), lower(__rh, hoist)]);
   if (!( stmt63 && ! tail63)) {
     return(__lh);
   }
 };
 var lower_if = function (args, hoist, stmt63, tail63) {
-  var ____id17 = args;
-  var __cond = ____id17[0];
-  var ___then = ____id17[1];
-  var ___else = ____id17[2];
+  var ____id18 = args;
+  var __cond = ____id18[0];
+  var ___then = ____id18[1];
+  var ___else = ____id18[2];
   if (stmt63) {
     var __e51;
     if (is63(___else)) {
@@ -909,20 +918,20 @@ var lower_if = function (args, hoist, stmt63, tail63) {
   }
 };
 var lower_short = function (x, args, hoist) {
-  var ____id18 = args;
-  var __a3 = ____id18[0];
-  var __b4 = ____id18[1];
+  var ____id19 = args;
+  var __a3 = ____id19[0];
+  var __b4 = ____id19[1];
   var __hoist1 = [];
   var __b11 = lower(__b4, __hoist1);
   if (some63(__hoist1)) {
-    var __id19 = unique("id");
+    var __id20 = unique("id");
     var __e52;
     if (x === "and") {
-      __e52 = ["%if", __id19, __b4, __id19];
+      __e52 = ["%if", __id20, __b4, __id20];
     } else {
-      __e52 = ["%if", __id19, __id19, __b4];
+      __e52 = ["%if", __id20, __id20, __b4];
     }
-    return(lower(["do", ["%local", __id19, __a3], __e52], hoist));
+    return(lower(["do", ["%local", __id20, __a3], __e52], hoist));
   } else {
     return([x, lower(__a3, hoist), __b11]);
   }
@@ -931,9 +940,9 @@ var lower_try = function (args, hoist, tail63) {
   return(add(hoist, ["%try", lower_body(args, tail63)]));
 };
 var lower_while = function (args, hoist) {
-  var ____id20 = args;
-  var __c4 = ____id20[0];
-  var __body5 = cut(____id20, 1);
+  var ____id21 = args;
+  var __c4 = ____id21[0];
+  var __body5 = cut(____id21, 1);
   var __pre = [];
   var __c5 = lower(__c4, __pre);
   var __e53;
@@ -945,31 +954,31 @@ var lower_while = function (args, hoist) {
   return(add(hoist, __e53));
 };
 var lower_for = function (args, hoist) {
-  var ____id21 = args;
-  var __t = ____id21[0];
-  var __k13 = ____id21[1];
-  var __body6 = cut(____id21, 2);
+  var ____id22 = args;
+  var __t = ____id22[0];
+  var __k13 = ____id22[1];
+  var __body6 = cut(____id22, 2);
   return(add(hoist, ["%for", lower(__t, hoist), __k13, lower_body(__body6)]));
 };
 var lower_function = function (args) {
-  var ____id22 = args;
-  var __a4 = ____id22[0];
-  var __body7 = cut(____id22, 1);
+  var ____id23 = args;
+  var __a4 = ____id23[0];
+  var __body7 = cut(____id23, 1);
   return(["%function", __a4, lower_body(__body7, true)]);
 };
 var lower_definition = function (kind, args, hoist) {
-  var ____id23 = args;
-  var __name4 = ____id23[0];
-  var __args6 = ____id23[1];
-  var __body8 = cut(____id23, 2);
+  var ____id24 = args;
+  var __name4 = ____id24[0];
+  var __args6 = ____id24[1];
+  var __body8 = cut(____id24, 2);
   return(add(hoist, [kind, __name4, __args6, lower_body(__body8, true)]));
 };
 var lower_call = function (form, hoist) {
-  var __form2 = map(function (x) {
+  var __form3 = map(function (x) {
     return(lower(x, hoist));
   }, form);
-  if (some63(__form2)) {
-    return(__form2);
+  if (some63(__form3)) {
+    return(__form3);
   }
 };
 var pairwise63 = function (form) {
@@ -978,9 +987,9 @@ var pairwise63 = function (form) {
 var lower_pairwise = function (form) {
   if (pairwise63(form)) {
     var __e4 = [];
-    var ____id24 = form;
-    var __x125 = ____id24[0];
-    var __args7 = cut(____id24, 1);
+    var ____id25 = form;
+    var __x125 = ____id25[0];
+    var __args7 = cut(____id25, 1);
     reduce(function (a, b) {
       add(__e4, [__x125, a, b]);
       return(a);
@@ -994,10 +1003,10 @@ var lower_infix63 = function (form) {
   return(infix63(hd(form)) && _35(form) > 3);
 };
 var lower_infix = function (form, hoist) {
-  var __form3 = lower_pairwise(form);
-  var ____id25 = __form3;
-  var __x128 = ____id25[0];
-  var __args8 = cut(____id25, 1);
+  var __form4 = lower_pairwise(form);
+  var ____id26 = __form4;
+  var __x128 = ____id26[0];
+  var __args8 = cut(____id26, 1);
   return(lower(reduce(function (a, b) {
     return([__x128, b, a]);
   }, reverse(__args8)), hoist));
@@ -1021,9 +1030,9 @@ lower = function (form, hoist, stmt63, tail63) {
         if (lower_infix63(form)) {
           return(lower_infix(form, hoist));
         } else {
-          var ____id26 = form;
-          var __x131 = ____id26[0];
-          var __args9 = cut(____id26, 1);
+          var ____id27 = form;
+          var __x131 = ____id27[0];
+          var __args9 = cut(____id27, 1);
           if (__x131 === "do") {
             return(lower_do(__args9, hoist, stmt63, tail63));
           } else {
@@ -1233,7 +1242,7 @@ setenv("error", {_stash: true, special: function (x) {
   return(indentation() + __e12);
 }, stmt: true});
 setenv("%local", {_stash: true, special: function (name, value) {
-  var __id28 = compile(name);
+  var __id29 = compile(name);
   var __value11 = compile(value);
   var __e57;
   if (is63(value)) {
@@ -1250,7 +1259,7 @@ setenv("%local", {_stash: true, special: function (name, value) {
   }
   var __keyword1 = __e58;
   var __ind11 = indentation();
-  return(__ind11 + __keyword1 + __id28 + __rh2);
+  return(__ind11 + __keyword1 + __id29 + __rh2);
 }, stmt: true});
 setenv("%set", {_stash: true, special: function (lh, rh) {
   var __lh2 = compile(lh);
@@ -1334,9 +1343,9 @@ setenv("%object", {_stash: true, special: function () {
     }
     var __k22 = __e64;
     if (number63(__k22)) {
-      var ____id30 = __v12;
-      var __k23 = ____id30[0];
-      var __v13 = ____id30[1];
+      var ____id31 = __v12;
+      var __k23 = ____id31[0];
+      var __v13 = ____id31[1];
       if (! string63(__k23)) {
         throw new Error("Illegal key: " + str(__k23));
       }

--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -200,72 +200,17 @@ var can_unquote63 = function (depth) {
 var quasisplice63 = function (x, depth) {
   return(can_unquote63(depth) && ! atom63(x) && hd(x) === "unquote-splicing");
 };
-var expand_local = function (__x38) {
-  var ____id1 = __x38;
-  var __x39 = ____id1[0];
-  var __name = ____id1[1];
-  var __value = ____id1[2];
-  setenv(__name, {_stash: true, variable: true});
-  return(["%local", __name, macroexpand(__value)]);
-};
-var expand_function = function (__x41) {
-  var ____id2 = __x41;
-  var __x42 = ____id2[0];
-  var __args = ____id2[1];
-  var __body = cut(____id2, 2);
-  add(environment, {});
-  var ____o3 = __args;
-  var ____i5 = undefined;
-  for (____i5 in ____o3) {
-    var ____x43 = ____o3[____i5];
-    var __e27;
-    if (numeric63(____i5)) {
-      __e27 = parseInt(____i5);
-    } else {
-      __e27 = ____i5;
-    }
-    var ____i51 = __e27;
-    setenv(____x43, {_stash: true, variable: true});
-  }
-  var ____x44 = join(["%function", __args], macroexpand(__body));
-  drop(environment);
-  return(____x44);
-};
-var expand_definition = function (__x46) {
-  var ____id3 = __x46;
-  var __x47 = ____id3[0];
-  var __name1 = ____id3[1];
-  var __args11 = ____id3[2];
-  var __body1 = cut(____id3, 3);
-  add(environment, {});
-  var ____o4 = __args11;
-  var ____i6 = undefined;
-  for (____i6 in ____o4) {
-    var ____x48 = ____o4[____i6];
-    var __e28;
-    if (numeric63(____i6)) {
-      __e28 = parseInt(____i6);
-    } else {
-      __e28 = ____i6;
-    }
-    var ____i61 = __e28;
-    setenv(____x48, {_stash: true, variable: true});
-  }
-  var ____x49 = join([__x47, __name1, __args11], macroexpand(__body1));
-  drop(environment);
-  return(____x49);
-};
 var expand_macro = function (form) {
   return(expand1(form, true));
 };
-expand1 = function (__x51, expand63) {
-  var ____id4 = __x51;
-  var __name2 = ____id4[0];
-  var __body2 = cut(____id4, 1);
-  var ____id5 = getenv(__name2);
-  var __macro = ____id5.macro;
-  var __once = ____id5.once;
-  var __form = apply(__macro, __body2);
+expand1 = function (__x38, expand63) {
+  var ____id1 = __x38;
+  var __name = ____id1[0];
+  var __body = cut(____id1, 1);
+  var ____id2 = getenv(__name);
+  var __macro = ____id2.macro;
+  var __once = ____id2.once;
+  var __form = apply(__macro, __body);
   if (expand63) {
     if (! __once) {
       __form = macroexpand(__form);
@@ -280,67 +225,51 @@ macroexpand = function (form) {
     if (atom63(form)) {
       return(form);
     } else {
-      var __x52 = hd(form);
-      if (__x52 === "%local") {
-        return(expand_local(form));
+      var __x39 = hd(form);
+      if (macro63(__x39)) {
+        return(expand_macro(form));
       } else {
-        if (__x52 === "%function") {
-          return(expand_function(form));
-        } else {
-          if (__x52 === "%global-function") {
-            return(expand_definition(form));
-          } else {
-            if (__x52 === "%local-function") {
-              return(expand_definition(form));
-            } else {
-              if (macro63(__x52)) {
-                return(expand_macro(form));
-              } else {
-                return(map(macroexpand, form));
-              }
-            }
-          }
-        }
+        return(map(macroexpand, form));
       }
     }
   }
 };
 var quasiquote_list = function (form, depth) {
   var __xs = [["list"]];
-  var ____o5 = form;
+  var ____o3 = form;
   var __k7 = undefined;
-  for (__k7 in ____o5) {
-    var __v4 = ____o5[__k7];
-    var __e29;
+  for (__k7 in ____o3) {
+    var __v4 = ____o3[__k7];
+    var __e27;
     if (numeric63(__k7)) {
-      __e29 = parseInt(__k7);
+      __e27 = parseInt(__k7);
     } else {
-      __e29 = __k7;
+      __e27 = __k7;
     }
-    var __k8 = __e29;
+    var __k8 = __e27;
     if (! number63(__k8)) {
-      var __e30;
+      var __e28;
       if (quasisplice63(__v4, depth)) {
-        __e30 = quasiexpand(__v4[1]);
+        __e28 = quasiexpand(__v4[1]);
       } else {
-        __e30 = quasiexpand(__v4, depth);
+        __e28 = quasiexpand(__v4, depth);
       }
-      var __v5 = __e30;
+      var __v5 = __e28;
       last(__xs)[__k8] = __v5;
     }
   }
-  var ____x55 = form;
-  var ____i8 = 0;
-  while (____i8 < _35(____x55)) {
-    var __x56 = ____x55[____i8];
-    if (quasisplice63(__x56, depth)) {
-      var __x57 = quasiexpand(__x56[1]);
-      add(__xs, __x57);
+  var ____x42 = form;
+  var ____i6 = 0;
+  while (____i6 < _35(____x42)) {
+    var __x43 = ____x42[____i6];
+    if (quasisplice63(__x43, depth)) {
+      var __x44 = quasiexpand(__x43[1]);
+      add(__xs, __x44);
       add(__xs, ["list"]);
     } else {
-      add(last(__xs), quasiexpand(__x56, depth));
+      add(last(__xs), quasiexpand(__x43, depth));
     }
-    ____i8 = ____i8 + 1;
+    ____i6 = ____i6 + 1;
   }
   var __pruned = keep(function (x) {
     return(_35(x) > 1 || !( hd(x) === "list") || keys63(x));
@@ -388,11 +317,11 @@ quasiexpand = function (form, depth) {
     }
   }
 };
-expand_if = function (__x61) {
-  var ____id6 = __x61;
-  var __a = ____id6[0];
-  var __b1 = ____id6[1];
-  var __c = cut(____id6, 2);
+expand_if = function (__x48) {
+  var ____id3 = __x48;
+  var __a = ____id3[0];
+  var __b1 = ____id3[1];
+  var __c = cut(____id3, 2);
   if (is63(__b1)) {
     return([join(["%if", __a, __b1], expand_if(__c))]);
   } else {
@@ -404,10 +333,10 @@ expand_if = function (__x61) {
 indent_level = 0;
 indentation = function () {
   var __s = "";
-  var __i9 = 0;
-  while (__i9 < indent_level) {
+  var __i7 = 0;
+  while (__i7 < indent_level) {
     __s = __s + "  ";
-    __i9 = __i9 + 1;
+    __i7 = __i7 + 1;
   }
   return(__s);
 };
@@ -419,38 +348,38 @@ var valid_code63 = function (n) {
   return(number_code63(n) || n > 64 && n < 91 || n > 96 && n < 123 || n === 95);
 };
 var id = function (id) {
-  var __e31;
+  var __e29;
   if (number_code63(code(id, 0))) {
-    __e31 = "_";
+    __e29 = "_";
   } else {
-    __e31 = "";
+    __e29 = "";
   }
-  var __id11 = __e31;
-  var __i10 = 0;
-  while (__i10 < _35(id)) {
-    var __c1 = char(id, __i10);
-    var __n7 = code(__c1);
-    var __e32;
+  var __id11 = __e29;
+  var __i8 = 0;
+  while (__i8 < _35(id)) {
+    var __c1 = char(id, __i8);
+    var __n5 = code(__c1);
+    var __e30;
     if (__c1 === "-" && !( id === "-")) {
-      __e32 = "_";
+      __e30 = "_";
     } else {
-      var __e33;
-      if (valid_code63(__n7)) {
-        __e33 = __c1;
+      var __e31;
+      if (valid_code63(__n5)) {
+        __e31 = __c1;
       } else {
-        var __e34;
-        if (__i10 === 0) {
-          __e34 = "_" + __n7;
+        var __e32;
+        if (__i8 === 0) {
+          __e32 = "_" + __n5;
         } else {
-          __e34 = __n7;
+          __e32 = __n5;
         }
-        __e33 = __e34;
+        __e31 = __e32;
       }
-      __e32 = __e33;
+      __e30 = __e31;
     }
-    var __c11 = __e32;
+    var __c11 = __e30;
     __id11 = __id11 + __c11;
-    __i10 = __i10 + 1;
+    __i8 = __i8 + 1;
   }
   if (reserved63(__id11)) {
     return("_" + __id11);
@@ -463,20 +392,20 @@ valid_id63 = function (x) {
 };
 var __names = {};
 unique = function (x) {
-  var __x65 = id(x);
-  if (__names[__x65]) {
-    var __i11 = __names[__x65];
-    __names[__x65] = __names[__x65] + 1;
-    return(unique(__x65 + __i11));
+  var __x52 = id(x);
+  if (__names[__x52]) {
+    var __i9 = __names[__x52];
+    __names[__x52] = __names[__x52] + 1;
+    return(unique(__x52 + __i9));
   } else {
-    __names[__x65] = 1;
-    return("__" + __x65);
+    __names[__x52] = 1;
+    return("__" + __x52);
   }
 };
 key = function (k) {
-  var __i12 = inner(k);
-  if (valid_id63(__i12)) {
-    return(__i12);
+  var __i10 = inner(k);
+  if (valid_id63(__i10)) {
+    return(__i10);
   } else {
     if (target === "js") {
       return(k);
@@ -486,64 +415,64 @@ key = function (k) {
   }
 };
 mapo = function (f, t) {
-  var __o6 = [];
-  var ____o7 = t;
+  var __o4 = [];
+  var ____o5 = t;
   var __k9 = undefined;
-  for (__k9 in ____o7) {
-    var __v6 = ____o7[__k9];
-    var __e35;
+  for (__k9 in ____o5) {
+    var __v6 = ____o5[__k9];
+    var __e33;
     if (numeric63(__k9)) {
-      __e35 = parseInt(__k9);
+      __e33 = parseInt(__k9);
     } else {
-      __e35 = __k9;
+      __e33 = __k9;
     }
-    var __k10 = __e35;
-    var __x66 = f(__v6);
-    if (is63(__x66)) {
-      add(__o6, literal(__k10));
-      add(__o6, __x66);
+    var __k10 = __e33;
+    var __x53 = f(__v6);
+    if (is63(__x53)) {
+      add(__o4, literal(__k10));
+      add(__o4, __x53);
     }
   }
-  return(__o6);
+  return(__o4);
 };
-var ____x68 = [];
-var ____x69 = [];
-____x69.js = "!";
-____x69.lua = "not";
-____x68["not"] = ____x69;
-var ____x70 = [];
-____x70["*"] = true;
-____x70["/"] = true;
-____x70["%"] = true;
-var ____x71 = [];
-var ____x72 = [];
-____x72.js = "+";
-____x72.lua = "..";
-____x71.cat = ____x72;
-var ____x73 = [];
-____x73["+"] = true;
-____x73["-"] = true;
-var ____x74 = [];
-____x74["<"] = true;
-____x74[">"] = true;
-____x74["<="] = true;
-____x74[">="] = true;
-var ____x75 = [];
-var ____x76 = [];
-____x76.js = "===";
-____x76.lua = "==";
-____x75["="] = ____x76;
-var ____x77 = [];
-var ____x78 = [];
-____x78.js = "&&";
-____x78.lua = "and";
-____x77["and"] = ____x78;
-var ____x79 = [];
-var ____x80 = [];
-____x80.js = "||";
-____x80.lua = "or";
-____x79["or"] = ____x80;
-var infix = [____x68, ____x70, ____x71, ____x73, ____x74, ____x75, ____x77, ____x79];
+var ____x55 = [];
+var ____x56 = [];
+____x56.js = "!";
+____x56.lua = "not";
+____x55["not"] = ____x56;
+var ____x57 = [];
+____x57["*"] = true;
+____x57["/"] = true;
+____x57["%"] = true;
+var ____x58 = [];
+var ____x59 = [];
+____x59.js = "+";
+____x59.lua = "..";
+____x58.cat = ____x59;
+var ____x60 = [];
+____x60["+"] = true;
+____x60["-"] = true;
+var ____x61 = [];
+____x61["<"] = true;
+____x61[">"] = true;
+____x61["<="] = true;
+____x61[">="] = true;
+var ____x62 = [];
+var ____x63 = [];
+____x63.js = "===";
+____x63.lua = "==";
+____x62["="] = ____x63;
+var ____x64 = [];
+var ____x65 = [];
+____x65.js = "&&";
+____x65.lua = "and";
+____x64["and"] = ____x65;
+var ____x66 = [];
+var ____x67 = [];
+____x67.js = "||";
+____x67.lua = "or";
+____x66["or"] = ____x67;
+var infix = [____x55, ____x57, ____x58, ____x60, ____x61, ____x62, ____x64, ____x66];
 var unary63 = function (form) {
   return(two63(form) && in63(hd(form), ["not", "-"]));
 };
@@ -552,17 +481,17 @@ var index = function (k) {
 };
 var precedence = function (form) {
   if (!( atom63(form) || unary63(form))) {
-    var ____o8 = infix;
+    var ____o6 = infix;
     var __k11 = undefined;
-    for (__k11 in ____o8) {
-      var __v7 = ____o8[__k11];
-      var __e36;
+    for (__k11 in ____o6) {
+      var __v7 = ____o6[__k11];
+      var __e34;
       if (numeric63(__k11)) {
-        __e36 = parseInt(__k11);
+        __e34 = parseInt(__k11);
       } else {
-        __e36 = __k11;
+        __e34 = __k11;
       }
-      var __k12 = __e36;
+      var __k12 = __e34;
       if (__v7[hd(form)]) {
         return(index(__k12));
       }
@@ -572,12 +501,12 @@ var precedence = function (form) {
 };
 var getop = function (op) {
   return(find(function (level) {
-    var __x82 = level[op];
-    if (__x82 === true) {
+    var __x69 = level[op];
+    if (__x69 === true) {
       return(op);
     } else {
-      if (is63(__x82)) {
-        return(__x82[target]);
+      if (is63(__x69)) {
+        return(__x69[target]);
       }
     }
   }, infix));
@@ -591,35 +520,35 @@ infix_operator63 = function (x) {
 var compile_args = function (args) {
   var __s1 = "(";
   var __c2 = "";
-  var ____x83 = args;
-  var ____i15 = 0;
-  while (____i15 < _35(____x83)) {
-    var __x84 = ____x83[____i15];
-    __s1 = __s1 + __c2 + compile(__x84);
+  var ____x70 = args;
+  var ____i13 = 0;
+  while (____i13 < _35(____x70)) {
+    var __x71 = ____x70[____i13];
+    __s1 = __s1 + __c2 + compile(__x71);
     __c2 = ", ";
-    ____i15 = ____i15 + 1;
+    ____i13 = ____i13 + 1;
   }
   return(__s1 + ")");
 };
 var escape_newlines = function (s) {
   var __s11 = "";
-  var __i16 = 0;
-  while (__i16 < _35(s)) {
-    var __c3 = char(s, __i16);
-    var __e37;
+  var __i14 = 0;
+  while (__i14 < _35(s)) {
+    var __c3 = char(s, __i14);
+    var __e35;
     if (__c3 === "\n") {
-      __e37 = "\\n";
+      __e35 = "\\n";
     } else {
-      var __e38;
+      var __e36;
       if (__c3 === "\r") {
-        __e38 = "\\r";
+        __e36 = "\\r";
       } else {
-        __e38 = __c3;
+        __e36 = __c3;
       }
-      __e37 = __e38;
+      __e35 = __e36;
     }
-    __s11 = __s11 + __e37;
-    __i16 = __i16 + 1;
+    __s11 = __s11 + __e35;
+    __i14 = __i14 + 1;
   }
   return(__s11);
 };
@@ -682,15 +611,15 @@ var terminator = function (stmt63) {
   }
 };
 var compile_special = function (form, stmt63) {
-  var ____id7 = form;
-  var __x85 = ____id7[0];
-  var __args2 = cut(____id7, 1);
-  var ____id8 = getenv(__x85);
-  var __special = ____id8.special;
-  var __stmt = ____id8.stmt;
-  var __self_tr63 = ____id8.tr;
+  var ____id4 = form;
+  var __x72 = ____id4[0];
+  var __args = cut(____id4, 1);
+  var ____id5 = getenv(__x72);
+  var __special = ____id5.special;
+  var __stmt = ____id5.stmt;
+  var __self_tr63 = ____id5.tr;
   var __tr = terminator(stmt63 && ! __self_tr63);
-  return(apply(__special, __args2) + __tr);
+  return(apply(__special, __args) + __tr);
 };
 var parenthesize_call63 = function (x) {
   return(! atom63(x) && hd(x) === "%function" || precedence(x) > 0);
@@ -698,43 +627,43 @@ var parenthesize_call63 = function (x) {
 var compile_call = function (form) {
   var __f = hd(form);
   var __f1 = compile(__f);
-  var __args3 = compile_args(stash42(tl(form)));
+  var __args11 = compile_args(stash42(tl(form)));
   if (parenthesize_call63(__f)) {
-    return("(" + __f1 + ")" + __args3);
+    return("(" + __f1 + ")" + __args11);
   } else {
-    return(__f1 + __args3);
+    return(__f1 + __args11);
   }
 };
 var op_delims = function (parent, child) {
-  var ____r57 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __parent = destash33(parent, ____r57);
-  var __child = destash33(child, ____r57);
-  var ____id9 = ____r57;
-  var __right = ____id9.right;
-  var __e39;
+  var ____r54 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __parent = destash33(parent, ____r54);
+  var __child = destash33(child, ____r54);
+  var ____id6 = ____r54;
+  var __right = ____id6.right;
+  var __e37;
   if (__right) {
-    __e39 = _6261;
+    __e37 = _6261;
   } else {
-    __e39 = _62;
+    __e37 = _62;
   }
-  if (__e39(precedence(__child), precedence(__parent))) {
+  if (__e37(precedence(__child), precedence(__parent))) {
     return(["(", ")"]);
   } else {
     return(["", ""]);
   }
 };
 var compile_infix = function (form) {
-  var ____id10 = form;
-  var __op = ____id10[0];
-  var ____id111 = cut(____id10, 1);
-  var __a1 = ____id111[0];
-  var __b2 = ____id111[1];
-  var ____id12 = op_delims(form, __a1);
-  var __ao = ____id12[0];
-  var __ac = ____id12[1];
-  var ____id13 = op_delims(form, __b2, {_stash: true, right: true});
-  var __bo = ____id13[0];
-  var __bc = ____id13[1];
+  var ____id7 = form;
+  var __op = ____id7[0];
+  var ____id8 = cut(____id7, 1);
+  var __a1 = ____id8[0];
+  var __b2 = ____id8[1];
+  var ____id9 = op_delims(form, __a1);
+  var __ao = ____id9[0];
+  var __ac = ____id9[1];
+  var ____id10 = op_delims(form, __b2, {_stash: true, right: true});
+  var __bo = ____id10[0];
+  var __bc = ____id10[1];
   var __a2 = compile(__a1);
   var __b3 = compile(__b2);
   var __op1 = getop(__op);
@@ -745,63 +674,63 @@ var compile_infix = function (form) {
   }
 };
 compile_function = function (args, body) {
-  var ____r59 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __args4 = destash33(args, ____r59);
-  var __body3 = destash33(body, ____r59);
-  var ____id14 = ____r59;
-  var __name3 = ____id14.name;
-  var __prefix = ____id14.prefix;
+  var ____r56 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __args2 = destash33(args, ____r56);
+  var __body1 = destash33(body, ____r56);
+  var ____id111 = ____r56;
+  var __name1 = ____id111.name;
+  var __prefix = ____id111.prefix;
+  var __e38;
+  if (__name1) {
+    __e38 = compile(__name1);
+  } else {
+    __e38 = "";
+  }
+  var __id12 = __e38;
+  var __e39;
+  if (target === "lua" && __args2.rest) {
+    __e39 = join(__args2, ["|...|"]);
+  } else {
+    __e39 = __args2;
+  }
+  var __args12 = __e39;
+  var __args3 = compile_args(__args12);
+  indent_level = indent_level + 1;
+  var ____x76 = compile(__body1, {_stash: true, stmt: true});
+  indent_level = indent_level - 1;
+  var __body2 = ____x76;
+  var __ind = indentation();
   var __e40;
-  if (__name3) {
-    __e40 = compile(__name3);
+  if (__prefix) {
+    __e40 = __prefix + " ";
   } else {
     __e40 = "";
   }
-  var __id15 = __e40;
+  var __p = __e40;
   var __e41;
-  if (target === "lua" && __args4.rest) {
-    __e41 = join(__args4, ["|...|"]);
-  } else {
-    __e41 = __args4;
-  }
-  var __args12 = __e41;
-  var __args5 = compile_args(__args12);
-  indent_level = indent_level + 1;
-  var ____x89 = compile(__body3, {_stash: true, stmt: true});
-  indent_level = indent_level - 1;
-  var __body4 = ____x89;
-  var __ind = indentation();
-  var __e42;
-  if (__prefix) {
-    __e42 = __prefix + " ";
-  } else {
-    __e42 = "";
-  }
-  var __p = __e42;
-  var __e43;
   if (target === "js") {
-    __e43 = "";
+    __e41 = "";
   } else {
-    __e43 = "end";
+    __e41 = "end";
   }
-  var __tr1 = __e43;
-  if (__name3) {
+  var __tr1 = __e41;
+  if (__name1) {
     __tr1 = __tr1 + "\n";
   }
   if (target === "js") {
-    return("function " + __id15 + __args5 + " {\n" + __body4 + __ind + "}" + __tr1);
+    return("function " + __id12 + __args3 + " {\n" + __body2 + __ind + "}" + __tr1);
   } else {
-    return(__p + "function " + __id15 + __args5 + "\n" + __body4 + __ind + __tr1);
+    return(__p + "function " + __id12 + __args3 + "\n" + __body2 + __ind + __tr1);
   }
 };
 var can_return63 = function (form) {
   return(is63(form) && (atom63(form) || !( hd(form) === "return") && ! statement63(hd(form))));
 };
 compile = function (form) {
-  var ____r61 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __form1 = destash33(form, ____r61);
-  var ____id16 = ____r61;
-  var __stmt1 = ____id16.stmt;
+  var ____r58 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __form1 = destash33(form, ____r58);
+  var ____id13 = ____r58;
+  var __stmt1 = ____id13.stmt;
   if (nil63(__form1)) {
     return("");
   } else {
@@ -809,26 +738,26 @@ compile = function (form) {
       return(compile_special(__form1, __stmt1));
     } else {
       var __tr2 = terminator(__stmt1);
-      var __e44;
+      var __e42;
       if (__stmt1) {
-        __e44 = indentation();
+        __e42 = indentation();
       } else {
-        __e44 = "";
+        __e42 = "";
       }
-      var __ind1 = __e44;
-      var __e45;
+      var __ind1 = __e42;
+      var __e43;
       if (atom63(__form1)) {
-        __e45 = compile_atom(__form1);
+        __e43 = compile_atom(__form1);
       } else {
-        var __e46;
+        var __e44;
         if (infix63(hd(__form1))) {
-          __e46 = compile_infix(__form1);
+          __e44 = compile_infix(__form1);
         } else {
-          __e46 = compile_call(__form1);
+          __e44 = compile_call(__form1);
         }
-        __e45 = __e46;
+        __e43 = __e44;
       }
-      var __form2 = __e45;
+      var __form2 = __e43;
       return(__ind1 + __form2 + __tr2);
     }
   }
@@ -836,25 +765,25 @@ compile = function (form) {
 var lower_statement = function (form, tail63) {
   var __hoist = [];
   var __e = lower(form, __hoist, true, tail63);
-  var __e47;
+  var __e45;
   if (some63(__hoist) && is63(__e)) {
-    __e47 = join(["do"], __hoist, [__e]);
+    __e45 = join(["do"], __hoist, [__e]);
   } else {
-    var __e48;
+    var __e46;
     if (is63(__e)) {
-      __e48 = __e;
+      __e46 = __e;
     } else {
-      var __e49;
+      var __e47;
       if (_35(__hoist) > 1) {
-        __e49 = join(["do"], __hoist);
+        __e47 = join(["do"], __hoist);
       } else {
-        __e49 = hd(__hoist);
+        __e47 = hd(__hoist);
       }
-      __e48 = __e49;
+      __e46 = __e47;
     }
-    __e47 = __e48;
+    __e45 = __e46;
   }
-  return(either(__e47, ["do"]));
+  return(either(__e45, ["do"]));
 };
 var lower_body = function (body, tail63) {
   return(lower_statement(join(["do"], body), tail63));
@@ -866,18 +795,18 @@ var standalone63 = function (form) {
   return(! atom63(form) && ! infix63(hd(form)) && ! literal63(form) && !( "get" === hd(form)) || id_literal63(form));
 };
 var lower_do = function (args, hoist, stmt63, tail63) {
-  var ____x95 = almost(args);
-  var ____i17 = 0;
-  while (____i17 < _35(____x95)) {
-    var __x96 = ____x95[____i17];
-    var ____y = lower(__x96, hoist, stmt63);
+  var ____x82 = almost(args);
+  var ____i15 = 0;
+  while (____i15 < _35(____x82)) {
+    var __x83 = ____x82[____i15];
+    var ____y = lower(__x83, hoist, stmt63);
     if (yes(____y)) {
       var __e1 = ____y;
       if (standalone63(__e1)) {
         add(hoist, __e1);
       }
     }
-    ____i17 = ____i17 + 1;
+    ____i15 = ____i15 + 1;
   }
   var __e2 = lower(last(args), hoist, stmt63, tail63);
   if (tail63 && can_return63(__e2)) {
@@ -887,51 +816,51 @@ var lower_do = function (args, hoist, stmt63, tail63) {
   }
 };
 var lower_set = function (args, hoist, stmt63, tail63) {
-  var ____id17 = args;
-  var __lh = ____id17[0];
-  var __rh = ____id17[1];
+  var ____id14 = args;
+  var __lh = ____id14[0];
+  var __rh = ____id14[1];
   add(hoist, ["%set", lower(__lh, hoist), lower(__rh, hoist)]);
   if (!( stmt63 && ! tail63)) {
     return(__lh);
   }
 };
 var lower_if = function (args, hoist, stmt63, tail63) {
-  var ____id18 = args;
-  var __cond = ____id18[0];
-  var ___then = ____id18[1];
-  var ___else = ____id18[2];
+  var ____id15 = args;
+  var __cond = ____id15[0];
+  var ___then = ____id15[1];
+  var ___else = ____id15[2];
   if (stmt63) {
-    var __e51;
+    var __e49;
     if (is63(___else)) {
-      __e51 = [lower_body([___else], tail63)];
+      __e49 = [lower_body([___else], tail63)];
     }
-    return(add(hoist, join(["%if", lower(__cond, hoist), lower_body([___then], tail63)], __e51)));
+    return(add(hoist, join(["%if", lower(__cond, hoist), lower_body([___then], tail63)], __e49)));
   } else {
     var __e3 = unique("e");
     add(hoist, ["%local", __e3]);
-    var __e50;
+    var __e48;
     if (is63(___else)) {
-      __e50 = [lower(["%set", __e3, ___else])];
+      __e48 = [lower(["%set", __e3, ___else])];
     }
-    add(hoist, join(["%if", lower(__cond, hoist), lower(["%set", __e3, ___then])], __e50));
+    add(hoist, join(["%if", lower(__cond, hoist), lower(["%set", __e3, ___then])], __e48));
     return(__e3);
   }
 };
 var lower_short = function (x, args, hoist) {
-  var ____id19 = args;
-  var __a3 = ____id19[0];
-  var __b4 = ____id19[1];
+  var ____id16 = args;
+  var __a3 = ____id16[0];
+  var __b4 = ____id16[1];
   var __hoist1 = [];
   var __b11 = lower(__b4, __hoist1);
   if (some63(__hoist1)) {
-    var __id20 = unique("id");
-    var __e52;
+    var __id17 = unique("id");
+    var __e50;
     if (x === "and") {
-      __e52 = ["%if", __id20, __b4, __id20];
+      __e50 = ["%if", __id17, __b4, __id17];
     } else {
-      __e52 = ["%if", __id20, __id20, __b4];
+      __e50 = ["%if", __id17, __id17, __b4];
     }
-    return(lower(["do", ["%local", __id20, __a3], __e52], hoist));
+    return(lower(["do", ["%local", __id17, __a3], __e50], hoist));
   } else {
     return([x, lower(__a3, hoist), __b11]);
   }
@@ -940,38 +869,38 @@ var lower_try = function (args, hoist, tail63) {
   return(add(hoist, ["%try", lower_body(args, tail63)]));
 };
 var lower_while = function (args, hoist) {
-  var ____id21 = args;
-  var __c4 = ____id21[0];
-  var __body5 = cut(____id21, 1);
+  var ____id18 = args;
+  var __c4 = ____id18[0];
+  var __body3 = cut(____id18, 1);
   var __pre = [];
   var __c5 = lower(__c4, __pre);
-  var __e53;
+  var __e51;
   if (none63(__pre)) {
-    __e53 = ["while", __c5, lower_body(__body5)];
+    __e51 = ["while", __c5, lower_body(__body3)];
   } else {
-    __e53 = ["while", true, join(["do"], __pre, [["%if", ["not", __c5], ["break"]], lower_body(__body5)])];
+    __e51 = ["while", true, join(["do"], __pre, [["%if", ["not", __c5], ["break"]], lower_body(__body3)])];
   }
-  return(add(hoist, __e53));
+  return(add(hoist, __e51));
 };
 var lower_for = function (args, hoist) {
-  var ____id22 = args;
-  var __t = ____id22[0];
-  var __k13 = ____id22[1];
-  var __body6 = cut(____id22, 2);
-  return(add(hoist, ["%for", lower(__t, hoist), __k13, lower_body(__body6)]));
+  var ____id19 = args;
+  var __t = ____id19[0];
+  var __k13 = ____id19[1];
+  var __body4 = cut(____id19, 2);
+  return(add(hoist, ["%for", lower(__t, hoist), __k13, lower_body(__body4)]));
 };
 var lower_function = function (args) {
-  var ____id23 = args;
-  var __a4 = ____id23[0];
-  var __body7 = cut(____id23, 1);
-  return(["%function", __a4, lower_body(__body7, true)]);
+  var ____id20 = args;
+  var __a4 = ____id20[0];
+  var __body5 = cut(____id20, 1);
+  return(["%function", __a4, lower_body(__body5, true)]);
 };
 var lower_definition = function (kind, args, hoist) {
-  var ____id24 = args;
-  var __name4 = ____id24[0];
-  var __args6 = ____id24[1];
-  var __body8 = cut(____id24, 2);
-  return(add(hoist, [kind, __name4, __args6, lower_body(__body8, true)]));
+  var ____id21 = args;
+  var __name2 = ____id21[0];
+  var __args4 = ____id21[1];
+  var __body6 = cut(____id21, 2);
+  return(add(hoist, [kind, __name2, __args4, lower_body(__body6, true)]));
 };
 var lower_call = function (form, hoist) {
   var __form3 = map(function (x) {
@@ -987,13 +916,13 @@ var pairwise63 = function (form) {
 var lower_pairwise = function (form) {
   if (pairwise63(form)) {
     var __e4 = [];
-    var ____id25 = form;
-    var __x125 = ____id25[0];
-    var __args7 = cut(____id25, 1);
+    var ____id22 = form;
+    var __x112 = ____id22[0];
+    var __args5 = cut(____id22, 1);
     reduce(function (a, b) {
-      add(__e4, [__x125, a, b]);
+      add(__e4, [__x112, a, b]);
       return(a);
-    }, __args7);
+    }, __args5);
     return(join(["and"], reverse(__e4)));
   } else {
     return(form);
@@ -1004,12 +933,12 @@ var lower_infix63 = function (form) {
 };
 var lower_infix = function (form, hoist) {
   var __form4 = lower_pairwise(form);
-  var ____id26 = __form4;
-  var __x128 = ____id26[0];
-  var __args8 = cut(____id26, 1);
+  var ____id23 = __form4;
+  var __x115 = ____id23[0];
+  var __args6 = cut(____id23, 1);
   return(lower(reduce(function (a, b) {
-    return([__x128, b, a]);
-  }, reverse(__args8)), hoist));
+    return([__x115, b, a]);
+  }, reverse(__args6)), hoist));
 };
 var lower_special = function (form, hoist) {
   var __e5 = lower_call(form, hoist);
@@ -1030,37 +959,37 @@ lower = function (form, hoist, stmt63, tail63) {
         if (lower_infix63(form)) {
           return(lower_infix(form, hoist));
         } else {
-          var ____id27 = form;
-          var __x131 = ____id27[0];
-          var __args9 = cut(____id27, 1);
-          if (__x131 === "do") {
-            return(lower_do(__args9, hoist, stmt63, tail63));
+          var ____id24 = form;
+          var __x118 = ____id24[0];
+          var __args7 = cut(____id24, 1);
+          if (__x118 === "do") {
+            return(lower_do(__args7, hoist, stmt63, tail63));
           } else {
-            if (__x131 === "%set") {
-              return(lower_set(__args9, hoist, stmt63, tail63));
+            if (__x118 === "%set") {
+              return(lower_set(__args7, hoist, stmt63, tail63));
             } else {
-              if (__x131 === "%if") {
-                return(lower_if(__args9, hoist, stmt63, tail63));
+              if (__x118 === "%if") {
+                return(lower_if(__args7, hoist, stmt63, tail63));
               } else {
-                if (__x131 === "%try") {
-                  return(lower_try(__args9, hoist, tail63));
+                if (__x118 === "%try") {
+                  return(lower_try(__args7, hoist, tail63));
                 } else {
-                  if (__x131 === "while") {
-                    return(lower_while(__args9, hoist));
+                  if (__x118 === "while") {
+                    return(lower_while(__args7, hoist));
                   } else {
-                    if (__x131 === "%for") {
-                      return(lower_for(__args9, hoist));
+                    if (__x118 === "%for") {
+                      return(lower_for(__args7, hoist));
                     } else {
-                      if (__x131 === "%function") {
-                        return(lower_function(__args9));
+                      if (__x118 === "%function") {
+                        return(lower_function(__args7));
                       } else {
-                        if (__x131 === "%local-function" || __x131 === "%global-function") {
-                          return(lower_definition(__x131, __args9, hoist));
+                        if (__x118 === "%local-function" || __x118 === "%global-function") {
+                          return(lower_definition(__x118, __args7, hoist));
                         } else {
-                          if (in63(__x131, ["and", "or"])) {
-                            return(lower_short(__x131, __args9, hoist));
+                          if (in63(__x118, ["and", "or"])) {
+                            return(lower_short(__x118, __args7, hoist));
                           } else {
-                            if (statement63(__x131)) {
+                            if (statement63(__x118)) {
                               return(lower_special(form, hoist));
                             } else {
                               return(lower_call(form, hoist));
@@ -1099,37 +1028,37 @@ immediate_call63 = function (x) {
 setenv("do", {_stash: true, special: function () {
   var __forms1 = unstash(Array.prototype.slice.call(arguments, 0));
   var __s3 = "";
-  var ____x136 = __forms1;
-  var ____i19 = 0;
-  while (____i19 < _35(____x136)) {
-    var __x137 = ____x136[____i19];
-    if (target === "lua" && immediate_call63(__x137) && "\n" === char(__s3, edge(__s3))) {
+  var ____x123 = __forms1;
+  var ____i17 = 0;
+  while (____i17 < _35(____x123)) {
+    var __x124 = ____x123[____i17];
+    if (target === "lua" && immediate_call63(__x124) && "\n" === char(__s3, edge(__s3))) {
       __s3 = clip(__s3, 0, edge(__s3)) + ";\n";
     }
-    __s3 = __s3 + compile(__x137, {_stash: true, stmt: true});
-    if (! atom63(__x137)) {
-      if (hd(__x137) === "return" || hd(__x137) === "break") {
+    __s3 = __s3 + compile(__x124, {_stash: true, stmt: true});
+    if (! atom63(__x124)) {
+      if (hd(__x124) === "return" || hd(__x124) === "break") {
         break;
       }
     }
-    ____i19 = ____i19 + 1;
+    ____i17 = ____i17 + 1;
   }
   return(__s3);
 }, stmt: true, tr: true});
 setenv("%if", {_stash: true, special: function (cond, cons, alt) {
   var __cond2 = compile(cond);
   indent_level = indent_level + 1;
-  var ____x140 = compile(cons, {_stash: true, stmt: true});
+  var ____x127 = compile(cons, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __cons1 = ____x140;
-  var __e54;
+  var __cons1 = ____x127;
+  var __e52;
   if (alt) {
     indent_level = indent_level + 1;
-    var ____x141 = compile(alt, {_stash: true, stmt: true});
+    var ____x128 = compile(alt, {_stash: true, stmt: true});
     indent_level = indent_level - 1;
-    __e54 = ____x141;
+    __e52 = ____x128;
   }
-  var __alt1 = __e54;
+  var __alt1 = __e52;
   var __ind3 = indentation();
   var __s5 = "";
   if (target === "js") {
@@ -1153,42 +1082,42 @@ setenv("%if", {_stash: true, special: function (cond, cons, alt) {
 setenv("while", {_stash: true, special: function (cond, form) {
   var __cond4 = compile(cond);
   indent_level = indent_level + 1;
-  var ____x143 = compile(form, {_stash: true, stmt: true});
+  var ____x130 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __body10 = ____x143;
+  var __body8 = ____x130;
   var __ind5 = indentation();
   if (target === "js") {
-    return(__ind5 + "while (" + __cond4 + ") {\n" + __body10 + __ind5 + "}\n");
+    return(__ind5 + "while (" + __cond4 + ") {\n" + __body8 + __ind5 + "}\n");
   } else {
-    return(__ind5 + "while " + __cond4 + " do\n" + __body10 + __ind5 + "end\n");
+    return(__ind5 + "while " + __cond4 + " do\n" + __body8 + __ind5 + "end\n");
   }
 }, stmt: true, tr: true});
 setenv("%for", {_stash: true, special: function (t, k, form) {
   var __t2 = compile(t);
   var __ind7 = indentation();
   indent_level = indent_level + 1;
-  var ____x145 = compile(form, {_stash: true, stmt: true});
+  var ____x132 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __body12 = ____x145;
+  var __body10 = ____x132;
   if (target === "lua") {
-    return(__ind7 + "for " + k + " in next, " + __t2 + " do\n" + __body12 + __ind7 + "end\n");
+    return(__ind7 + "for " + k + " in next, " + __t2 + " do\n" + __body10 + __ind7 + "end\n");
   } else {
-    return(__ind7 + "for (" + k + " in " + __t2 + ") {\n" + __body12 + __ind7 + "}\n");
+    return(__ind7 + "for (" + k + " in " + __t2 + ") {\n" + __body10 + __ind7 + "}\n");
   }
 }, stmt: true, tr: true});
 setenv("%try", {_stash: true, special: function (form) {
   var __e8 = unique("e");
   var __ind9 = indentation();
   indent_level = indent_level + 1;
-  var ____x150 = compile(form, {_stash: true, stmt: true});
+  var ____x137 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __body14 = ____x150;
+  var __body12 = ____x137;
   var __hf1 = ["return", ["%array", false, __e8]];
   indent_level = indent_level + 1;
-  var ____x153 = compile(__hf1, {_stash: true, stmt: true});
+  var ____x140 = compile(__hf1, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __h1 = ____x153;
-  return(__ind9 + "try {\n" + __body14 + __ind9 + "}\n" + __ind9 + "catch (" + __e8 + ") {\n" + __h1 + __ind9 + "}\n");
+  var __h1 = ____x140;
+  return(__ind9 + "try {\n" + __body12 + __ind9 + "}\n" + __ind9 + "catch (" + __e8 + ") {\n" + __h1 + __ind9 + "}\n");
 }, stmt: true, tr: true});
 setenv("%delete", {_stash: true, special: function (place) {
   return(indentation() + "delete " + compile(place));
@@ -1201,29 +1130,29 @@ setenv("%function", {_stash: true, special: function (args, body) {
 }});
 setenv("%global-function", {_stash: true, special: function (name, args, body) {
   if (target === "lua") {
-    var __x157 = compile_function(args, body, {_stash: true, name: name});
-    return(indentation() + __x157);
+    var __x144 = compile_function(args, body, {_stash: true, name: name});
+    return(indentation() + __x144);
   } else {
     return(compile(["%set", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
 }, stmt: true, tr: true});
 setenv("%local-function", {_stash: true, special: function (name, args, body) {
   if (target === "lua") {
-    var __x163 = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
-    return(indentation() + __x163);
+    var __x150 = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
+    return(indentation() + __x150);
   } else {
     return(compile(["%local", name, ["%function", args, body]], {_stash: true, stmt: true}));
   }
 }, stmt: true, tr: true});
 setenv("return", {_stash: true, special: function (x) {
-  var __e55;
+  var __e53;
   if (nil63(x)) {
-    __e55 = "return";
+    __e53 = "return";
   } else {
-    __e55 = "return(" + compile(x) + ")";
+    __e53 = "return(" + compile(x) + ")";
   }
-  var __x167 = __e55;
-  return(indentation() + __x167);
+  var __x154 = __e53;
+  return(indentation() + __x154);
 }, stmt: true});
 setenv("new", {_stash: true, special: function (x) {
   return("new " + compile(x));
@@ -1232,44 +1161,44 @@ setenv("typeof", {_stash: true, special: function (x) {
   return("typeof(" + compile(x) + ")");
 }});
 setenv("error", {_stash: true, special: function (x) {
-  var __e56;
+  var __e54;
   if (target === "js") {
-    __e56 = "throw " + compile(["new", ["Error", x]]);
+    __e54 = "throw " + compile(["new", ["Error", x]]);
   } else {
-    __e56 = "error(" + compile(x) + ")";
+    __e54 = "error(" + compile(x) + ")";
   }
-  var __e12 = __e56;
+  var __e12 = __e54;
   return(indentation() + __e12);
 }, stmt: true});
 setenv("%local", {_stash: true, special: function (name, value) {
-  var __id29 = compile(name);
+  var __id26 = compile(name);
   var __value11 = compile(value);
-  var __e57;
+  var __e55;
   if (is63(value)) {
-    __e57 = " = " + __value11;
+    __e55 = " = " + __value11;
   } else {
-    __e57 = "";
+    __e55 = "";
   }
-  var __rh2 = __e57;
-  var __e58;
+  var __rh2 = __e55;
+  var __e56;
   if (target === "js") {
-    __e58 = "var ";
+    __e56 = "var ";
   } else {
-    __e58 = "local ";
+    __e56 = "local ";
   }
-  var __keyword1 = __e58;
+  var __keyword1 = __e56;
   var __ind11 = indentation();
-  return(__ind11 + __keyword1 + __id29 + __rh2);
+  return(__ind11 + __keyword1 + __id26 + __rh2);
 }, stmt: true});
 setenv("%set", {_stash: true, special: function (lh, rh) {
   var __lh2 = compile(lh);
-  var __e59;
+  var __e57;
   if (nil63(rh)) {
-    __e59 = "nil";
+    __e57 = "nil";
   } else {
-    __e59 = rh;
+    __e57 = rh;
   }
-  var __rh4 = compile(__e59);
+  var __rh4 = compile(__e57);
   return(indentation() + __lh2 + " = " + __rh4);
 }, stmt: true});
 setenv("get", {_stash: true, special: function (t, k) {
@@ -1286,33 +1215,33 @@ setenv("get", {_stash: true, special: function (t, k) {
 }});
 setenv("%array", {_stash: true, special: function () {
   var __forms3 = unstash(Array.prototype.slice.call(arguments, 0));
-  var __e60;
+  var __e58;
   if (target === "lua") {
-    __e60 = "{";
+    __e58 = "{";
   } else {
-    __e60 = "[";
+    __e58 = "[";
   }
-  var __open1 = __e60;
-  var __e61;
+  var __open1 = __e58;
+  var __e59;
   if (target === "lua") {
-    __e61 = "}";
+    __e59 = "}";
   } else {
-    __e61 = "]";
+    __e59 = "]";
   }
-  var __close1 = __e61;
+  var __close1 = __e59;
   var __s7 = "";
   var __c7 = "";
-  var ____o10 = __forms3;
+  var ____o8 = __forms3;
   var __k16 = undefined;
-  for (__k16 in ____o10) {
-    var __v9 = ____o10[__k16];
-    var __e62;
+  for (__k16 in ____o8) {
+    var __v9 = ____o8[__k16];
+    var __e60;
     if (numeric63(__k16)) {
-      __e62 = parseInt(__k16);
+      __e60 = parseInt(__k16);
     } else {
-      __e62 = __k16;
+      __e60 = __k16;
     }
-    var __k17 = __e62;
+    var __k17 = __e60;
     if (number63(__k17)) {
       __s7 = __s7 + __c7 + compile(__v9);
       __c7 = ", ";
@@ -1324,28 +1253,28 @@ setenv("%object", {_stash: true, special: function () {
   var __forms5 = unstash(Array.prototype.slice.call(arguments, 0));
   var __s9 = "{";
   var __c9 = "";
-  var __e63;
+  var __e61;
   if (target === "lua") {
-    __e63 = " = ";
+    __e61 = " = ";
   } else {
-    __e63 = ": ";
+    __e61 = ": ";
   }
-  var __sep1 = __e63;
-  var ____o12 = pair(__forms5);
+  var __sep1 = __e61;
+  var ____o10 = pair(__forms5);
   var __k21 = undefined;
-  for (__k21 in ____o12) {
-    var __v12 = ____o12[__k21];
-    var __e64;
+  for (__k21 in ____o10) {
+    var __v12 = ____o10[__k21];
+    var __e62;
     if (numeric63(__k21)) {
-      __e64 = parseInt(__k21);
+      __e62 = parseInt(__k21);
     } else {
-      __e64 = __k21;
+      __e62 = __k21;
     }
-    var __k22 = __e64;
+    var __k22 = __e62;
     if (number63(__k22)) {
-      var ____id31 = __v12;
-      var __k23 = ____id31[0];
-      var __v13 = ____id31[1];
+      var ____id28 = __v12;
+      var __k23 = ____id28[0];
+      var __v13 = ____id28[1];
       if (! string63(__k23)) {
         throw new Error("Illegal key: " + str(__k23));
       }
@@ -1356,8 +1285,8 @@ setenv("%object", {_stash: true, special: function () {
   return(__s9 + "}");
 }});
 setenv("%literal", {_stash: true, special: function () {
-  var __args111 = unstash(Array.prototype.slice.call(arguments, 0));
-  return(apply(cat, map(compile, __args111)));
+  var __args9 = unstash(Array.prototype.slice.call(arguments, 0));
+  return(apply(cat, map(compile, __args9)));
 }});
 exports.run = run;
 exports["eval"] = _eval;

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -221,13 +221,22 @@ local function expand_definition(__x46)
   return(____x49)
 end
 local function expand_macro(form)
-  return(macroexpand(expand1(form)))
+  return(expand1(form, true))
 end
-function expand1(__x51)
+function expand1(__x51, expand63)
   local ____id4 = __x51
   local __name2 = ____id4[1]
   local __body2 = cut(____id4, 1)
-  return(apply(macro_function(__name2), __body2))
+  local ____id5 = getenv(__name2)
+  local __macro = ____id5.macro
+  local __once = ____id5.once
+  local __form = apply(__macro, __body2)
+  if expand63 then
+    if not __once then
+      __form = macroexpand(__form)
+    end
+  end
+  return(__form)
 end
 function macroexpand(form)
   if symbol63(form) then
@@ -338,10 +347,10 @@ function quasiexpand(form, depth)
   end
 end
 function expand_if(__x61)
-  local ____id5 = __x61
-  local __a = ____id5[1]
-  local __b1 = ____id5[2]
-  local __c = cut(____id5, 2)
+  local ____id6 = __x61
+  local __a = ____id6[1]
+  local __b1 = ____id6[2]
+  local __c = cut(____id6, 2)
   if is63(__b1) then
     return({join({"%if", __a, __b1}, expand_if(__c))})
   else
@@ -619,13 +628,13 @@ local function terminator(stmt63)
   end
 end
 local function compile_special(form, stmt63)
-  local ____id6 = form
-  local __x85 = ____id6[1]
-  local __args2 = cut(____id6, 1)
-  local ____id7 = getenv(__x85)
-  local __special = ____id7.special
-  local __stmt = ____id7.stmt
-  local __self_tr63 = ____id7.tr
+  local ____id7 = form
+  local __x85 = ____id7[1]
+  local __args2 = cut(____id7, 1)
+  local ____id8 = getenv(__x85)
+  local __special = ____id8.special
+  local __stmt = ____id8.stmt
+  local __self_tr63 = ____id8.tr
   local __tr = terminator(stmt63 and not __self_tr63)
   return(apply(__special, __args2) .. __tr)
 end
@@ -646,8 +655,8 @@ local function op_delims(parent, child, ...)
   local ____r57 = unstash({...})
   local __parent = destash33(parent, ____r57)
   local __child = destash33(child, ____r57)
-  local ____id8 = ____r57
-  local __right = ____id8.right
+  local ____id9 = ____r57
+  local __right = ____id9.right
   local __e31
   if __right then
     __e31 = _6261
@@ -661,17 +670,17 @@ local function op_delims(parent, child, ...)
   end
 end
 local function compile_infix(form)
-  local ____id9 = form
-  local __op = ____id9[1]
-  local ____id10 = cut(____id9, 1)
-  local __a1 = ____id10[1]
-  local __b2 = ____id10[2]
-  local ____id111 = op_delims(form, __a1)
-  local __ao = ____id111[1]
-  local __ac = ____id111[2]
-  local ____id12 = op_delims(form, __b2, {_stash = true, right = true})
-  local __bo = ____id12[1]
-  local __bc = ____id12[2]
+  local ____id10 = form
+  local __op = ____id10[1]
+  local ____id111 = cut(____id10, 1)
+  local __a1 = ____id111[1]
+  local __b2 = ____id111[2]
+  local ____id12 = op_delims(form, __a1)
+  local __ao = ____id12[1]
+  local __ac = ____id12[2]
+  local ____id13 = op_delims(form, __b2, {_stash = true, right = true})
+  local __bo = ____id13[1]
+  local __bc = ____id13[2]
   local __a2 = compile(__a1)
   local __b3 = compile(__b2)
   local __op1 = getop(__op)
@@ -685,16 +694,16 @@ function compile_function(args, body, ...)
   local ____r59 = unstash({...})
   local __args4 = destash33(args, ____r59)
   local __body3 = destash33(body, ____r59)
-  local ____id13 = ____r59
-  local __name3 = ____id13.name
-  local __prefix = ____id13.prefix
+  local ____id14 = ____r59
+  local __name3 = ____id14.name
+  local __prefix = ____id14.prefix
   local __e32
   if __name3 then
     __e32 = compile(__name3)
   else
     __e32 = ""
   end
-  local __id14 = __e32
+  local __id15 = __e32
   local __e33
   if target == "lua" and __args4.rest then
     __e33 = join(__args4, {"|...|"})
@@ -726,9 +735,9 @@ function compile_function(args, body, ...)
     __tr1 = __tr1 .. "\n"
   end
   if target == "js" then
-    return("function " .. __id14 .. __args5 .. " {\n" .. __body4 .. __ind .. "}" .. __tr1)
+    return("function " .. __id15 .. __args5 .. " {\n" .. __body4 .. __ind .. "}" .. __tr1)
   else
-    return(__p .. "function " .. __id14 .. __args5 .. "\n" .. __body4 .. __ind .. __tr1)
+    return(__p .. "function " .. __id15 .. __args5 .. "\n" .. __body4 .. __ind .. __tr1)
   end
 end
 local function can_return63(form)
@@ -736,14 +745,14 @@ local function can_return63(form)
 end
 function compile(form, ...)
   local ____r61 = unstash({...})
-  local __form = destash33(form, ____r61)
-  local ____id15 = ____r61
-  local __stmt1 = ____id15.stmt
-  if nil63(__form) then
+  local __form1 = destash33(form, ____r61)
+  local ____id16 = ____r61
+  local __stmt1 = ____id16.stmt
+  if nil63(__form1) then
     return("")
   else
-    if special_form63(__form) then
-      return(compile_special(__form, __stmt1))
+    if special_form63(__form1) then
+      return(compile_special(__form1, __stmt1))
     else
       local __tr2 = terminator(__stmt1)
       local __e36
@@ -754,19 +763,19 @@ function compile(form, ...)
       end
       local __ind1 = __e36
       local __e37
-      if atom63(__form) then
-        __e37 = compile_atom(__form)
+      if atom63(__form1) then
+        __e37 = compile_atom(__form1)
       else
         local __e38
-        if infix63(hd(__form)) then
-          __e38 = compile_infix(__form)
+        if infix63(hd(__form1)) then
+          __e38 = compile_infix(__form1)
         else
-          __e38 = compile_call(__form)
+          __e38 = compile_call(__form1)
         end
         __e37 = __e38
       end
-      local __form1 = __e37
-      return(__ind1 .. __form1 .. __tr2)
+      local __form2 = __e37
+      return(__ind1 .. __form2 .. __tr2)
     end
   end
 end
@@ -824,19 +833,19 @@ local function lower_do(args, hoist, stmt63, tail63)
   end
 end
 local function lower_set(args, hoist, stmt63, tail63)
-  local ____id16 = args
-  local __lh = ____id16[1]
-  local __rh = ____id16[2]
+  local ____id17 = args
+  local __lh = ____id17[1]
+  local __rh = ____id17[2]
   add(hoist, {"%set", lower(__lh, hoist), lower(__rh, hoist)})
   if not( stmt63 and not tail63) then
     return(__lh)
   end
 end
 local function lower_if(args, hoist, stmt63, tail63)
-  local ____id17 = args
-  local __cond = ____id17[1]
-  local ___then = ____id17[2]
-  local ___else = ____id17[3]
+  local ____id18 = args
+  local __cond = ____id18[1]
+  local ___then = ____id18[2]
+  local ___else = ____id18[3]
   if stmt63 then
     local __e43
     if is63(___else) then
@@ -855,20 +864,20 @@ local function lower_if(args, hoist, stmt63, tail63)
   end
 end
 local function lower_short(x, args, hoist)
-  local ____id18 = args
-  local __a3 = ____id18[1]
-  local __b4 = ____id18[2]
+  local ____id19 = args
+  local __a3 = ____id19[1]
+  local __b4 = ____id19[2]
   local __hoist1 = {}
   local __b11 = lower(__b4, __hoist1)
   if some63(__hoist1) then
-    local __id19 = unique("id")
+    local __id20 = unique("id")
     local __e44
     if x == "and" then
-      __e44 = {"%if", __id19, __b4, __id19}
+      __e44 = {"%if", __id20, __b4, __id20}
     else
-      __e44 = {"%if", __id19, __id19, __b4}
+      __e44 = {"%if", __id20, __id20, __b4}
     end
-    return(lower({"do", {"%local", __id19, __a3}, __e44}, hoist))
+    return(lower({"do", {"%local", __id20, __a3}, __e44}, hoist))
   else
     return({x, lower(__a3, hoist), __b11})
   end
@@ -877,9 +886,9 @@ local function lower_try(args, hoist, tail63)
   return(add(hoist, {"%try", lower_body(args, tail63)}))
 end
 local function lower_while(args, hoist)
-  local ____id20 = args
-  local __c4 = ____id20[1]
-  local __body5 = cut(____id20, 1)
+  local ____id21 = args
+  local __c4 = ____id21[1]
+  local __body5 = cut(____id21, 1)
   local __pre = {}
   local __c5 = lower(__c4, __pre)
   local __e45
@@ -891,31 +900,31 @@ local function lower_while(args, hoist)
   return(add(hoist, __e45))
 end
 local function lower_for(args, hoist)
-  local ____id21 = args
-  local __t = ____id21[1]
-  local __k7 = ____id21[2]
-  local __body6 = cut(____id21, 2)
+  local ____id22 = args
+  local __t = ____id22[1]
+  local __k7 = ____id22[2]
+  local __body6 = cut(____id22, 2)
   return(add(hoist, {"%for", lower(__t, hoist), __k7, lower_body(__body6)}))
 end
 local function lower_function(args)
-  local ____id22 = args
-  local __a4 = ____id22[1]
-  local __body7 = cut(____id22, 1)
+  local ____id23 = args
+  local __a4 = ____id23[1]
+  local __body7 = cut(____id23, 1)
   return({"%function", __a4, lower_body(__body7, true)})
 end
 local function lower_definition(kind, args, hoist)
-  local ____id23 = args
-  local __name4 = ____id23[1]
-  local __args6 = ____id23[2]
-  local __body8 = cut(____id23, 2)
+  local ____id24 = args
+  local __name4 = ____id24[1]
+  local __args6 = ____id24[2]
+  local __body8 = cut(____id24, 2)
   return(add(hoist, {kind, __name4, __args6, lower_body(__body8, true)}))
 end
 local function lower_call(form, hoist)
-  local __form2 = map(function (x)
+  local __form3 = map(function (x)
     return(lower(x, hoist))
   end, form)
-  if some63(__form2) then
-    return(__form2)
+  if some63(__form3) then
+    return(__form3)
   end
 end
 local function pairwise63(form)
@@ -924,9 +933,9 @@ end
 local function lower_pairwise(form)
   if pairwise63(form) then
     local __e4 = {}
-    local ____id24 = form
-    local __x128 = ____id24[1]
-    local __args7 = cut(____id24, 1)
+    local ____id25 = form
+    local __x128 = ____id25[1]
+    local __args7 = cut(____id25, 1)
     reduce(function (a, b)
       add(__e4, {__x128, a, b})
       return(a)
@@ -940,10 +949,10 @@ local function lower_infix63(form)
   return(infix63(hd(form)) and _35(form) > 3)
 end
 local function lower_infix(form, hoist)
-  local __form3 = lower_pairwise(form)
-  local ____id25 = __form3
-  local __x131 = ____id25[1]
-  local __args8 = cut(____id25, 1)
+  local __form4 = lower_pairwise(form)
+  local ____id26 = __form4
+  local __x131 = ____id26[1]
+  local __args8 = cut(____id26, 1)
   return(lower(reduce(function (a, b)
     return({__x131, b, a})
   end, reverse(__args8)), hoist))
@@ -967,9 +976,9 @@ function lower(form, hoist, stmt63, tail63)
         if lower_infix63(form) then
           return(lower_infix(form, hoist))
         else
-          local ____id26 = form
-          local __x134 = ____id26[1]
-          local __args9 = cut(____id26, 1)
+          local ____id27 = form
+          local __x134 = ____id27[1]
+          local __args9 = cut(____id27, 1)
           if __x134 == "do" then
             return(lower_do(__args9, hoist, stmt63, tail63))
           else
@@ -1186,7 +1195,7 @@ setenv("error", {_stash = true, special = function (x)
   return(indentation() .. __e12)
 end, stmt = true})
 setenv("%local", {_stash = true, special = function (name, value)
-  local __id28 = compile(name)
+  local __id29 = compile(name)
   local __value11 = compile(value)
   local __e49
   if is63(value) then
@@ -1203,7 +1212,7 @@ setenv("%local", {_stash = true, special = function (name, value)
   end
   local __keyword1 = __e50
   local __ind11 = indentation()
-  return(__ind11 .. __keyword1 .. __id28 .. __rh2)
+  return(__ind11 .. __keyword1 .. __id29 .. __rh2)
 end, stmt = true})
 setenv("%set", {_stash = true, special = function (lh, rh)
   local __lh2 = compile(lh)
@@ -1273,9 +1282,9 @@ setenv("%object", {_stash = true, special = function (...)
   for __k14 in next, ____o12 do
     local __v12 = ____o12[__k14]
     if number63(__k14) then
-      local ____id30 = __v12
-      local __k15 = ____id30[1]
-      local __v13 = ____id30[2]
+      local ____id31 = __v12
+      local __k15 = ____id31[1]
+      local __v13 = ____id31[2]
       if not string63(__k15) then
         error("Illegal key: " .. str(__k15))
       end

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -179,58 +179,17 @@ end
 local function quasisplice63(x, depth)
   return(can_unquote63(depth) and not atom63(x) and hd(x) == "unquote-splicing")
 end
-local function expand_local(__x38)
-  local ____id1 = __x38
-  local __x39 = ____id1[1]
-  local __name = ____id1[2]
-  local __value = ____id1[3]
-  setenv(__name, {_stash = true, variable = true})
-  return({"%local", __name, macroexpand(__value)})
-end
-local function expand_function(__x41)
-  local ____id2 = __x41
-  local __x42 = ____id2[1]
-  local __args = ____id2[2]
-  local __body = cut(____id2, 2)
-  add(environment, {})
-  local ____o3 = __args
-  local ____i5 = nil
-  for ____i5 in next, ____o3 do
-    local ____x43 = ____o3[____i5]
-    setenv(____x43, {_stash = true, variable = true})
-  end
-  local ____x44 = join({"%function", __args}, macroexpand(__body))
-  drop(environment)
-  return(____x44)
-end
-local function expand_definition(__x46)
-  local ____id3 = __x46
-  local __x47 = ____id3[1]
-  local __name1 = ____id3[2]
-  local __args11 = ____id3[3]
-  local __body1 = cut(____id3, 3)
-  add(environment, {})
-  local ____o4 = __args11
-  local ____i6 = nil
-  for ____i6 in next, ____o4 do
-    local ____x48 = ____o4[____i6]
-    setenv(____x48, {_stash = true, variable = true})
-  end
-  local ____x49 = join({__x47, __name1, __args11}, macroexpand(__body1))
-  drop(environment)
-  return(____x49)
-end
 local function expand_macro(form)
   return(expand1(form, true))
 end
-function expand1(__x51, expand63)
-  local ____id4 = __x51
-  local __name2 = ____id4[1]
-  local __body2 = cut(____id4, 1)
-  local ____id5 = getenv(__name2)
-  local __macro = ____id5.macro
-  local __once = ____id5.once
-  local __form = apply(__macro, __body2)
+function expand1(__x38, expand63)
+  local ____id1 = __x38
+  local __name = ____id1[1]
+  local __body = cut(____id1, 1)
+  local ____id2 = getenv(__name)
+  local __macro = ____id2.macro
+  local __once = ____id2.once
+  local __form = apply(__macro, __body)
   if expand63 then
     if not __once then
       __form = macroexpand(__form)
@@ -245,37 +204,21 @@ function macroexpand(form)
     if atom63(form) then
       return(form)
     else
-      local __x52 = hd(form)
-      if __x52 == "%local" then
-        return(expand_local(form))
+      local __x39 = hd(form)
+      if macro63(__x39) then
+        return(expand_macro(form))
       else
-        if __x52 == "%function" then
-          return(expand_function(form))
-        else
-          if __x52 == "%global-function" then
-            return(expand_definition(form))
-          else
-            if __x52 == "%local-function" then
-              return(expand_definition(form))
-            else
-              if macro63(__x52) then
-                return(expand_macro(form))
-              else
-                return(map(macroexpand, form))
-              end
-            end
-          end
-        end
+        return(map(macroexpand, form))
       end
     end
   end
 end
 local function quasiquote_list(form, depth)
   local __xs = {{"list"}}
-  local ____o5 = form
+  local ____o3 = form
   local __k4 = nil
-  for __k4 in next, ____o5 do
-    local __v4 = ____o5[__k4]
+  for __k4 in next, ____o3 do
+    local __v4 = ____o3[__k4]
     if not number63(__k4) then
       local __e24
       if quasisplice63(__v4, depth) then
@@ -287,18 +230,18 @@ local function quasiquote_list(form, depth)
       last(__xs)[__k4] = __v5
     end
   end
-  local ____x55 = form
-  local ____i8 = 0
-  while ____i8 < _35(____x55) do
-    local __x56 = ____x55[____i8 + 1]
-    if quasisplice63(__x56, depth) then
-      local __x57 = quasiexpand(__x56[2])
-      add(__xs, __x57)
+  local ____x42 = form
+  local ____i6 = 0
+  while ____i6 < _35(____x42) do
+    local __x43 = ____x42[____i6 + 1]
+    if quasisplice63(__x43, depth) then
+      local __x44 = quasiexpand(__x43[2])
+      add(__xs, __x44)
       add(__xs, {"list"})
     else
-      add(last(__xs), quasiexpand(__x56, depth))
+      add(last(__xs), quasiexpand(__x43, depth))
     end
-    ____i8 = ____i8 + 1
+    ____i6 = ____i6 + 1
   end
   local __pruned = keep(function (x)
     return(_35(x) > 1 or not( hd(x) == "list") or keys63(x))
@@ -346,11 +289,11 @@ function quasiexpand(form, depth)
     end
   end
 end
-function expand_if(__x61)
-  local ____id6 = __x61
-  local __a = ____id6[1]
-  local __b1 = ____id6[2]
-  local __c = cut(____id6, 2)
+function expand_if(__x48)
+  local ____id3 = __x48
+  local __a = ____id3[1]
+  local __b1 = ____id3[2]
+  local __c = cut(____id3, 2)
   if is63(__b1) then
     return({join({"%if", __a, __b1}, expand_if(__c))})
   else
@@ -362,10 +305,10 @@ end
 indent_level = 0
 function indentation()
   local __s = ""
-  local __i9 = 0
-  while __i9 < indent_level do
+  local __i7 = 0
+  while __i7 < indent_level do
     __s = __s .. "  "
-    __i9 = __i9 + 1
+    __i7 = __i7 + 1
   end
   return(__s)
 end
@@ -384,23 +327,23 @@ local function id(id)
     __e25 = ""
   end
   local __id11 = __e25
-  local __i10 = 0
-  while __i10 < _35(id) do
-    local __c1 = char(id, __i10)
-    local __n7 = code(__c1)
+  local __i8 = 0
+  while __i8 < _35(id) do
+    local __c1 = char(id, __i8)
+    local __n5 = code(__c1)
     local __e26
     if __c1 == "-" and not( id == "-") then
       __e26 = "_"
     else
       local __e27
-      if valid_code63(__n7) then
+      if valid_code63(__n5) then
         __e27 = __c1
       else
         local __e28
-        if __i10 == 0 then
-          __e28 = "_" .. __n7
+        if __i8 == 0 then
+          __e28 = "_" .. __n5
         else
-          __e28 = __n7
+          __e28 = __n5
         end
         __e27 = __e28
       end
@@ -408,7 +351,7 @@ local function id(id)
     end
     local __c11 = __e26
     __id11 = __id11 .. __c11
-    __i10 = __i10 + 1
+    __i8 = __i8 + 1
   end
   if reserved63(__id11) then
     return("_" .. __id11)
@@ -421,20 +364,20 @@ function valid_id63(x)
 end
 local __names = {}
 function unique(x)
-  local __x65 = id(x)
-  if __names[__x65] then
-    local __i11 = __names[__x65]
-    __names[__x65] = __names[__x65] + 1
-    return(unique(__x65 .. __i11))
+  local __x52 = id(x)
+  if __names[__x52] then
+    local __i9 = __names[__x52]
+    __names[__x52] = __names[__x52] + 1
+    return(unique(__x52 .. __i9))
   else
-    __names[__x65] = 1
-    return("__" .. __x65)
+    __names[__x52] = 1
+    return("__" .. __x52)
   end
 end
 function key(k)
-  local __i12 = inner(k)
-  if valid_id63(__i12) then
-    return(__i12)
+  local __i10 = inner(k)
+  if valid_id63(__i10) then
+    return(__i10)
   else
     if target == "js" then
       return(k)
@@ -444,57 +387,57 @@ function key(k)
   end
 end
 function mapo(f, t)
-  local __o6 = {}
-  local ____o7 = t
+  local __o4 = {}
+  local ____o5 = t
   local __k5 = nil
-  for __k5 in next, ____o7 do
-    local __v6 = ____o7[__k5]
-    local __x66 = f(__v6)
-    if is63(__x66) then
-      add(__o6, literal(__k5))
-      add(__o6, __x66)
+  for __k5 in next, ____o5 do
+    local __v6 = ____o5[__k5]
+    local __x53 = f(__v6)
+    if is63(__x53) then
+      add(__o4, literal(__k5))
+      add(__o4, __x53)
     end
   end
-  return(__o6)
+  return(__o4)
 end
-local ____x68 = {}
-local ____x69 = {}
-____x69.js = "!"
-____x69.lua = "not"
-____x68["not"] = ____x69
-local ____x70 = {}
-____x70["*"] = true
-____x70["/"] = true
-____x70["%"] = true
-local ____x71 = {}
-local ____x72 = {}
-____x72.js = "+"
-____x72.lua = ".."
-____x71.cat = ____x72
-local ____x73 = {}
-____x73["+"] = true
-____x73["-"] = true
-local ____x74 = {}
-____x74["<"] = true
-____x74[">"] = true
-____x74["<="] = true
-____x74[">="] = true
-local ____x75 = {}
-local ____x76 = {}
-____x76.js = "==="
-____x76.lua = "=="
-____x75["="] = ____x76
-local ____x77 = {}
-local ____x78 = {}
-____x78.js = "&&"
-____x78.lua = "and"
-____x77["and"] = ____x78
-local ____x79 = {}
-local ____x80 = {}
-____x80.js = "||"
-____x80.lua = "or"
-____x79["or"] = ____x80
-local infix = {____x68, ____x70, ____x71, ____x73, ____x74, ____x75, ____x77, ____x79}
+local ____x55 = {}
+local ____x56 = {}
+____x56.js = "!"
+____x56.lua = "not"
+____x55["not"] = ____x56
+local ____x57 = {}
+____x57["*"] = true
+____x57["/"] = true
+____x57["%"] = true
+local ____x58 = {}
+local ____x59 = {}
+____x59.js = "+"
+____x59.lua = ".."
+____x58.cat = ____x59
+local ____x60 = {}
+____x60["+"] = true
+____x60["-"] = true
+local ____x61 = {}
+____x61["<"] = true
+____x61[">"] = true
+____x61["<="] = true
+____x61[">="] = true
+local ____x62 = {}
+local ____x63 = {}
+____x63.js = "==="
+____x63.lua = "=="
+____x62["="] = ____x63
+local ____x64 = {}
+local ____x65 = {}
+____x65.js = "&&"
+____x65.lua = "and"
+____x64["and"] = ____x65
+local ____x66 = {}
+local ____x67 = {}
+____x67.js = "||"
+____x67.lua = "or"
+____x66["or"] = ____x67
+local infix = {____x55, ____x57, ____x58, ____x60, ____x61, ____x62, ____x64, ____x66}
 local function unary63(form)
   return(two63(form) and in63(hd(form), {"not", "-"}))
 end
@@ -505,10 +448,10 @@ local function index(k)
 end
 local function precedence(form)
   if not( atom63(form) or unary63(form)) then
-    local ____o8 = infix
+    local ____o6 = infix
     local __k6 = nil
-    for __k6 in next, ____o8 do
-      local __v7 = ____o8[__k6]
+    for __k6 in next, ____o6 do
+      local __v7 = ____o6[__k6]
       if __v7[hd(form)] then
         return(index(__k6))
       end
@@ -518,12 +461,12 @@ local function precedence(form)
 end
 local function getop(op)
   return(find(function (level)
-    local __x82 = level[op]
-    if __x82 == true then
+    local __x69 = level[op]
+    if __x69 == true then
       return(op)
     else
-      if is63(__x82) then
-        return(__x82[target])
+      if is63(__x69) then
+        return(__x69[target])
       end
     end
   end, infix))
@@ -537,21 +480,21 @@ end
 local function compile_args(args)
   local __s1 = "("
   local __c2 = ""
-  local ____x83 = args
-  local ____i15 = 0
-  while ____i15 < _35(____x83) do
-    local __x84 = ____x83[____i15 + 1]
-    __s1 = __s1 .. __c2 .. compile(__x84)
+  local ____x70 = args
+  local ____i13 = 0
+  while ____i13 < _35(____x70) do
+    local __x71 = ____x70[____i13 + 1]
+    __s1 = __s1 .. __c2 .. compile(__x71)
     __c2 = ", "
-    ____i15 = ____i15 + 1
+    ____i13 = ____i13 + 1
   end
   return(__s1 .. ")")
 end
 local function escape_newlines(s)
   local __s11 = ""
-  local __i16 = 0
-  while __i16 < _35(s) do
-    local __c3 = char(s, __i16)
+  local __i14 = 0
+  while __i14 < _35(s) do
+    local __c3 = char(s, __i14)
     local __e29
     if __c3 == "\n" then
       __e29 = "\\n"
@@ -565,7 +508,7 @@ local function escape_newlines(s)
       __e29 = __e30
     end
     __s11 = __s11 .. __e29
-    __i16 = __i16 + 1
+    __i14 = __i14 + 1
   end
   return(__s11)
 end
@@ -628,15 +571,15 @@ local function terminator(stmt63)
   end
 end
 local function compile_special(form, stmt63)
-  local ____id7 = form
-  local __x85 = ____id7[1]
-  local __args2 = cut(____id7, 1)
-  local ____id8 = getenv(__x85)
-  local __special = ____id8.special
-  local __stmt = ____id8.stmt
-  local __self_tr63 = ____id8.tr
+  local ____id4 = form
+  local __x72 = ____id4[1]
+  local __args = cut(____id4, 1)
+  local ____id5 = getenv(__x72)
+  local __special = ____id5.special
+  local __stmt = ____id5.stmt
+  local __self_tr63 = ____id5.tr
   local __tr = terminator(stmt63 and not __self_tr63)
-  return(apply(__special, __args2) .. __tr)
+  return(apply(__special, __args) .. __tr)
 end
 local function parenthesize_call63(x)
   return(not atom63(x) and hd(x) == "%function" or precedence(x) > 0)
@@ -644,19 +587,19 @@ end
 local function compile_call(form)
   local __f = hd(form)
   local __f1 = compile(__f)
-  local __args3 = compile_args(stash42(tl(form)))
+  local __args11 = compile_args(stash42(tl(form)))
   if parenthesize_call63(__f) then
-    return("(" .. __f1 .. ")" .. __args3)
+    return("(" .. __f1 .. ")" .. __args11)
   else
-    return(__f1 .. __args3)
+    return(__f1 .. __args11)
   end
 end
 local function op_delims(parent, child, ...)
-  local ____r57 = unstash({...})
-  local __parent = destash33(parent, ____r57)
-  local __child = destash33(child, ____r57)
-  local ____id9 = ____r57
-  local __right = ____id9.right
+  local ____r54 = unstash({...})
+  local __parent = destash33(parent, ____r54)
+  local __child = destash33(child, ____r54)
+  local ____id6 = ____r54
+  local __right = ____id6.right
   local __e31
   if __right then
     __e31 = _6261
@@ -670,17 +613,17 @@ local function op_delims(parent, child, ...)
   end
 end
 local function compile_infix(form)
-  local ____id10 = form
-  local __op = ____id10[1]
-  local ____id111 = cut(____id10, 1)
-  local __a1 = ____id111[1]
-  local __b2 = ____id111[2]
-  local ____id12 = op_delims(form, __a1)
-  local __ao = ____id12[1]
-  local __ac = ____id12[2]
-  local ____id13 = op_delims(form, __b2, {_stash = true, right = true})
-  local __bo = ____id13[1]
-  local __bc = ____id13[2]
+  local ____id7 = form
+  local __op = ____id7[1]
+  local ____id8 = cut(____id7, 1)
+  local __a1 = ____id8[1]
+  local __b2 = ____id8[2]
+  local ____id9 = op_delims(form, __a1)
+  local __ao = ____id9[1]
+  local __ac = ____id9[2]
+  local ____id10 = op_delims(form, __b2, {_stash = true, right = true})
+  local __bo = ____id10[1]
+  local __bc = ____id10[2]
   local __a2 = compile(__a1)
   local __b3 = compile(__b2)
   local __op1 = getop(__op)
@@ -691,31 +634,31 @@ local function compile_infix(form)
   end
 end
 function compile_function(args, body, ...)
-  local ____r59 = unstash({...})
-  local __args4 = destash33(args, ____r59)
-  local __body3 = destash33(body, ____r59)
-  local ____id14 = ____r59
-  local __name3 = ____id14.name
-  local __prefix = ____id14.prefix
+  local ____r56 = unstash({...})
+  local __args2 = destash33(args, ____r56)
+  local __body1 = destash33(body, ____r56)
+  local ____id111 = ____r56
+  local __name1 = ____id111.name
+  local __prefix = ____id111.prefix
   local __e32
-  if __name3 then
-    __e32 = compile(__name3)
+  if __name1 then
+    __e32 = compile(__name1)
   else
     __e32 = ""
   end
-  local __id15 = __e32
+  local __id12 = __e32
   local __e33
-  if target == "lua" and __args4.rest then
-    __e33 = join(__args4, {"|...|"})
+  if target == "lua" and __args2.rest then
+    __e33 = join(__args2, {"|...|"})
   else
-    __e33 = __args4
+    __e33 = __args2
   end
   local __args12 = __e33
-  local __args5 = compile_args(__args12)
+  local __args3 = compile_args(__args12)
   indent_level = indent_level + 1
-  local ____x91 = compile(__body3, {_stash = true, stmt = true})
+  local ____x78 = compile(__body1, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __body4 = ____x91
+  local __body2 = ____x78
   local __ind = indentation()
   local __e34
   if __prefix then
@@ -731,23 +674,23 @@ function compile_function(args, body, ...)
     __e35 = "end"
   end
   local __tr1 = __e35
-  if __name3 then
+  if __name1 then
     __tr1 = __tr1 .. "\n"
   end
   if target == "js" then
-    return("function " .. __id15 .. __args5 .. " {\n" .. __body4 .. __ind .. "}" .. __tr1)
+    return("function " .. __id12 .. __args3 .. " {\n" .. __body2 .. __ind .. "}" .. __tr1)
   else
-    return(__p .. "function " .. __id15 .. __args5 .. "\n" .. __body4 .. __ind .. __tr1)
+    return(__p .. "function " .. __id12 .. __args3 .. "\n" .. __body2 .. __ind .. __tr1)
   end
 end
 local function can_return63(form)
   return(is63(form) and (atom63(form) or not( hd(form) == "return") and not statement63(hd(form))))
 end
 function compile(form, ...)
-  local ____r61 = unstash({...})
-  local __form1 = destash33(form, ____r61)
-  local ____id16 = ____r61
-  local __stmt1 = ____id16.stmt
+  local ____r58 = unstash({...})
+  local __form1 = destash33(form, ____r58)
+  local ____id13 = ____r58
+  local __stmt1 = ____id13.stmt
   if nil63(__form1) then
     return("")
   else
@@ -812,18 +755,18 @@ local function standalone63(form)
   return(not atom63(form) and not infix63(hd(form)) and not literal63(form) and not( "get" == hd(form)) or id_literal63(form))
 end
 local function lower_do(args, hoist, stmt63, tail63)
-  local ____x98 = almost(args)
-  local ____i17 = 0
-  while ____i17 < _35(____x98) do
-    local __x99 = ____x98[____i17 + 1]
-    local ____y = lower(__x99, hoist, stmt63)
+  local ____x85 = almost(args)
+  local ____i15 = 0
+  while ____i15 < _35(____x85) do
+    local __x86 = ____x85[____i15 + 1]
+    local ____y = lower(__x86, hoist, stmt63)
     if yes(____y) then
       local __e1 = ____y
       if standalone63(__e1) then
         add(hoist, __e1)
       end
     end
-    ____i17 = ____i17 + 1
+    ____i15 = ____i15 + 1
   end
   local __e2 = lower(last(args), hoist, stmt63, tail63)
   if tail63 and can_return63(__e2) then
@@ -833,19 +776,19 @@ local function lower_do(args, hoist, stmt63, tail63)
   end
 end
 local function lower_set(args, hoist, stmt63, tail63)
-  local ____id17 = args
-  local __lh = ____id17[1]
-  local __rh = ____id17[2]
+  local ____id14 = args
+  local __lh = ____id14[1]
+  local __rh = ____id14[2]
   add(hoist, {"%set", lower(__lh, hoist), lower(__rh, hoist)})
   if not( stmt63 and not tail63) then
     return(__lh)
   end
 end
 local function lower_if(args, hoist, stmt63, tail63)
-  local ____id18 = args
-  local __cond = ____id18[1]
-  local ___then = ____id18[2]
-  local ___else = ____id18[3]
+  local ____id15 = args
+  local __cond = ____id15[1]
+  local ___then = ____id15[2]
+  local ___else = ____id15[3]
   if stmt63 then
     local __e43
     if is63(___else) then
@@ -864,20 +807,20 @@ local function lower_if(args, hoist, stmt63, tail63)
   end
 end
 local function lower_short(x, args, hoist)
-  local ____id19 = args
-  local __a3 = ____id19[1]
-  local __b4 = ____id19[2]
+  local ____id16 = args
+  local __a3 = ____id16[1]
+  local __b4 = ____id16[2]
   local __hoist1 = {}
   local __b11 = lower(__b4, __hoist1)
   if some63(__hoist1) then
-    local __id20 = unique("id")
+    local __id17 = unique("id")
     local __e44
     if x == "and" then
-      __e44 = {"%if", __id20, __b4, __id20}
+      __e44 = {"%if", __id17, __b4, __id17}
     else
-      __e44 = {"%if", __id20, __id20, __b4}
+      __e44 = {"%if", __id17, __id17, __b4}
     end
-    return(lower({"do", {"%local", __id20, __a3}, __e44}, hoist))
+    return(lower({"do", {"%local", __id17, __a3}, __e44}, hoist))
   else
     return({x, lower(__a3, hoist), __b11})
   end
@@ -886,38 +829,38 @@ local function lower_try(args, hoist, tail63)
   return(add(hoist, {"%try", lower_body(args, tail63)}))
 end
 local function lower_while(args, hoist)
-  local ____id21 = args
-  local __c4 = ____id21[1]
-  local __body5 = cut(____id21, 1)
+  local ____id18 = args
+  local __c4 = ____id18[1]
+  local __body3 = cut(____id18, 1)
   local __pre = {}
   local __c5 = lower(__c4, __pre)
   local __e45
   if none63(__pre) then
-    __e45 = {"while", __c5, lower_body(__body5)}
+    __e45 = {"while", __c5, lower_body(__body3)}
   else
-    __e45 = {"while", true, join({"do"}, __pre, {{"%if", {"not", __c5}, {"break"}}, lower_body(__body5)})}
+    __e45 = {"while", true, join({"do"}, __pre, {{"%if", {"not", __c5}, {"break"}}, lower_body(__body3)})}
   end
   return(add(hoist, __e45))
 end
 local function lower_for(args, hoist)
-  local ____id22 = args
-  local __t = ____id22[1]
-  local __k7 = ____id22[2]
-  local __body6 = cut(____id22, 2)
-  return(add(hoist, {"%for", lower(__t, hoist), __k7, lower_body(__body6)}))
+  local ____id19 = args
+  local __t = ____id19[1]
+  local __k7 = ____id19[2]
+  local __body4 = cut(____id19, 2)
+  return(add(hoist, {"%for", lower(__t, hoist), __k7, lower_body(__body4)}))
 end
 local function lower_function(args)
-  local ____id23 = args
-  local __a4 = ____id23[1]
-  local __body7 = cut(____id23, 1)
-  return({"%function", __a4, lower_body(__body7, true)})
+  local ____id20 = args
+  local __a4 = ____id20[1]
+  local __body5 = cut(____id20, 1)
+  return({"%function", __a4, lower_body(__body5, true)})
 end
 local function lower_definition(kind, args, hoist)
-  local ____id24 = args
-  local __name4 = ____id24[1]
-  local __args6 = ____id24[2]
-  local __body8 = cut(____id24, 2)
-  return(add(hoist, {kind, __name4, __args6, lower_body(__body8, true)}))
+  local ____id21 = args
+  local __name2 = ____id21[1]
+  local __args4 = ____id21[2]
+  local __body6 = cut(____id21, 2)
+  return(add(hoist, {kind, __name2, __args4, lower_body(__body6, true)}))
 end
 local function lower_call(form, hoist)
   local __form3 = map(function (x)
@@ -933,13 +876,13 @@ end
 local function lower_pairwise(form)
   if pairwise63(form) then
     local __e4 = {}
-    local ____id25 = form
-    local __x128 = ____id25[1]
-    local __args7 = cut(____id25, 1)
+    local ____id22 = form
+    local __x115 = ____id22[1]
+    local __args5 = cut(____id22, 1)
     reduce(function (a, b)
-      add(__e4, {__x128, a, b})
+      add(__e4, {__x115, a, b})
       return(a)
-    end, __args7)
+    end, __args5)
     return(join({"and"}, reverse(__e4)))
   else
     return(form)
@@ -950,12 +893,12 @@ local function lower_infix63(form)
 end
 local function lower_infix(form, hoist)
   local __form4 = lower_pairwise(form)
-  local ____id26 = __form4
-  local __x131 = ____id26[1]
-  local __args8 = cut(____id26, 1)
+  local ____id23 = __form4
+  local __x118 = ____id23[1]
+  local __args6 = cut(____id23, 1)
   return(lower(reduce(function (a, b)
-    return({__x131, b, a})
-  end, reverse(__args8)), hoist))
+    return({__x118, b, a})
+  end, reverse(__args6)), hoist))
 end
 local function lower_special(form, hoist)
   local __e5 = lower_call(form, hoist)
@@ -976,37 +919,37 @@ function lower(form, hoist, stmt63, tail63)
         if lower_infix63(form) then
           return(lower_infix(form, hoist))
         else
-          local ____id27 = form
-          local __x134 = ____id27[1]
-          local __args9 = cut(____id27, 1)
-          if __x134 == "do" then
-            return(lower_do(__args9, hoist, stmt63, tail63))
+          local ____id24 = form
+          local __x121 = ____id24[1]
+          local __args7 = cut(____id24, 1)
+          if __x121 == "do" then
+            return(lower_do(__args7, hoist, stmt63, tail63))
           else
-            if __x134 == "%set" then
-              return(lower_set(__args9, hoist, stmt63, tail63))
+            if __x121 == "%set" then
+              return(lower_set(__args7, hoist, stmt63, tail63))
             else
-              if __x134 == "%if" then
-                return(lower_if(__args9, hoist, stmt63, tail63))
+              if __x121 == "%if" then
+                return(lower_if(__args7, hoist, stmt63, tail63))
               else
-                if __x134 == "%try" then
-                  return(lower_try(__args9, hoist, tail63))
+                if __x121 == "%try" then
+                  return(lower_try(__args7, hoist, tail63))
                 else
-                  if __x134 == "while" then
-                    return(lower_while(__args9, hoist))
+                  if __x121 == "while" then
+                    return(lower_while(__args7, hoist))
                   else
-                    if __x134 == "%for" then
-                      return(lower_for(__args9, hoist))
+                    if __x121 == "%for" then
+                      return(lower_for(__args7, hoist))
                     else
-                      if __x134 == "%function" then
-                        return(lower_function(__args9))
+                      if __x121 == "%function" then
+                        return(lower_function(__args7))
                       else
-                        if __x134 == "%local-function" or __x134 == "%global-function" then
-                          return(lower_definition(__x134, __args9, hoist))
+                        if __x121 == "%local-function" or __x121 == "%global-function" then
+                          return(lower_definition(__x121, __args7, hoist))
                         else
-                          if in63(__x134, {"and", "or"}) then
-                            return(lower_short(__x134, __args9, hoist))
+                          if in63(__x121, {"and", "or"}) then
+                            return(lower_short(__x121, __args7, hoist))
                           else
-                            if statement63(__x134) then
+                            if statement63(__x121) then
                               return(lower_special(form, hoist))
                             else
                               return(lower_call(form, hoist))
@@ -1052,35 +995,35 @@ end
 setenv("do", {_stash = true, special = function (...)
   local __forms1 = unstash({...})
   local __s3 = ""
-  local ____x140 = __forms1
-  local ____i19 = 0
-  while ____i19 < _35(____x140) do
-    local __x141 = ____x140[____i19 + 1]
-    if target == "lua" and immediate_call63(__x141) and "\n" == char(__s3, edge(__s3)) then
+  local ____x127 = __forms1
+  local ____i17 = 0
+  while ____i17 < _35(____x127) do
+    local __x128 = ____x127[____i17 + 1]
+    if target == "lua" and immediate_call63(__x128) and "\n" == char(__s3, edge(__s3)) then
       __s3 = clip(__s3, 0, edge(__s3)) .. ";\n"
     end
-    __s3 = __s3 .. compile(__x141, {_stash = true, stmt = true})
-    if not atom63(__x141) then
-      if hd(__x141) == "return" or hd(__x141) == "break" then
+    __s3 = __s3 .. compile(__x128, {_stash = true, stmt = true})
+    if not atom63(__x128) then
+      if hd(__x128) == "return" or hd(__x128) == "break" then
         break
       end
     end
-    ____i19 = ____i19 + 1
+    ____i17 = ____i17 + 1
   end
   return(__s3)
 end, stmt = true, tr = true})
 setenv("%if", {_stash = true, special = function (cond, cons, alt)
   local __cond2 = compile(cond)
   indent_level = indent_level + 1
-  local ____x144 = compile(cons, {_stash = true, stmt = true})
+  local ____x131 = compile(cons, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __cons1 = ____x144
+  local __cons1 = ____x131
   local __e46
   if alt then
     indent_level = indent_level + 1
-    local ____x145 = compile(alt, {_stash = true, stmt = true})
+    local ____x132 = compile(alt, {_stash = true, stmt = true})
     indent_level = indent_level - 1
-    __e46 = ____x145
+    __e46 = ____x132
   end
   local __alt1 = __e46
   local __ind3 = indentation()
@@ -1106,42 +1049,42 @@ end, stmt = true, tr = true})
 setenv("while", {_stash = true, special = function (cond, form)
   local __cond4 = compile(cond)
   indent_level = indent_level + 1
-  local ____x147 = compile(form, {_stash = true, stmt = true})
+  local ____x134 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __body10 = ____x147
+  local __body8 = ____x134
   local __ind5 = indentation()
   if target == "js" then
-    return(__ind5 .. "while (" .. __cond4 .. ") {\n" .. __body10 .. __ind5 .. "}\n")
+    return(__ind5 .. "while (" .. __cond4 .. ") {\n" .. __body8 .. __ind5 .. "}\n")
   else
-    return(__ind5 .. "while " .. __cond4 .. " do\n" .. __body10 .. __ind5 .. "end\n")
+    return(__ind5 .. "while " .. __cond4 .. " do\n" .. __body8 .. __ind5 .. "end\n")
   end
 end, stmt = true, tr = true})
 setenv("%for", {_stash = true, special = function (t, k, form)
   local __t2 = compile(t)
   local __ind7 = indentation()
   indent_level = indent_level + 1
-  local ____x149 = compile(form, {_stash = true, stmt = true})
+  local ____x136 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __body12 = ____x149
+  local __body10 = ____x136
   if target == "lua" then
-    return(__ind7 .. "for " .. k .. " in next, " .. __t2 .. " do\n" .. __body12 .. __ind7 .. "end\n")
+    return(__ind7 .. "for " .. k .. " in next, " .. __t2 .. " do\n" .. __body10 .. __ind7 .. "end\n")
   else
-    return(__ind7 .. "for (" .. k .. " in " .. __t2 .. ") {\n" .. __body12 .. __ind7 .. "}\n")
+    return(__ind7 .. "for (" .. k .. " in " .. __t2 .. ") {\n" .. __body10 .. __ind7 .. "}\n")
   end
 end, stmt = true, tr = true})
 setenv("%try", {_stash = true, special = function (form)
   local __e8 = unique("e")
   local __ind9 = indentation()
   indent_level = indent_level + 1
-  local ____x154 = compile(form, {_stash = true, stmt = true})
+  local ____x141 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __body14 = ____x154
+  local __body12 = ____x141
   local __hf1 = {"return", {"%array", false, __e8}}
   indent_level = indent_level + 1
-  local ____x157 = compile(__hf1, {_stash = true, stmt = true})
+  local ____x144 = compile(__hf1, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __h1 = ____x157
-  return(__ind9 .. "try {\n" .. __body14 .. __ind9 .. "}\n" .. __ind9 .. "catch (" .. __e8 .. ") {\n" .. __h1 .. __ind9 .. "}\n")
+  local __h1 = ____x144
+  return(__ind9 .. "try {\n" .. __body12 .. __ind9 .. "}\n" .. __ind9 .. "catch (" .. __e8 .. ") {\n" .. __h1 .. __ind9 .. "}\n")
 end, stmt = true, tr = true})
 setenv("%delete", {_stash = true, special = function (place)
   return(indentation() .. "delete " .. compile(place))
@@ -1154,16 +1097,16 @@ setenv("%function", {_stash = true, special = function (args, body)
 end})
 setenv("%global-function", {_stash = true, special = function (name, args, body)
   if target == "lua" then
-    local __x161 = compile_function(args, body, {_stash = true, name = name})
-    return(indentation() .. __x161)
+    local __x148 = compile_function(args, body, {_stash = true, name = name})
+    return(indentation() .. __x148)
   else
     return(compile({"%set", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
 end, stmt = true, tr = true})
 setenv("%local-function", {_stash = true, special = function (name, args, body)
   if target == "lua" then
-    local __x167 = compile_function(args, body, {_stash = true, name = name, prefix = "local"})
-    return(indentation() .. __x167)
+    local __x154 = compile_function(args, body, {_stash = true, name = name, prefix = "local"})
+    return(indentation() .. __x154)
   else
     return(compile({"%local", name, {"%function", args, body}}, {_stash = true, stmt = true}))
   end
@@ -1175,8 +1118,8 @@ setenv("return", {_stash = true, special = function (x)
   else
     __e47 = "return(" .. compile(x) .. ")"
   end
-  local __x171 = __e47
-  return(indentation() .. __x171)
+  local __x158 = __e47
+  return(indentation() .. __x158)
 end, stmt = true})
 setenv("new", {_stash = true, special = function (x)
   return("new " .. compile(x))
@@ -1195,7 +1138,7 @@ setenv("error", {_stash = true, special = function (x)
   return(indentation() .. __e12)
 end, stmt = true})
 setenv("%local", {_stash = true, special = function (name, value)
-  local __id29 = compile(name)
+  local __id26 = compile(name)
   local __value11 = compile(value)
   local __e49
   if is63(value) then
@@ -1212,7 +1155,7 @@ setenv("%local", {_stash = true, special = function (name, value)
   end
   local __keyword1 = __e50
   local __ind11 = indentation()
-  return(__ind11 .. __keyword1 .. __id29 .. __rh2)
+  return(__ind11 .. __keyword1 .. __id26 .. __rh2)
 end, stmt = true})
 setenv("%set", {_stash = true, special = function (lh, rh)
   local __lh2 = compile(lh)
@@ -1255,10 +1198,10 @@ setenv("%array", {_stash = true, special = function (...)
   local __close1 = __e53
   local __s7 = ""
   local __c7 = ""
-  local ____o10 = __forms3
+  local ____o8 = __forms3
   local __k10 = nil
-  for __k10 in next, ____o10 do
-    local __v9 = ____o10[__k10]
+  for __k10 in next, ____o8 do
+    local __v9 = ____o8[__k10]
     if number63(__k10) then
       __s7 = __s7 .. __c7 .. compile(__v9)
       __c7 = ", "
@@ -1277,14 +1220,14 @@ setenv("%object", {_stash = true, special = function (...)
     __e54 = ": "
   end
   local __sep1 = __e54
-  local ____o12 = pair(__forms5)
+  local ____o10 = pair(__forms5)
   local __k14 = nil
-  for __k14 in next, ____o12 do
-    local __v12 = ____o12[__k14]
+  for __k14 in next, ____o10 do
+    local __v12 = ____o10[__k14]
     if number63(__k14) then
-      local ____id31 = __v12
-      local __k15 = ____id31[1]
-      local __v13 = ____id31[2]
+      local ____id28 = __v12
+      local __k15 = ____id28[1]
+      local __v13 = ____id28[2]
       if not string63(__k15) then
         error("Illegal key: " .. str(__k15))
       end
@@ -1295,7 +1238,7 @@ setenv("%object", {_stash = true, special = function (...)
   return(__s9 .. "}")
 end})
 setenv("%literal", {_stash = true, special = function (...)
-  local __args111 = unstash({...})
-  return(apply(cat, map(compile, __args111)))
+  local __args9 = unstash({...})
+  return(apply(cat, map(compile, __args9)))
 end})
 return({run = run, ["eval"] = _eval, expand = expand, compile = compile})

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -901,7 +901,7 @@ setenv("define-macro", {_stash: true, macro: function (name, args) {
   var __body15 = cut(____id23, 0);
   var ____x103 = ["setenv", ["quote", __name1]];
   ____x103.macro = join(["fn", __args3], __body15);
-  var __form1 = ____x103;
+  var __form1 = join(____x103, keys(__body15));
   _eval(__form1);
   return(__form1);
 }});

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -773,13 +773,13 @@ setenv("list", {_stash: true, macro: function () {
   var __k2 = undefined;
   for (__k2 in ____o1) {
     var __v1 = ____o1[__k2];
-    var __e8;
+    var __e11;
     if (numeric63(__k2)) {
-      __e8 = parseInt(__k2);
+      __e11 = parseInt(__k2);
     } else {
-      __e8 = __k2;
+      __e11 = __k2;
     }
-    var __k3 = __e8;
+    var __k3 = __e11;
     if (number63(__k3)) {
       __l1[__k3] = __v1;
     } else {
@@ -1055,28 +1055,28 @@ setenv("each", {_stash: true, macro: function (x, t) {
   var __o3 = unique("o");
   var __n3 = unique("n");
   var __i3 = unique("i");
-  var __e9;
+  var __e12;
   if (atom63(__x268)) {
-    __e9 = [__i3, __x268];
+    __e12 = [__i3, __x268];
   } else {
-    var __e10;
+    var __e13;
     if (_35(__x268) > 1) {
-      __e10 = __x268;
+      __e13 = __x268;
     } else {
-      __e10 = [__i3, hd(__x268)];
+      __e13 = [__i3, hd(__x268)];
     }
-    __e9 = __e10;
+    __e12 = __e13;
   }
-  var ____id53 = __e9;
+  var ____id53 = __e12;
   var __k5 = ____id53[0];
   var __v7 = ____id53[1];
-  var __e11;
+  var __e14;
   if (target === "lua") {
-    __e11 = __body37;
+    __e14 = __body37;
   } else {
-    __e11 = [join(["let", __k5, ["if", ["numeric?", __k5], ["parseInt", __k5], __k5]], __body37)];
+    __e14 = [join(["let", __k5, ["if", ["numeric?", __k5], ["parseInt", __k5], __k5]], __body37)];
   }
-  return(["let", [__o3, __t1, __k5, "nil"], ["%for", __o3, __k5, join(["let", [__v7, ["get", __o3, __k5]]], __e11)]]);
+  return(["let", [__o3, __t1, __k5, "nil"], ["%for", __o3, __k5, join(["let", [__v7, ["get", __o3, __k5]]], __e14)]]);
 }});
 setenv("for", {_stash: true, macro: function (i, to) {
   var ____r63 = unstash(Array.prototype.slice.call(arguments, 2));
@@ -1103,13 +1103,13 @@ setenv("set-of", {_stash: true, macro: function () {
   var ____i9 = undefined;
   for (____i9 in ____o5) {
     var __x310 = ____o5[____i9];
-    var __e12;
+    var __e15;
     if (numeric63(____i9)) {
-      __e12 = parseInt(____i9);
+      __e15 = parseInt(____i9);
     } else {
-      __e12 = ____i9;
+      __e15 = ____i9;
     }
-    var ____i91 = __e12;
+    var ____i91 = __e15;
     __l3[__x310] = true;
   }
   return(join(["obj"], __l3));
@@ -1136,22 +1136,22 @@ setenv("cat!", {_stash: true, macro: function (a) {
   return(["set", __a5, join(["cat", __a5], __bs7)]);
 }});
 setenv("inc", {_stash: true, macro: function (n, by) {
-  var __e13;
+  var __e16;
   if (nil63(by)) {
-    __e13 = 1;
+    __e16 = 1;
   } else {
-    __e13 = by;
+    __e16 = by;
   }
-  return(["set", n, ["+", n, __e13]]);
+  return(["set", n, ["+", n, __e16]]);
 }});
 setenv("dec", {_stash: true, macro: function (n, by) {
-  var __e14;
+  var __e17;
   if (nil63(by)) {
-    __e14 = 1;
+    __e17 = 1;
   } else {
-    __e14 = by;
+    __e17 = by;
   }
-  return(["set", n, ["-", n, __e14]]);
+  return(["set", n, ["-", n, __e17]]);
 }});
 setenv("with-indent", {_stash: true, macro: function (form) {
   var __x335 = unique("x");
@@ -1169,13 +1169,13 @@ setenv("export", {_stash: true, macro: function () {
     var ____i11 = undefined;
     for (____i11 in ____o7) {
       var __k7 = ____o7[____i11];
-      var __e15;
+      var __e18;
       if (numeric63(____i11)) {
-        __e15 = parseInt(____i11);
+        __e18 = parseInt(____i11);
       } else {
-        __e15 = ____i11;
+        __e18 = ____i11;
       }
-      var ____i111 = __e15;
+      var ____i111 = __e18;
       __x351[__k7] = __k7;
     }
     return(["return", join(["%object"], mapo(function (x) {
@@ -1187,6 +1187,81 @@ setenv("when-compiling", {_stash: true, macro: function () {
   var __body43 = unstash(Array.prototype.slice.call(arguments, 0));
   return(_eval(join(["do"], __body43)));
 }});
+setenv("%local", {_stash: true, macro: function (name, value) {
+  setenv(name, {_stash: true, variable: true});
+  return(["%local", name, macroexpand(value)]);
+}, once: true});
+setenv("%function", {_stash: true, macro: function (args) {
+  var ____r85 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __args11 = destash33(args, ____r85);
+  var ____id63 = ____r85;
+  var __body45 = cut(____id63, 0);
+  add(environment, {});
+  var ____o9 = __args11;
+  var ____i13 = undefined;
+  for (____i13 in ____o9) {
+    var ____x361 = ____o9[____i13];
+    var __e19;
+    if (numeric63(____i13)) {
+      __e19 = parseInt(____i13);
+    } else {
+      __e19 = ____i13;
+    }
+    var ____i131 = __e19;
+    setenv(____x361, {_stash: true, variable: true});
+  }
+  var ____x362 = join(["%function", __args11], map(macroexpand, __body45));
+  drop(environment);
+  return(____x362);
+}, once: true});
+setenv("%local-function", {_stash: true, macro: function (name, args) {
+  var ____r87 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __name11 = destash33(name, ____r87);
+  var __args13 = destash33(args, ____r87);
+  var ____id65 = ____r87;
+  var __body47 = cut(____id65, 0);
+  add(environment, {});
+  var ____o11 = __args13;
+  var ____i15 = undefined;
+  for (____i15 in ____o11) {
+    var ____x367 = ____o11[____i15];
+    var __e20;
+    if (numeric63(____i15)) {
+      __e20 = parseInt(____i15);
+    } else {
+      __e20 = ____i15;
+    }
+    var ____i151 = __e20;
+    setenv(____x367, {_stash: true, variable: true});
+  }
+  var ____x368 = join(["%local-function", __name11, __args13], map(macroexpand, __body47));
+  drop(environment);
+  return(____x368);
+}, once: true});
+setenv("%global-function", {_stash: true, macro: function (name, args) {
+  var ____r89 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __name13 = destash33(name, ____r89);
+  var __args15 = destash33(args, ____r89);
+  var ____id67 = ____r89;
+  var __body49 = cut(____id67, 0);
+  add(environment, {});
+  var ____o13 = __args15;
+  var ____i17 = undefined;
+  for (____i17 in ____o13) {
+    var ____x373 = ____o13[____i17];
+    var __e21;
+    if (numeric63(____i17)) {
+      __e21 = parseInt(____i17);
+    } else {
+      __e21 = ____i17;
+    }
+    var ____i171 = __e21;
+    setenv(____x373, {_stash: true, variable: true});
+  }
+  var ____x374 = join(["%global-function", __name13, __args15], map(macroexpand, __body49));
+  drop(environment);
+  return(____x374);
+}, once: true});
 var reader = require("reader");
 var compiler = require("compiler");
 var system = require("system");

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -792,7 +792,7 @@ setenv("define-macro", {_stash = true, macro = function (name, args, ...)
   local __body15 = cut(____id23, 0)
   local ____x114 = {"setenv", {"quote", __name1}}
   ____x114.macro = join({"fn", __args3}, __body15)
-  local __form1 = ____x114
+  local __form1 = join(____x114, keys(__body15))
   _eval(__form1)
   return(__form1)
 end})

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -946,28 +946,28 @@ setenv("each", {_stash = true, macro = function (x, t, ...)
   local __o3 = unique("o")
   local __n3 = unique("n")
   local __i3 = unique("i")
-  local __e8
+  local __e11
   if atom63(__x291) then
-    __e8 = {__i3, __x291}
+    __e11 = {__i3, __x291}
   else
-    local __e9
+    local __e12
     if _35(__x291) > 1 then
-      __e9 = __x291
+      __e12 = __x291
     else
-      __e9 = {__i3, hd(__x291)}
+      __e12 = {__i3, hd(__x291)}
     end
-    __e8 = __e9
+    __e11 = __e12
   end
-  local ____id53 = __e8
+  local ____id53 = __e11
   local __k4 = ____id53[1]
   local __v7 = ____id53[2]
-  local __e10
+  local __e13
   if target == "lua" then
-    __e10 = __body37
+    __e13 = __body37
   else
-    __e10 = {join({"let", __k4, {"if", {"numeric?", __k4}, {"parseInt", __k4}, __k4}}, __body37)}
+    __e13 = {join({"let", __k4, {"if", {"numeric?", __k4}, {"parseInt", __k4}, __k4}}, __body37)}
   end
-  return({"let", {__o3, __t1, __k4, "nil"}, {"%for", __o3, __k4, join({"let", {__v7, {"get", __o3, __k4}}}, __e10)}})
+  return({"let", {__o3, __t1, __k4, "nil"}, {"%for", __o3, __k4, join({"let", {__v7, {"get", __o3, __k4}}}, __e13)}})
 end})
 setenv("for", {_stash = true, macro = function (i, to, ...)
   local ____r63 = unstash({...})
@@ -1020,22 +1020,22 @@ setenv("cat!", {_stash = true, macro = function (a, ...)
   return({"set", __a5, join({"cat", __a5}, __bs7)})
 end})
 setenv("inc", {_stash = true, macro = function (n, by)
-  local __e11
+  local __e14
   if nil63(by) then
-    __e11 = 1
+    __e14 = 1
   else
-    __e11 = by
+    __e14 = by
   end
-  return({"set", n, {"+", n, __e11}})
+  return({"set", n, {"+", n, __e14}})
 end})
 setenv("dec", {_stash = true, macro = function (n, by)
-  local __e12
+  local __e15
   if nil63(by) then
-    __e12 = 1
+    __e15 = 1
   else
-    __e12 = by
+    __e15 = by
   end
-  return({"set", n, {"-", n, __e12}})
+  return({"set", n, {"-", n, __e15}})
 end})
 setenv("with-indent", {_stash = true, macro = function (form)
   local __x364 = unique("x")
@@ -1064,6 +1064,60 @@ setenv("when-compiling", {_stash = true, macro = function (...)
   local __body43 = unstash({...})
   return(_eval(join({"do"}, __body43)))
 end})
+setenv("%local", {_stash = true, macro = function (name, value)
+  setenv(name, {_stash = true, variable = true})
+  return({"%local", name, macroexpand(value)})
+end, once = true})
+setenv("%function", {_stash = true, macro = function (args, ...)
+  local ____r85 = unstash({...})
+  local __args11 = destash33(args, ____r85)
+  local ____id63 = ____r85
+  local __body45 = cut(____id63, 0)
+  add(environment, {})
+  local ____o9 = __args11
+  local ____i13 = nil
+  for ____i13 in next, ____o9 do
+    local ____x393 = ____o9[____i13]
+    setenv(____x393, {_stash = true, variable = true})
+  end
+  local ____x394 = join({"%function", __args11}, map(macroexpand, __body45))
+  drop(environment)
+  return(____x394)
+end, once = true})
+setenv("%local-function", {_stash = true, macro = function (name, args, ...)
+  local ____r87 = unstash({...})
+  local __name11 = destash33(name, ____r87)
+  local __args13 = destash33(args, ____r87)
+  local ____id65 = ____r87
+  local __body47 = cut(____id65, 0)
+  add(environment, {})
+  local ____o11 = __args13
+  local ____i15 = nil
+  for ____i15 in next, ____o11 do
+    local ____x400 = ____o11[____i15]
+    setenv(____x400, {_stash = true, variable = true})
+  end
+  local ____x401 = join({"%local-function", __name11, __args13}, map(macroexpand, __body47))
+  drop(environment)
+  return(____x401)
+end, once = true})
+setenv("%global-function", {_stash = true, macro = function (name, args, ...)
+  local ____r89 = unstash({...})
+  local __name13 = destash33(name, ____r89)
+  local __args15 = destash33(args, ____r89)
+  local ____id67 = ____r89
+  local __body49 = cut(____id67, 0)
+  add(environment, {})
+  local ____o13 = __args15
+  local ____i17 = nil
+  for ____i17 in next, ____o13 do
+    local ____x407 = ____o13[____i17]
+    setenv(____x407, {_stash = true, variable = true})
+  end
+  local ____x408 = join({"%global-function", __name13, __args15}, map(macroexpand, __body49))
+  drop(environment)
+  return(____x408)
+end, once = true})
 local reader = require("reader")
 local compiler = require("compiler")
 local system = require("system")

--- a/compiler.l
+++ b/compiler.l
@@ -133,10 +133,14 @@
     `(,x ,name ,args ,@(macroexpand body))))
 
 (define expand-macro (form)
-  (macroexpand (expand1 form)))
+  (expand1 form true))
 
-(define-global expand1 ((name rest: body))
-  (apply (macro-function name) body))
+(define-global expand1 ((name rest: body) expand?)
+  (let ((:macro :once) (getenv name))
+    (with form (apply macro body)
+      (when expand?
+        (unless once
+          (set form (macroexpand form)))))))
 
 (define-global macroexpand (form)
   (if (symbol? form)

--- a/compiler.l
+++ b/compiler.l
@@ -120,18 +120,6 @@
        (not (atom? x))
        (= (hd x) 'unquote-splicing)))
 
-(define expand-local ((x name value))
-  (setenv name :variable)
-  `(%local ,name ,(macroexpand value)))
-
-(define expand-function ((x args rest: body))
-  (with-bindings (args)
-    `(%function ,args ,@(macroexpand body))))
-
-(define expand-definition ((x name args rest: body))
-  (with-bindings (args)
-    `(,x ,name ,args ,@(macroexpand body))))
-
 (define expand-macro (form)
   (expand1 form true))
 
@@ -147,11 +135,7 @@
       (macroexpand (symbol-expansion form))
       (atom? form) form
     (let x (hd form)
-      (if (= x '%local) (expand-local form)
-          (= x '%function) (expand-function form)
-          (= x '%global-function) (expand-definition form)
-          (= x '%local-function) (expand-definition form)
-          (macro? x) (expand-macro form)
+      (if (macro? x) (expand-macro form)
         (map macroexpand form)))))
 
 (define quasiquote-list (form depth)

--- a/macros.l
+++ b/macros.l
@@ -79,7 +79,7 @@
            ,@body)))))
 
 (define-macro define-macro (name args rest: body)
-  (let form `(setenv ',name macro: (fn ,args ,@body))
+  (let form `(setenv ',name macro: (fn ,args ,@body) ,@(keys body))
     (eval form)
     form))
 

--- a/macros.l
+++ b/macros.l
@@ -234,3 +234,19 @@
 
 (define-macro when-compiling body
   (eval `(do ,@body)))
+
+(define-macro %local (name value) :once
+  (setenv name :variable)
+  `(%local ,name ,(macroexpand value)))
+
+(define-macro %function (args rest: body) :once
+  (with-bindings (args)
+    `(%function ,args ,@(map macroexpand body))))
+
+(define-macro %local-function (name args rest: body) :once
+  (with-bindings (args)
+    `(%local-function ,name ,args ,@(map macroexpand body))))
+
+(define-macro %global-function (name args rest: body) :once
+  (with-bindings (args)
+    `(%global-function ,name ,args ,@(map macroexpand body))))


### PR DESCRIPTION
- `define-macro` now supports a `:once` option. When provided, the macro's expansion won't be expanded.
- Get rid of `expand-local`, `expand-function`, and `expand-definition`.
- Define `%local`, `%function`, `%local-function`, and `%global-function` as macros using the `:once` option.