### PR TITLE
Minor fix in UNIQUE

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -455,7 +455,7 @@ valid_id63 = function (x) {
 var __names = {};
 unique = function (x) {
   var __x65 = id(x);
-  if (__names[__x65]) {
+  if (has63(__names, __x65)) {
     var __i11 = __names[__x65];
     __names[__x65] = __names[__x65] + 1;
     return(unique(__x65 + __i11));

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -413,7 +413,7 @@ end
 local __names = {}
 function unique(x)
   local __x65 = id(x)
-  if __names[__x65] then
+  if has63(__names, __x65) then
     local __i11 = __names[__x65]
     __names[__x65] = __names[__x65] + 1
     return(unique(__x65 .. __i11))

--- a/compiler.l
+++ b/compiler.l
@@ -254,7 +254,7 @@
 (let (names (obj))
   (define-global unique (x)
     (let x (id x)
-      (if (get names x)
+      (if (has? names x)
           (let i (get names x)
             (inc (get names x))
             (unique (cat x i)))


### PR DESCRIPTION
Closes #145.

This PR fixes the following bug:

```
$ LUMEN_HOST=node bin/lumen -e "(unique 'toString)"
"__toStringfunction32toString4041321233291native32code9332125"
```