### PR TITLE
Update %OBJECT to allow non-string-literal keys

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -465,15 +465,19 @@ unique = function (x) {
   }
 };
 key = function (k) {
-  var __i12 = inner(k);
-  if (valid_id63(__i12)) {
-    return(__i12);
-  } else {
-    if (target === "js") {
-      return(k);
+  if (string_literal63(k)) {
+    var __i12 = inner(k);
+    if (valid_id63(__i12)) {
+      return(__i12);
     } else {
-      return("[" + k + "]");
+      if (target === "js") {
+        return(k);
+      } else {
+        return("[" + k + "]");
+      }
     }
+  } else {
+    return("[" + k + "]");
   }
 };
 mapo = function (f, t) {
@@ -1337,9 +1341,6 @@ setenv("%object", {_stash: true, special: function () {
       var ____id30 = __v12;
       var __k23 = ____id30[0];
       var __v13 = ____id30[1];
-      if (! string63(__k23)) {
-        throw new Error("Illegal key: " + str(__k23));
-      }
       __s9 = __s9 + __c9 + key(__k23) + __sep1 + compile(__v13);
       __c9 = ", ";
     }

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -423,15 +423,19 @@ function unique(x)
   end
 end
 function key(k)
-  local __i12 = inner(k)
-  if valid_id63(__i12) then
-    return(__i12)
-  else
-    if target == "js" then
-      return(k)
+  if string_literal63(k) then
+    local __i12 = inner(k)
+    if valid_id63(__i12) then
+      return(__i12)
     else
-      return("[" .. k .. "]")
+      if target == "js" then
+        return(k)
+      else
+        return("[" .. k .. "]")
+      end
     end
+  else
+    return("[" .. k .. "]")
   end
 end
 function mapo(f, t)
@@ -1276,9 +1280,6 @@ setenv("%object", {_stash = true, special = function (...)
       local ____id30 = __v12
       local __k15 = ____id30[1]
       local __v13 = ____id30[2]
-      if not string63(__k15) then
-        error("Illegal key: " .. str(__k15))
-      end
       __s9 = __s9 .. __c9 .. key(__k15) .. __sep1 .. compile(__v13)
       __c9 = ", "
     end

--- a/compiler.l
+++ b/compiler.l
@@ -262,10 +262,12 @@
             (cat "__" x))))))
 
 (define-global key (k)
-  (let i (inner k)
-    (if (valid-id? i) i
-        (= target 'js) k
-      (cat "[" k "]"))))
+  (if (string-literal? k)
+      (let i (inner k)
+        (if (valid-id? i) i
+            (= target 'js) k
+          (cat "[" k "]")))
+    (cat "[" k "]")))
 
 (define-global mapo (f t)
   (with o ()
@@ -724,8 +726,6 @@
     (each (k v) (pair forms)
       (when (number? k)
         (let ((k v) v)
-          (unless (string? k)
-            (error (cat "Illegal key: " (str k))))
           (cat! s c (key k) sep (compile v))
           (set c ", "))))
     (cat s "}")))


### PR DESCRIPTION
```
$ bin/lumen -e "(let k 'foo (%object k 'bar))"
(foo: "bar")
$ bin/lumen -e "(print (compile (expand '(let k 'foo (%object k 'bar))))))"
local __k = "foo"
{[__k] = "bar"}
```