### PR TITLE
Fix RETURN for multiple values on Lua

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -1211,7 +1211,7 @@ setenv("return", {_stash: true, special: function (x) {
   if (nil63(x)) {
     __e55 = "return";
   } else {
-    __e55 = "return(" + compile(x) + ")";
+    __e55 = "return " + compile(x);
   }
   var __x167 = __e55;
   return(indentation() + __x167);

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -1164,7 +1164,7 @@ setenv("return", {_stash = true, special = function (x)
   if nil63(x) then
     __e47 = "return"
   else
-    __e47 = "return(" .. compile(x) .. ")"
+    __e47 = "return " .. compile(x)
   end
   local __x171 = __e47
   return(indentation() .. __x171)

--- a/compiler.l
+++ b/compiler.l
@@ -668,7 +668,7 @@
 (define-special return (x) :stmt
   (let x (if (nil? x)
              "return"
-           (cat "return(" (compile x) ")"))
+           (cat "return " (compile x)))
     (cat (indentation) x)))
 
 (define-special new (x)


### PR DESCRIPTION
Returning a call to a function that returns multiple values will now correctly return all of those values.

For example, `xpcall` returns multiple values:
```
> (list (xpcall (fn () (error 'foo)) (fn (m) m)))
(false "[string \"_37result = {xpcall(function ()...\"]:2: foo")
```

Without this PR, returning a call to `xpcall` will only give the first value:
```
> (define-global xpcall* (f err) (xpcall f err))
> (list (xpcall* (fn () (error 'foo)) (fn (m) m)))
(false)
```

After this PR, returning a call to `xpcall` will correctly give all the values:
```
> (define-global xpcall* (f err) (xpcall f err))
> (list (xpcall* (fn () (error 'foo)) (fn (m) m)))
(false "[string \"_37result = {xpcall42(function ()...\"]:2: foo")
```