### PR TITLE
Update DEFINE-MACRO to take an :EXPANDED parameter

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -256,7 +256,11 @@ var expand_definition = function (__x46) {
   return(____x49);
 };
 var expand_macro = function (form) {
-  return(macroexpand(expand1(form)));
+  if (getenv(hd(form), "expanded")) {
+    return(expand1(form));
+  } else {
+    return(macroexpand(expand1(form)));
+  }
 };
 expand1 = function (__x51) {
   var ____id4 = __x51;

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -221,7 +221,11 @@ local function expand_definition(__x46)
   return(____x49)
 end
 local function expand_macro(form)
-  return(macroexpand(expand1(form)))
+  if getenv(hd(form), "expanded") then
+    return(expand1(form))
+  else
+    return(macroexpand(expand1(form)))
+  end
 end
 function expand1(__x51)
   local ____id4 = __x51

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -901,7 +901,7 @@ setenv("define-macro", {_stash: true, macro: function (name, args) {
   var __body15 = cut(____id23, 0);
   var ____x103 = ["setenv", ["quote", __name1]];
   ____x103.macro = join(["fn", __args3], __body15);
-  var __form1 = ____x103;
+  var __form1 = join(____x103, keys(__body15));
   _eval(__form1);
   return(__form1);
 }});

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -792,7 +792,7 @@ setenv("define-macro", {_stash = true, macro = function (name, args, ...)
   local __body15 = cut(____id23, 0)
   local ____x114 = {"setenv", {"quote", __name1}}
   ____x114.macro = join({"fn", __args3}, __body15)
-  local __form1 = ____x114
+  local __form1 = join(____x114, keys(__body15))
   _eval(__form1)
   return(__form1)
 end})

--- a/compiler.l
+++ b/compiler.l
@@ -133,7 +133,9 @@
     `(,x ,name ,args ,@(macroexpand body))))
 
 (define expand-macro (form)
-  (macroexpand (expand1 form)))
+  (if (getenv (hd form) 'expanded)
+      (expand1 form)
+    (macroexpand (expand1 form))))
 
 (define-global expand1 ((name rest: body))
   (apply (macro-function name) body))

--- a/macros.l
+++ b/macros.l
@@ -79,7 +79,7 @@
            ,@body)))))
 
 (define-macro define-macro (name args rest: body)
-  (let form `(setenv ',name macro: (fn ,args ,@body))
+  (let form `(setenv ',name macro: (fn ,args ,@body) ,@(keys body))
     (eval form)
     form))
 


### PR DESCRIPTION
The :EXPANDED parameter prevents MACROEXPAND from being called on the macro's return value. It indicates that the resulting expression has already been fully expanded by the macro function.

This allows users to define macros similar to %LOCAL, %FUNCTION, etc.
