### PR TITLE
Fix expansion (attempt #3)

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -200,24 +200,22 @@ var can_unquote63 = function (depth) {
 var quasisplice63 = function (x, depth) {
   return can_unquote63(depth) && ! atom63(x) && hd(x) === "unquote-splicing";
 };
-var expand_local = function (__x38) {
+var expand_local = function (x, __x38) {
   var ____id1 = __x38;
-  var __x39 = ____id1[0];
-  var __name = ____id1[1];
-  var __value = ____id1[2];
+  var __name = ____id1[0];
+  var __value = ____id1[1];
   setenv(__name, {_stash: true, variable: true});
   return ["%local", __name, macroexpand(__value)];
 };
-var expand_function = function (__x41) {
-  var ____id2 = __x41;
-  var __x42 = ____id2[0];
-  var __args = ____id2[1];
-  var __body = cut(____id2, 2);
+var expand_function = function (x, __x40) {
+  var ____id2 = __x40;
+  var __args = ____id2[0];
+  var __body = cut(____id2, 1);
   add(environment, {});
   var ____o3 = __args;
   var ____i5 = undefined;
   for (____i5 in ____o3) {
-    var ____x43 = ____o3[____i5];
+    var ____x41 = ____o3[____i5];
     var __e27;
     if (numeric63(____i5)) {
       __e27 = parseInt(____i5);
@@ -225,23 +223,22 @@ var expand_function = function (__x41) {
       __e27 = ____i5;
     }
     var ____i51 = __e27;
-    setenv(____x43, {_stash: true, variable: true});
+    setenv(____x41, {_stash: true, variable: true});
   }
-  var ____x44 = join(["%function", __args], macroexpand(__body));
+  var ____x42 = join(["%function", __args], macroexpand(__body));
   drop(environment);
-  return ____x44;
+  return ____x42;
 };
-var expand_definition = function (__x46) {
-  var ____id3 = __x46;
-  var __x47 = ____id3[0];
-  var __name1 = ____id3[1];
-  var __args11 = ____id3[2];
-  var __body1 = cut(____id3, 3);
+var expand_definition = function (x, __x44) {
+  var ____id3 = __x44;
+  var __name1 = ____id3[0];
+  var __args11 = ____id3[1];
+  var __body1 = cut(____id3, 2);
   add(environment, {});
   var ____o4 = __args11;
   var ____i6 = undefined;
   for (____i6 in ____o4) {
-    var ____x48 = ____o4[____i6];
+    var ____x45 = ____o4[____i6];
     var __e28;
     if (numeric63(____i6)) {
       __e28 = parseInt(____i6);
@@ -249,17 +246,17 @@ var expand_definition = function (__x46) {
       __e28 = ____i6;
     }
     var ____i61 = __e28;
-    setenv(____x48, {_stash: true, variable: true});
+    setenv(____x45, {_stash: true, variable: true});
   }
-  var ____x49 = join([__x47, __name1, __args11], macroexpand(__body1));
+  var ____x46 = join([x, __name1, __args11], macroexpand(__body1));
   drop(environment);
-  return ____x49;
+  return ____x46;
 };
-var expand_macro = function (form) {
-  return macroexpand(expand1(form));
+var expand_macro = function (x, args) {
+  return macroexpand(apply(macro_function(x), args));
 };
-expand1 = function (__x51) {
-  var ____id4 = __x51;
+expand1 = function (__x48) {
+  var ____id4 = __x48;
   var __name2 = ____id4[0];
   var __body2 = cut(____id4, 1);
   return apply(macro_function(__name2), __body2);
@@ -271,23 +268,36 @@ macroexpand = function (form) {
     if (atom63(form)) {
       return form;
     } else {
-      var __x52 = hd(form);
-      if (__x52 === "%local") {
-        return expand_local(form);
+      if (none63(form)) {
+        return map(macroexpand, form);
       } else {
-        if (__x52 === "%function") {
-          return expand_function(form);
+        var ____id5 = form;
+        var __x49 = ____id5[0];
+        var __args2 = cut(____id5, 1);
+        var __x50 = macroexpand(__x49);
+        if (nil63(__x50)) {
+          return macroexpand(__args2);
         } else {
-          if (__x52 === "%global-function") {
-            return expand_definition(form);
+          if (__x50 === "%local") {
+            return expand_local(__x50, __args2);
           } else {
-            if (__x52 === "%local-function") {
-              return expand_definition(form);
+            if (__x50 === "%function") {
+              return expand_function(__x50, __args2);
             } else {
-              if (macro63(__x52)) {
-                return expand_macro(form);
+              if (__x50 === "%global-function") {
+                return expand_definition(__x50, __args2);
               } else {
-                return map(macroexpand, form);
+                if (__x50 === "%local-function") {
+                  return expand_definition(__x50, __args2);
+                } else {
+                  if (macro63(__x50)) {
+                    return expand_macro(__x50, __args2);
+                  } else {
+                    var __form = map(macroexpand, __args2);
+                    insert(__form, __x50, 0);
+                    return __form;
+                  }
+                }
               }
             }
           }
@@ -320,16 +330,16 @@ var quasiquote_list = function (form, depth) {
       last(__xs)[__k8] = __v5;
     }
   }
-  var ____x55 = form;
+  var ____x53 = form;
   var ____i8 = 0;
-  while (____i8 < _35(____x55)) {
-    var __x56 = ____x55[____i8];
-    if (quasisplice63(__x56, depth)) {
-      var __x57 = quasiexpand(__x56[1]);
-      add(__xs, __x57);
+  while (____i8 < _35(____x53)) {
+    var __x54 = ____x53[____i8];
+    if (quasisplice63(__x54, depth)) {
+      var __x55 = quasiexpand(__x54[1]);
+      add(__xs, __x55);
       add(__xs, ["list"]);
     } else {
-      add(last(__xs), quasiexpand(__x56, depth));
+      add(last(__xs), quasiexpand(__x54, depth));
     }
     ____i8 = ____i8 + 1;
   }
@@ -379,11 +389,11 @@ quasiexpand = function (form, depth) {
     }
   }
 };
-expand_if = function (__x61) {
-  var ____id5 = __x61;
-  var __a = ____id5[0];
-  var __b1 = ____id5[1];
-  var __c = cut(____id5, 2);
+expand_if = function (__x59) {
+  var ____id6 = __x59;
+  var __a = ____id6[0];
+  var __b1 = ____id6[1];
+  var __c = cut(____id6, 2);
   if (is63(__b1)) {
     return [join(["%if", __a, __b1], expand_if(__c))];
   } else {
@@ -454,14 +464,14 @@ valid_id63 = function (x) {
 };
 var __names = {};
 unique = function (x) {
-  var __x65 = id(x);
-  if (__names[__x65]) {
-    var __i11 = __names[__x65];
-    __names[__x65] = __names[__x65] + 1;
-    return unique(__x65 + __i11);
+  var __x63 = id(x);
+  if (__names[__x63]) {
+    var __i11 = __names[__x63];
+    __names[__x63] = __names[__x63] + 1;
+    return unique(__x63 + __i11);
   } else {
-    __names[__x65] = 1;
-    return "__" + __x65;
+    __names[__x63] = 1;
+    return "__" + __x63;
   }
 };
 key = function (k) {
@@ -489,52 +499,52 @@ mapo = function (f, t) {
       __e35 = __k9;
     }
     var __k10 = __e35;
-    var __x66 = f(__v6);
-    if (is63(__x66)) {
+    var __x64 = f(__v6);
+    if (is63(__x64)) {
       add(__o6, literal(__k10));
-      add(__o6, __x66);
+      add(__o6, __x64);
     }
   }
   return __o6;
 };
+var ____x66 = [];
+var ____x67 = [];
+____x67.js = "!";
+____x67.lua = "not";
+____x66["not"] = ____x67;
 var ____x68 = [];
+____x68["*"] = true;
+____x68["/"] = true;
+____x68["%"] = true;
 var ____x69 = [];
-____x69.js = "!";
-____x69.lua = "not";
-____x68["not"] = ____x69;
 var ____x70 = [];
-____x70["*"] = true;
-____x70["/"] = true;
-____x70["%"] = true;
+____x70.js = "+";
+____x70.lua = "..";
+____x69.cat = ____x70;
 var ____x71 = [];
+____x71["+"] = true;
+____x71["-"] = true;
 var ____x72 = [];
-____x72.js = "+";
-____x72.lua = "..";
-____x71.cat = ____x72;
+____x72["<"] = true;
+____x72[">"] = true;
+____x72["<="] = true;
+____x72[">="] = true;
 var ____x73 = [];
-____x73["+"] = true;
-____x73["-"] = true;
 var ____x74 = [];
-____x74["<"] = true;
-____x74[">"] = true;
-____x74["<="] = true;
-____x74[">="] = true;
+____x74.js = "===";
+____x74.lua = "==";
+____x73["="] = ____x74;
 var ____x75 = [];
 var ____x76 = [];
-____x76.js = "===";
-____x76.lua = "==";
-____x75["="] = ____x76;
+____x76.js = "&&";
+____x76.lua = "and";
+____x75["and"] = ____x76;
 var ____x77 = [];
 var ____x78 = [];
-____x78.js = "&&";
-____x78.lua = "and";
-____x77["and"] = ____x78;
-var ____x79 = [];
-var ____x80 = [];
-____x80.js = "||";
-____x80.lua = "or";
-____x79["or"] = ____x80;
-var infix = [____x68, ____x70, ____x71, ____x73, ____x74, ____x75, ____x77, ____x79];
+____x78.js = "||";
+____x78.lua = "or";
+____x77["or"] = ____x78;
+var infix = [____x66, ____x68, ____x69, ____x71, ____x72, ____x73, ____x75, ____x77];
 var unary63 = function (form) {
   return two63(form) && in63(hd(form), ["not", "-"]);
 };
@@ -563,12 +573,12 @@ var precedence = function (form) {
 };
 var getop = function (op) {
   return find(function (level) {
-    var __x82 = level[op];
-    if (__x82 === true) {
+    var __x80 = level[op];
+    if (__x80 === true) {
       return op;
     } else {
-      if (is63(__x82)) {
-        return __x82[target];
+      if (is63(__x80)) {
+        return __x80[target];
       }
     }
   }, infix);
@@ -582,11 +592,11 @@ infix_operator63 = function (x) {
 var compile_args = function (args) {
   var __s1 = "(";
   var __c2 = "";
-  var ____x83 = args;
+  var ____x81 = args;
   var ____i15 = 0;
-  while (____i15 < _35(____x83)) {
-    var __x84 = ____x83[____i15];
-    __s1 = __s1 + __c2 + compile(__x84);
+  while (____i15 < _35(____x81)) {
+    var __x82 = ____x81[____i15];
+    __s1 = __s1 + __c2 + compile(__x82);
     __c2 = ", ";
     ____i15 = ____i15 + 1;
   }
@@ -673,15 +683,15 @@ var terminator = function (stmt63) {
   }
 };
 var compile_special = function (form, stmt63) {
-  var ____id6 = form;
-  var __x85 = ____id6[0];
-  var __args2 = cut(____id6, 1);
-  var ____id7 = getenv(__x85);
-  var __special = ____id7.special;
-  var __stmt = ____id7.stmt;
-  var __self_tr63 = ____id7.tr;
+  var ____id7 = form;
+  var __x83 = ____id7[0];
+  var __args3 = cut(____id7, 1);
+  var ____id8 = getenv(__x83);
+  var __special = ____id8.special;
+  var __stmt = ____id8.stmt;
+  var __self_tr63 = ____id8.tr;
   var __tr = terminator(stmt63 && ! __self_tr63);
-  return apply(__special, __args2) + __tr;
+  return apply(__special, __args3) + __tr;
 };
 var parenthesize_call63 = function (x) {
   return ! atom63(x) && hd(x) === "%function" || precedence(x) > 0;
@@ -689,19 +699,19 @@ var parenthesize_call63 = function (x) {
 var compile_call = function (form) {
   var __f = hd(form);
   var __f1 = compile(__f);
-  var __args3 = compile_args(stash42(tl(form)));
+  var __args4 = compile_args(stash42(tl(form)));
   if (parenthesize_call63(__f)) {
-    return "(" + __f1 + ")" + __args3;
+    return "(" + __f1 + ")" + __args4;
   } else {
-    return __f1 + __args3;
+    return __f1 + __args4;
   }
 };
 var op_delims = function (parent, child) {
   var ____r57 = unstash(Array.prototype.slice.call(arguments, 2));
   var __parent = destash33(parent, ____r57);
   var __child = destash33(child, ____r57);
-  var ____id8 = ____r57;
-  var __right = ____id8.right;
+  var ____id9 = ____r57;
+  var __right = ____id9.right;
   var __e39;
   if (__right) {
     __e39 = _6261;
@@ -715,17 +725,17 @@ var op_delims = function (parent, child) {
   }
 };
 var compile_infix = function (form) {
-  var ____id9 = form;
-  var __op = ____id9[0];
-  var ____id10 = cut(____id9, 1);
-  var __a1 = ____id10[0];
-  var __b2 = ____id10[1];
-  var ____id111 = op_delims(form, __a1);
-  var __ao = ____id111[0];
-  var __ac = ____id111[1];
-  var ____id12 = op_delims(form, __b2, {_stash: true, right: true});
-  var __bo = ____id12[0];
-  var __bc = ____id12[1];
+  var ____id10 = form;
+  var __op = ____id10[0];
+  var ____id111 = cut(____id10, 1);
+  var __a1 = ____id111[0];
+  var __b2 = ____id111[1];
+  var ____id12 = op_delims(form, __a1);
+  var __ao = ____id12[0];
+  var __ac = ____id12[1];
+  var ____id13 = op_delims(form, __b2, {_stash: true, right: true});
+  var __bo = ____id13[0];
+  var __bc = ____id13[1];
   var __a2 = compile(__a1);
   var __b3 = compile(__b2);
   var __op1 = getop(__op);
@@ -737,30 +747,30 @@ var compile_infix = function (form) {
 };
 compile_function = function (args, body) {
   var ____r59 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __args4 = destash33(args, ____r59);
+  var __args5 = destash33(args, ____r59);
   var __body3 = destash33(body, ____r59);
-  var ____id13 = ____r59;
-  var __name3 = ____id13.name;
-  var __prefix = ____id13.prefix;
+  var ____id14 = ____r59;
+  var __name3 = ____id14.name;
+  var __prefix = ____id14.prefix;
   var __e40;
   if (__name3) {
     __e40 = compile(__name3);
   } else {
     __e40 = "";
   }
-  var __id14 = __e40;
+  var __id15 = __e40;
   var __e41;
-  if (target === "lua" && __args4.rest) {
-    __e41 = join(__args4, ["|...|"]);
+  if (target === "lua" && __args5.rest) {
+    __e41 = join(__args5, ["|...|"]);
   } else {
-    __e41 = __args4;
+    __e41 = __args5;
   }
   var __args12 = __e41;
-  var __args5 = compile_args(__args12);
+  var __args6 = compile_args(__args12);
   indent_level = indent_level + 1;
-  var ____x89 = compile(__body3, {_stash: true, stmt: true});
+  var ____x87 = compile(__body3, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __body4 = ____x89;
+  var __body4 = ____x87;
   var __ind = indentation();
   var __e42;
   if (__prefix) {
@@ -780,9 +790,9 @@ compile_function = function (args, body) {
     __tr1 = __tr1 + "\n";
   }
   if (target === "js") {
-    return "function " + __id14 + __args5 + " {\n" + __body4 + __ind + "}" + __tr1;
+    return "function " + __id15 + __args6 + " {\n" + __body4 + __ind + "}" + __tr1;
   } else {
-    return __p + "function " + __id14 + __args5 + "\n" + __body4 + __ind + __tr1;
+    return __p + "function " + __id15 + __args6 + "\n" + __body4 + __ind + __tr1;
   }
 };
 var can_return63 = function (form) {
@@ -790,14 +800,14 @@ var can_return63 = function (form) {
 };
 compile = function (form) {
   var ____r61 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __form = destash33(form, ____r61);
-  var ____id15 = ____r61;
-  var __stmt1 = ____id15.stmt;
-  if (nil63(__form)) {
+  var __form1 = destash33(form, ____r61);
+  var ____id16 = ____r61;
+  var __stmt1 = ____id16.stmt;
+  if (nil63(__form1)) {
     return "";
   } else {
-    if (special_form63(__form)) {
-      return compile_special(__form, __stmt1);
+    if (special_form63(__form1)) {
+      return compile_special(__form1, __stmt1);
     } else {
       var __tr2 = terminator(__stmt1);
       var __e44;
@@ -808,19 +818,19 @@ compile = function (form) {
       }
       var __ind1 = __e44;
       var __e45;
-      if (atom63(__form)) {
-        __e45 = compile_atom(__form);
+      if (atom63(__form1)) {
+        __e45 = compile_atom(__form1);
       } else {
         var __e46;
-        if (infix63(hd(__form))) {
-          __e46 = compile_infix(__form);
+        if (infix63(hd(__form1))) {
+          __e46 = compile_infix(__form1);
         } else {
-          __e46 = compile_call(__form);
+          __e46 = compile_call(__form1);
         }
         __e45 = __e46;
       }
-      var __form1 = __e45;
-      return __ind1 + __form1 + __tr2;
+      var __form2 = __e45;
+      return __ind1 + __form2 + __tr2;
     }
   }
 };
@@ -857,11 +867,11 @@ var standalone63 = function (form) {
   return ! atom63(form) && ! infix63(hd(form)) && ! literal63(form) && !( "get" === hd(form)) || id_literal63(form);
 };
 var lower_do = function (args, hoist, stmt63, tail63) {
-  var ____x95 = almost(args);
+  var ____x93 = almost(args);
   var ____i17 = 0;
-  while (____i17 < _35(____x95)) {
-    var __x96 = ____x95[____i17];
-    var ____y = lower(__x96, hoist, stmt63);
+  while (____i17 < _35(____x93)) {
+    var __x94 = ____x93[____i17];
+    var ____y = lower(__x94, hoist, stmt63);
     if (yes(____y)) {
       var __e1 = ____y;
       if (standalone63(__e1)) {
@@ -878,19 +888,19 @@ var lower_do = function (args, hoist, stmt63, tail63) {
   }
 };
 var lower_set = function (args, hoist, stmt63, tail63) {
-  var ____id16 = args;
-  var __lh = ____id16[0];
-  var __rh = ____id16[1];
+  var ____id17 = args;
+  var __lh = ____id17[0];
+  var __rh = ____id17[1];
   add(hoist, ["%set", lower(__lh, hoist), lower(__rh, hoist)]);
   if (!( stmt63 && ! tail63)) {
     return __lh;
   }
 };
 var lower_if = function (args, hoist, stmt63, tail63) {
-  var ____id17 = args;
-  var __cond = ____id17[0];
-  var ___then = ____id17[1];
-  var ___else = ____id17[2];
+  var ____id18 = args;
+  var __cond = ____id18[0];
+  var ___then = ____id18[1];
+  var ___else = ____id18[2];
   if (stmt63) {
     var __e51;
     if (is63(___else)) {
@@ -909,20 +919,20 @@ var lower_if = function (args, hoist, stmt63, tail63) {
   }
 };
 var lower_short = function (x, args, hoist) {
-  var ____id18 = args;
-  var __a3 = ____id18[0];
-  var __b4 = ____id18[1];
+  var ____id19 = args;
+  var __a3 = ____id19[0];
+  var __b4 = ____id19[1];
   var __hoist1 = [];
   var __b11 = lower(__b4, __hoist1);
   if (some63(__hoist1)) {
-    var __id19 = unique("id");
+    var __id20 = unique("id");
     var __e52;
     if (x === "and") {
-      __e52 = ["%if", __id19, __b4, __id19];
+      __e52 = ["%if", __id20, __b4, __id20];
     } else {
-      __e52 = ["%if", __id19, __id19, __b4];
+      __e52 = ["%if", __id20, __id20, __b4];
     }
-    return lower(["do", ["%local", __id19, __a3], __e52], hoist);
+    return lower(["do", ["%local", __id20, __a3], __e52], hoist);
   } else {
     return [x, lower(__a3, hoist), __b11];
   }
@@ -931,9 +941,9 @@ var lower_try = function (args, hoist, tail63) {
   return add(hoist, ["%try", lower_body(args, tail63)]);
 };
 var lower_while = function (args, hoist) {
-  var ____id20 = args;
-  var __c4 = ____id20[0];
-  var __body5 = cut(____id20, 1);
+  var ____id21 = args;
+  var __c4 = ____id21[0];
+  var __body5 = cut(____id21, 1);
   var __pre = [];
   var __c5 = lower(__c4, __pre);
   var __e53;
@@ -945,31 +955,31 @@ var lower_while = function (args, hoist) {
   return add(hoist, __e53);
 };
 var lower_for = function (args, hoist) {
-  var ____id21 = args;
-  var __t = ____id21[0];
-  var __k13 = ____id21[1];
-  var __body6 = cut(____id21, 2);
+  var ____id22 = args;
+  var __t = ____id22[0];
+  var __k13 = ____id22[1];
+  var __body6 = cut(____id22, 2);
   return add(hoist, ["%for", lower(__t, hoist), __k13, lower_body(__body6)]);
 };
 var lower_function = function (args) {
-  var ____id22 = args;
-  var __a4 = ____id22[0];
-  var __body7 = cut(____id22, 1);
+  var ____id23 = args;
+  var __a4 = ____id23[0];
+  var __body7 = cut(____id23, 1);
   return ["%function", __a4, lower_body(__body7, true)];
 };
 var lower_definition = function (kind, args, hoist) {
-  var ____id23 = args;
-  var __name4 = ____id23[0];
-  var __args6 = ____id23[1];
-  var __body8 = cut(____id23, 2);
-  return add(hoist, [kind, __name4, __args6, lower_body(__body8, true)]);
+  var ____id24 = args;
+  var __name4 = ____id24[0];
+  var __args7 = ____id24[1];
+  var __body8 = cut(____id24, 2);
+  return add(hoist, [kind, __name4, __args7, lower_body(__body8, true)]);
 };
 var lower_call = function (form, hoist) {
-  var __form2 = map(function (x) {
+  var __form3 = map(function (x) {
     return lower(x, hoist);
   }, form);
-  if (some63(__form2)) {
-    return __form2;
+  if (some63(__form3)) {
+    return __form3;
   }
 };
 var pairwise63 = function (form) {
@@ -978,13 +988,13 @@ var pairwise63 = function (form) {
 var lower_pairwise = function (form) {
   if (pairwise63(form)) {
     var __e4 = [];
-    var ____id24 = form;
-    var __x125 = ____id24[0];
-    var __args7 = cut(____id24, 1);
+    var ____id25 = form;
+    var __x123 = ____id25[0];
+    var __args8 = cut(____id25, 1);
     reduce(function (a, b) {
-      add(__e4, [__x125, a, b]);
+      add(__e4, [__x123, a, b]);
       return a;
-    }, __args7);
+    }, __args8);
     return join(["and"], reverse(__e4));
   } else {
     return form;
@@ -994,13 +1004,13 @@ var lower_infix63 = function (form) {
   return infix63(hd(form)) && _35(form) > 3;
 };
 var lower_infix = function (form, hoist) {
-  var __form3 = lower_pairwise(form);
-  var ____id25 = __form3;
-  var __x128 = ____id25[0];
-  var __args8 = cut(____id25, 1);
+  var __form4 = lower_pairwise(form);
+  var ____id26 = __form4;
+  var __x126 = ____id26[0];
+  var __args9 = cut(____id26, 1);
   return lower(reduce(function (a, b) {
-    return [__x128, b, a];
-  }, reverse(__args8)), hoist);
+    return [__x126, b, a];
+  }, reverse(__args9)), hoist);
 };
 var lower_special = function (form, hoist) {
   var __e5 = lower_call(form, hoist);
@@ -1021,37 +1031,37 @@ lower = function (form, hoist, stmt63, tail63) {
         if (lower_infix63(form)) {
           return lower_infix(form, hoist);
         } else {
-          var ____id26 = form;
-          var __x131 = ____id26[0];
-          var __args9 = cut(____id26, 1);
-          if (__x131 === "do") {
-            return lower_do(__args9, hoist, stmt63, tail63);
+          var ____id27 = form;
+          var __x129 = ____id27[0];
+          var __args10 = cut(____id27, 1);
+          if (__x129 === "do") {
+            return lower_do(__args10, hoist, stmt63, tail63);
           } else {
-            if (__x131 === "%set") {
-              return lower_set(__args9, hoist, stmt63, tail63);
+            if (__x129 === "%set") {
+              return lower_set(__args10, hoist, stmt63, tail63);
             } else {
-              if (__x131 === "%if") {
-                return lower_if(__args9, hoist, stmt63, tail63);
+              if (__x129 === "%if") {
+                return lower_if(__args10, hoist, stmt63, tail63);
               } else {
-                if (__x131 === "%try") {
-                  return lower_try(__args9, hoist, tail63);
+                if (__x129 === "%try") {
+                  return lower_try(__args10, hoist, tail63);
                 } else {
-                  if (__x131 === "while") {
-                    return lower_while(__args9, hoist);
+                  if (__x129 === "while") {
+                    return lower_while(__args10, hoist);
                   } else {
-                    if (__x131 === "%for") {
-                      return lower_for(__args9, hoist);
+                    if (__x129 === "%for") {
+                      return lower_for(__args10, hoist);
                     } else {
-                      if (__x131 === "%function") {
-                        return lower_function(__args9);
+                      if (__x129 === "%function") {
+                        return lower_function(__args10);
                       } else {
-                        if (__x131 === "%local-function" || __x131 === "%global-function") {
-                          return lower_definition(__x131, __args9, hoist);
+                        if (__x129 === "%local-function" || __x129 === "%global-function") {
+                          return lower_definition(__x129, __args10, hoist);
                         } else {
-                          if (in63(__x131, ["and", "or"])) {
-                            return lower_short(__x131, __args9, hoist);
+                          if (in63(__x129, ["and", "or"])) {
+                            return lower_short(__x129, __args10, hoist);
                           } else {
-                            if (statement63(__x131)) {
+                            if (statement63(__x129)) {
                               return lower_special(form, hoist);
                             } else {
                               return lower_call(form, hoist);
@@ -1090,16 +1100,16 @@ immediate_call63 = function (x) {
 setenv("do", {_stash: true, special: function () {
   var __forms1 = unstash(Array.prototype.slice.call(arguments, 0));
   var __s3 = "";
-  var ____x136 = __forms1;
+  var ____x134 = __forms1;
   var ____i19 = 0;
-  while (____i19 < _35(____x136)) {
-    var __x137 = ____x136[____i19];
-    if (target === "lua" && immediate_call63(__x137) && "\n" === char(__s3, edge(__s3))) {
+  while (____i19 < _35(____x134)) {
+    var __x135 = ____x134[____i19];
+    if (target === "lua" && immediate_call63(__x135) && "\n" === char(__s3, edge(__s3))) {
       __s3 = clip(__s3, 0, edge(__s3)) + ";\n";
     }
-    __s3 = __s3 + compile(__x137, {_stash: true, stmt: true});
-    if (! atom63(__x137)) {
-      if (hd(__x137) === "return" || hd(__x137) === "break") {
+    __s3 = __s3 + compile(__x135, {_stash: true, stmt: true});
+    if (! atom63(__x135)) {
+      if (hd(__x135) === "return" || hd(__x135) === "break") {
         break;
       }
     }
@@ -1110,15 +1120,15 @@ setenv("do", {_stash: true, special: function () {
 setenv("%if", {_stash: true, special: function (cond, cons, alt) {
   var __cond2 = compile(cond);
   indent_level = indent_level + 1;
-  var ____x140 = compile(cons, {_stash: true, stmt: true});
+  var ____x138 = compile(cons, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __cons1 = ____x140;
+  var __cons1 = ____x138;
   var __e54;
   if (alt) {
     indent_level = indent_level + 1;
-    var ____x141 = compile(alt, {_stash: true, stmt: true});
+    var ____x139 = compile(alt, {_stash: true, stmt: true});
     indent_level = indent_level - 1;
-    __e54 = ____x141;
+    __e54 = ____x139;
   }
   var __alt1 = __e54;
   var __ind3 = indentation();
@@ -1144,9 +1154,9 @@ setenv("%if", {_stash: true, special: function (cond, cons, alt) {
 setenv("while", {_stash: true, special: function (cond, form) {
   var __cond4 = compile(cond);
   indent_level = indent_level + 1;
-  var ____x143 = compile(form, {_stash: true, stmt: true});
+  var ____x141 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __body10 = ____x143;
+  var __body10 = ____x141;
   var __ind5 = indentation();
   if (target === "js") {
     return __ind5 + "while (" + __cond4 + ") {\n" + __body10 + __ind5 + "}\n";
@@ -1158,9 +1168,9 @@ setenv("%for", {_stash: true, special: function (t, k, form) {
   var __t2 = compile(t);
   var __ind7 = indentation();
   indent_level = indent_level + 1;
-  var ____x145 = compile(form, {_stash: true, stmt: true});
+  var ____x143 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __body12 = ____x145;
+  var __body12 = ____x143;
   if (target === "lua") {
     return __ind7 + "for " + k + " in next, " + __t2 + " do\n" + __body12 + __ind7 + "end\n";
   } else {
@@ -1171,14 +1181,14 @@ setenv("%try", {_stash: true, special: function (form) {
   var __e8 = unique("e");
   var __ind9 = indentation();
   indent_level = indent_level + 1;
-  var ____x150 = compile(form, {_stash: true, stmt: true});
+  var ____x148 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __body14 = ____x150;
+  var __body14 = ____x148;
   var __hf1 = ["return", ["%array", false, __e8]];
   indent_level = indent_level + 1;
-  var ____x153 = compile(__hf1, {_stash: true, stmt: true});
+  var ____x151 = compile(__hf1, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __h1 = ____x153;
+  var __h1 = ____x151;
   return __ind9 + "try {\n" + __body14 + __ind9 + "}\n" + __ind9 + "catch (" + __e8 + ") {\n" + __h1 + __ind9 + "}\n";
 }, stmt: true, tr: true});
 setenv("%delete", {_stash: true, special: function (place) {
@@ -1192,16 +1202,16 @@ setenv("%function", {_stash: true, special: function (args, body) {
 }});
 setenv("%global-function", {_stash: true, special: function (name, args, body) {
   if (target === "lua") {
-    var __x157 = compile_function(args, body, {_stash: true, name: name});
-    return indentation() + __x157;
+    var __x155 = compile_function(args, body, {_stash: true, name: name});
+    return indentation() + __x155;
   } else {
     return compile(["%set", name, ["%function", args, body]], {_stash: true, stmt: true});
   }
 }, stmt: true, tr: true});
 setenv("%local-function", {_stash: true, special: function (name, args, body) {
   if (target === "lua") {
-    var __x163 = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
-    return indentation() + __x163;
+    var __x161 = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
+    return indentation() + __x161;
   } else {
     return compile(["%local", name, ["%function", args, body]], {_stash: true, stmt: true});
   }
@@ -1213,8 +1223,8 @@ setenv("return", {_stash: true, special: function (x) {
   } else {
     __e55 = "return " + compile(x);
   }
-  var __x167 = __e55;
-  return indentation() + __x167;
+  var __x165 = __e55;
+  return indentation() + __x165;
 }, stmt: true});
 setenv("new", {_stash: true, special: function (x) {
   return "new " + compile(x);
@@ -1233,7 +1243,7 @@ setenv("error", {_stash: true, special: function (x) {
   return indentation() + __e12;
 }, stmt: true});
 setenv("%local", {_stash: true, special: function (name, value) {
-  var __id28 = compile(name);
+  var __id29 = compile(name);
   var __value11 = compile(value);
   var __e57;
   if (is63(value)) {
@@ -1250,7 +1260,7 @@ setenv("%local", {_stash: true, special: function (name, value) {
   }
   var __keyword1 = __e58;
   var __ind11 = indentation();
-  return __ind11 + __keyword1 + __id28 + __rh2;
+  return __ind11 + __keyword1 + __id29 + __rh2;
 }, stmt: true});
 setenv("%set", {_stash: true, special: function (lh, rh) {
   var __lh2 = compile(lh);
@@ -1334,9 +1344,9 @@ setenv("%object", {_stash: true, special: function () {
     }
     var __k22 = __e64;
     if (number63(__k22)) {
-      var ____id30 = __v12;
-      var __k23 = ____id30[0];
-      var __v13 = ____id30[1];
+      var ____id31 = __v12;
+      var __k23 = ____id31[0];
+      var __v13 = ____id31[1];
       if (! string63(__k23)) {
         throw new Error("Illegal key: " + str(__k23));
       }
@@ -1347,8 +1357,8 @@ setenv("%object", {_stash: true, special: function () {
   return __s9 + "}";
 }});
 setenv("%literal", {_stash: true, special: function () {
-  var __args111 = unstash(Array.prototype.slice.call(arguments, 0));
-  return apply(cat, map(compile, __args111));
+  var __args121 = unstash(Array.prototype.slice.call(arguments, 0));
+  return apply(cat, map(compile, __args121));
 }});
 exports.run = run;
 exports["eval"] = _eval;

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -179,52 +179,49 @@ end
 local function quasisplice63(x, depth)
   return can_unquote63(depth) and not atom63(x) and hd(x) == "unquote-splicing"
 end
-local function expand_local(__x38)
+local function expand_local(x, __x38)
   local ____id1 = __x38
-  local __x39 = ____id1[1]
-  local __name = ____id1[2]
-  local __value = ____id1[3]
+  local __name = ____id1[1]
+  local __value = ____id1[2]
   setenv(__name, {_stash = true, variable = true})
   return {"%local", __name, macroexpand(__value)}
 end
-local function expand_function(__x41)
-  local ____id2 = __x41
-  local __x42 = ____id2[1]
-  local __args = ____id2[2]
-  local __body = cut(____id2, 2)
+local function expand_function(x, __x40)
+  local ____id2 = __x40
+  local __args = ____id2[1]
+  local __body = cut(____id2, 1)
   add(environment, {})
   local ____o3 = __args
   local ____i5 = nil
   for ____i5 in next, ____o3 do
-    local ____x43 = ____o3[____i5]
-    setenv(____x43, {_stash = true, variable = true})
+    local ____x41 = ____o3[____i5]
+    setenv(____x41, {_stash = true, variable = true})
   end
-  local ____x44 = join({"%function", __args}, macroexpand(__body))
+  local ____x42 = join({"%function", __args}, macroexpand(__body))
   drop(environment)
-  return ____x44
+  return ____x42
 end
-local function expand_definition(__x46)
-  local ____id3 = __x46
-  local __x47 = ____id3[1]
-  local __name1 = ____id3[2]
-  local __args11 = ____id3[3]
-  local __body1 = cut(____id3, 3)
+local function expand_definition(x, __x44)
+  local ____id3 = __x44
+  local __name1 = ____id3[1]
+  local __args11 = ____id3[2]
+  local __body1 = cut(____id3, 2)
   add(environment, {})
   local ____o4 = __args11
   local ____i6 = nil
   for ____i6 in next, ____o4 do
-    local ____x48 = ____o4[____i6]
-    setenv(____x48, {_stash = true, variable = true})
+    local ____x45 = ____o4[____i6]
+    setenv(____x45, {_stash = true, variable = true})
   end
-  local ____x49 = join({__x47, __name1, __args11}, macroexpand(__body1))
+  local ____x46 = join({x, __name1, __args11}, macroexpand(__body1))
   drop(environment)
-  return ____x49
+  return ____x46
 end
-local function expand_macro(form)
-  return macroexpand(expand1(form))
+local function expand_macro(x, args)
+  return macroexpand(apply(macro_function(x), args))
 end
-function expand1(__x51)
-  local ____id4 = __x51
+function expand1(__x48)
+  local ____id4 = __x48
   local __name2 = ____id4[1]
   local __body2 = cut(____id4, 1)
   return apply(macro_function(__name2), __body2)
@@ -236,23 +233,36 @@ function macroexpand(form)
     if atom63(form) then
       return form
     else
-      local __x52 = hd(form)
-      if __x52 == "%local" then
-        return expand_local(form)
+      if none63(form) then
+        return map(macroexpand, form)
       else
-        if __x52 == "%function" then
-          return expand_function(form)
+        local ____id5 = form
+        local __x49 = ____id5[1]
+        local __args2 = cut(____id5, 1)
+        local __x50 = macroexpand(__x49)
+        if nil63(__x50) then
+          return macroexpand(__args2)
         else
-          if __x52 == "%global-function" then
-            return expand_definition(form)
+          if __x50 == "%local" then
+            return expand_local(__x50, __args2)
           else
-            if __x52 == "%local-function" then
-              return expand_definition(form)
+            if __x50 == "%function" then
+              return expand_function(__x50, __args2)
             else
-              if macro63(__x52) then
-                return expand_macro(form)
+              if __x50 == "%global-function" then
+                return expand_definition(__x50, __args2)
               else
-                return map(macroexpand, form)
+                if __x50 == "%local-function" then
+                  return expand_definition(__x50, __args2)
+                else
+                  if macro63(__x50) then
+                    return expand_macro(__x50, __args2)
+                  else
+                    local __form = map(macroexpand, __args2)
+                    insert(__form, __x50, 0)
+                    return __form
+                  end
+                end
               end
             end
           end
@@ -278,16 +288,16 @@ local function quasiquote_list(form, depth)
       last(__xs)[__k4] = __v5
     end
   end
-  local ____x55 = form
+  local ____x53 = form
   local ____i8 = 0
-  while ____i8 < _35(____x55) do
-    local __x56 = ____x55[____i8 + 1]
-    if quasisplice63(__x56, depth) then
-      local __x57 = quasiexpand(__x56[2])
-      add(__xs, __x57)
+  while ____i8 < _35(____x53) do
+    local __x54 = ____x53[____i8 + 1]
+    if quasisplice63(__x54, depth) then
+      local __x55 = quasiexpand(__x54[2])
+      add(__xs, __x55)
       add(__xs, {"list"})
     else
-      add(last(__xs), quasiexpand(__x56, depth))
+      add(last(__xs), quasiexpand(__x54, depth))
     end
     ____i8 = ____i8 + 1
   end
@@ -337,11 +347,11 @@ function quasiexpand(form, depth)
     end
   end
 end
-function expand_if(__x61)
-  local ____id5 = __x61
-  local __a = ____id5[1]
-  local __b1 = ____id5[2]
-  local __c = cut(____id5, 2)
+function expand_if(__x59)
+  local ____id6 = __x59
+  local __a = ____id6[1]
+  local __b1 = ____id6[2]
+  local __c = cut(____id6, 2)
   if is63(__b1) then
     return {join({"%if", __a, __b1}, expand_if(__c))}
   else
@@ -412,14 +422,14 @@ function valid_id63(x)
 end
 local __names = {}
 function unique(x)
-  local __x65 = id(x)
-  if __names[__x65] then
-    local __i11 = __names[__x65]
-    __names[__x65] = __names[__x65] + 1
-    return unique(__x65 .. __i11)
+  local __x63 = id(x)
+  if __names[__x63] then
+    local __i11 = __names[__x63]
+    __names[__x63] = __names[__x63] + 1
+    return unique(__x63 .. __i11)
   else
-    __names[__x65] = 1
-    return "__" .. __x65
+    __names[__x63] = 1
+    return "__" .. __x63
   end
 end
 function key(k)
@@ -440,52 +450,52 @@ function mapo(f, t)
   local __k5 = nil
   for __k5 in next, ____o7 do
     local __v6 = ____o7[__k5]
-    local __x66 = f(__v6)
-    if is63(__x66) then
+    local __x64 = f(__v6)
+    if is63(__x64) then
       add(__o6, literal(__k5))
-      add(__o6, __x66)
+      add(__o6, __x64)
     end
   end
   return __o6
 end
+local ____x66 = {}
+local ____x67 = {}
+____x67.js = "!"
+____x67.lua = "not"
+____x66["not"] = ____x67
 local ____x68 = {}
+____x68["*"] = true
+____x68["/"] = true
+____x68["%"] = true
 local ____x69 = {}
-____x69.js = "!"
-____x69.lua = "not"
-____x68["not"] = ____x69
 local ____x70 = {}
-____x70["*"] = true
-____x70["/"] = true
-____x70["%"] = true
+____x70.js = "+"
+____x70.lua = ".."
+____x69.cat = ____x70
 local ____x71 = {}
+____x71["+"] = true
+____x71["-"] = true
 local ____x72 = {}
-____x72.js = "+"
-____x72.lua = ".."
-____x71.cat = ____x72
+____x72["<"] = true
+____x72[">"] = true
+____x72["<="] = true
+____x72[">="] = true
 local ____x73 = {}
-____x73["+"] = true
-____x73["-"] = true
 local ____x74 = {}
-____x74["<"] = true
-____x74[">"] = true
-____x74["<="] = true
-____x74[">="] = true
+____x74.js = "==="
+____x74.lua = "=="
+____x73["="] = ____x74
 local ____x75 = {}
 local ____x76 = {}
-____x76.js = "==="
-____x76.lua = "=="
-____x75["="] = ____x76
+____x76.js = "&&"
+____x76.lua = "and"
+____x75["and"] = ____x76
 local ____x77 = {}
 local ____x78 = {}
-____x78.js = "&&"
-____x78.lua = "and"
-____x77["and"] = ____x78
-local ____x79 = {}
-local ____x80 = {}
-____x80.js = "||"
-____x80.lua = "or"
-____x79["or"] = ____x80
-local infix = {____x68, ____x70, ____x71, ____x73, ____x74, ____x75, ____x77, ____x79}
+____x78.js = "||"
+____x78.lua = "or"
+____x77["or"] = ____x78
+local infix = {____x66, ____x68, ____x69, ____x71, ____x72, ____x73, ____x75, ____x77}
 local function unary63(form)
   return two63(form) and in63(hd(form), {"not", "-"})
 end
@@ -509,12 +519,12 @@ local function precedence(form)
 end
 local function getop(op)
   return find(function (level)
-    local __x82 = level[op]
-    if __x82 == true then
+    local __x80 = level[op]
+    if __x80 == true then
       return op
     else
-      if is63(__x82) then
-        return __x82[target]
+      if is63(__x80) then
+        return __x80[target]
       end
     end
   end, infix)
@@ -528,11 +538,11 @@ end
 local function compile_args(args)
   local __s1 = "("
   local __c2 = ""
-  local ____x83 = args
+  local ____x81 = args
   local ____i15 = 0
-  while ____i15 < _35(____x83) do
-    local __x84 = ____x83[____i15 + 1]
-    __s1 = __s1 .. __c2 .. compile(__x84)
+  while ____i15 < _35(____x81) do
+    local __x82 = ____x81[____i15 + 1]
+    __s1 = __s1 .. __c2 .. compile(__x82)
     __c2 = ", "
     ____i15 = ____i15 + 1
   end
@@ -619,15 +629,15 @@ local function terminator(stmt63)
   end
 end
 local function compile_special(form, stmt63)
-  local ____id6 = form
-  local __x85 = ____id6[1]
-  local __args2 = cut(____id6, 1)
-  local ____id7 = getenv(__x85)
-  local __special = ____id7.special
-  local __stmt = ____id7.stmt
-  local __self_tr63 = ____id7.tr
+  local ____id7 = form
+  local __x83 = ____id7[1]
+  local __args3 = cut(____id7, 1)
+  local ____id8 = getenv(__x83)
+  local __special = ____id8.special
+  local __stmt = ____id8.stmt
+  local __self_tr63 = ____id8.tr
   local __tr = terminator(stmt63 and not __self_tr63)
-  return apply(__special, __args2) .. __tr
+  return apply(__special, __args3) .. __tr
 end
 local function parenthesize_call63(x)
   return not atom63(x) and hd(x) == "%function" or precedence(x) > 0
@@ -635,19 +645,19 @@ end
 local function compile_call(form)
   local __f = hd(form)
   local __f1 = compile(__f)
-  local __args3 = compile_args(stash42(tl(form)))
+  local __args4 = compile_args(stash42(tl(form)))
   if parenthesize_call63(__f) then
-    return "(" .. __f1 .. ")" .. __args3
+    return "(" .. __f1 .. ")" .. __args4
   else
-    return __f1 .. __args3
+    return __f1 .. __args4
   end
 end
 local function op_delims(parent, child, ...)
   local ____r57 = unstash({...})
   local __parent = destash33(parent, ____r57)
   local __child = destash33(child, ____r57)
-  local ____id8 = ____r57
-  local __right = ____id8.right
+  local ____id9 = ____r57
+  local __right = ____id9.right
   local __e31
   if __right then
     __e31 = _6261
@@ -661,17 +671,17 @@ local function op_delims(parent, child, ...)
   end
 end
 local function compile_infix(form)
-  local ____id9 = form
-  local __op = ____id9[1]
-  local ____id10 = cut(____id9, 1)
-  local __a1 = ____id10[1]
-  local __b2 = ____id10[2]
-  local ____id111 = op_delims(form, __a1)
-  local __ao = ____id111[1]
-  local __ac = ____id111[2]
-  local ____id12 = op_delims(form, __b2, {_stash = true, right = true})
-  local __bo = ____id12[1]
-  local __bc = ____id12[2]
+  local ____id10 = form
+  local __op = ____id10[1]
+  local ____id111 = cut(____id10, 1)
+  local __a1 = ____id111[1]
+  local __b2 = ____id111[2]
+  local ____id12 = op_delims(form, __a1)
+  local __ao = ____id12[1]
+  local __ac = ____id12[2]
+  local ____id13 = op_delims(form, __b2, {_stash = true, right = true})
+  local __bo = ____id13[1]
+  local __bc = ____id13[2]
   local __a2 = compile(__a1)
   local __b3 = compile(__b2)
   local __op1 = getop(__op)
@@ -683,30 +693,30 @@ local function compile_infix(form)
 end
 function compile_function(args, body, ...)
   local ____r59 = unstash({...})
-  local __args4 = destash33(args, ____r59)
+  local __args5 = destash33(args, ____r59)
   local __body3 = destash33(body, ____r59)
-  local ____id13 = ____r59
-  local __name3 = ____id13.name
-  local __prefix = ____id13.prefix
+  local ____id14 = ____r59
+  local __name3 = ____id14.name
+  local __prefix = ____id14.prefix
   local __e32
   if __name3 then
     __e32 = compile(__name3)
   else
     __e32 = ""
   end
-  local __id14 = __e32
+  local __id15 = __e32
   local __e33
-  if target == "lua" and __args4.rest then
-    __e33 = join(__args4, {"|...|"})
+  if target == "lua" and __args5.rest then
+    __e33 = join(__args5, {"|...|"})
   else
-    __e33 = __args4
+    __e33 = __args5
   end
   local __args12 = __e33
-  local __args5 = compile_args(__args12)
+  local __args6 = compile_args(__args12)
   indent_level = indent_level + 1
-  local ____x91 = compile(__body3, {_stash = true, stmt = true})
+  local ____x89 = compile(__body3, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __body4 = ____x91
+  local __body4 = ____x89
   local __ind = indentation()
   local __e34
   if __prefix then
@@ -726,9 +736,9 @@ function compile_function(args, body, ...)
     __tr1 = __tr1 .. "\n"
   end
   if target == "js" then
-    return "function " .. __id14 .. __args5 .. " {\n" .. __body4 .. __ind .. "}" .. __tr1
+    return "function " .. __id15 .. __args6 .. " {\n" .. __body4 .. __ind .. "}" .. __tr1
   else
-    return __p .. "function " .. __id14 .. __args5 .. "\n" .. __body4 .. __ind .. __tr1
+    return __p .. "function " .. __id15 .. __args6 .. "\n" .. __body4 .. __ind .. __tr1
   end
 end
 local function can_return63(form)
@@ -736,14 +746,14 @@ local function can_return63(form)
 end
 function compile(form, ...)
   local ____r61 = unstash({...})
-  local __form = destash33(form, ____r61)
-  local ____id15 = ____r61
-  local __stmt1 = ____id15.stmt
-  if nil63(__form) then
+  local __form1 = destash33(form, ____r61)
+  local ____id16 = ____r61
+  local __stmt1 = ____id16.stmt
+  if nil63(__form1) then
     return ""
   else
-    if special_form63(__form) then
-      return compile_special(__form, __stmt1)
+    if special_form63(__form1) then
+      return compile_special(__form1, __stmt1)
     else
       local __tr2 = terminator(__stmt1)
       local __e36
@@ -754,19 +764,19 @@ function compile(form, ...)
       end
       local __ind1 = __e36
       local __e37
-      if atom63(__form) then
-        __e37 = compile_atom(__form)
+      if atom63(__form1) then
+        __e37 = compile_atom(__form1)
       else
         local __e38
-        if infix63(hd(__form)) then
-          __e38 = compile_infix(__form)
+        if infix63(hd(__form1)) then
+          __e38 = compile_infix(__form1)
         else
-          __e38 = compile_call(__form)
+          __e38 = compile_call(__form1)
         end
         __e37 = __e38
       end
-      local __form1 = __e37
-      return __ind1 .. __form1 .. __tr2
+      local __form2 = __e37
+      return __ind1 .. __form2 .. __tr2
     end
   end
 end
@@ -803,11 +813,11 @@ local function standalone63(form)
   return not atom63(form) and not infix63(hd(form)) and not literal63(form) and not( "get" == hd(form)) or id_literal63(form)
 end
 local function lower_do(args, hoist, stmt63, tail63)
-  local ____x98 = almost(args)
+  local ____x96 = almost(args)
   local ____i17 = 0
-  while ____i17 < _35(____x98) do
-    local __x99 = ____x98[____i17 + 1]
-    local ____y = lower(__x99, hoist, stmt63)
+  while ____i17 < _35(____x96) do
+    local __x97 = ____x96[____i17 + 1]
+    local ____y = lower(__x97, hoist, stmt63)
     if yes(____y) then
       local __e1 = ____y
       if standalone63(__e1) then
@@ -824,19 +834,19 @@ local function lower_do(args, hoist, stmt63, tail63)
   end
 end
 local function lower_set(args, hoist, stmt63, tail63)
-  local ____id16 = args
-  local __lh = ____id16[1]
-  local __rh = ____id16[2]
+  local ____id17 = args
+  local __lh = ____id17[1]
+  local __rh = ____id17[2]
   add(hoist, {"%set", lower(__lh, hoist), lower(__rh, hoist)})
   if not( stmt63 and not tail63) then
     return __lh
   end
 end
 local function lower_if(args, hoist, stmt63, tail63)
-  local ____id17 = args
-  local __cond = ____id17[1]
-  local ___then = ____id17[2]
-  local ___else = ____id17[3]
+  local ____id18 = args
+  local __cond = ____id18[1]
+  local ___then = ____id18[2]
+  local ___else = ____id18[3]
   if stmt63 then
     local __e43
     if is63(___else) then
@@ -855,20 +865,20 @@ local function lower_if(args, hoist, stmt63, tail63)
   end
 end
 local function lower_short(x, args, hoist)
-  local ____id18 = args
-  local __a3 = ____id18[1]
-  local __b4 = ____id18[2]
+  local ____id19 = args
+  local __a3 = ____id19[1]
+  local __b4 = ____id19[2]
   local __hoist1 = {}
   local __b11 = lower(__b4, __hoist1)
   if some63(__hoist1) then
-    local __id19 = unique("id")
+    local __id20 = unique("id")
     local __e44
     if x == "and" then
-      __e44 = {"%if", __id19, __b4, __id19}
+      __e44 = {"%if", __id20, __b4, __id20}
     else
-      __e44 = {"%if", __id19, __id19, __b4}
+      __e44 = {"%if", __id20, __id20, __b4}
     end
-    return lower({"do", {"%local", __id19, __a3}, __e44}, hoist)
+    return lower({"do", {"%local", __id20, __a3}, __e44}, hoist)
   else
     return {x, lower(__a3, hoist), __b11}
   end
@@ -877,9 +887,9 @@ local function lower_try(args, hoist, tail63)
   return add(hoist, {"%try", lower_body(args, tail63)})
 end
 local function lower_while(args, hoist)
-  local ____id20 = args
-  local __c4 = ____id20[1]
-  local __body5 = cut(____id20, 1)
+  local ____id21 = args
+  local __c4 = ____id21[1]
+  local __body5 = cut(____id21, 1)
   local __pre = {}
   local __c5 = lower(__c4, __pre)
   local __e45
@@ -891,31 +901,31 @@ local function lower_while(args, hoist)
   return add(hoist, __e45)
 end
 local function lower_for(args, hoist)
-  local ____id21 = args
-  local __t = ____id21[1]
-  local __k7 = ____id21[2]
-  local __body6 = cut(____id21, 2)
+  local ____id22 = args
+  local __t = ____id22[1]
+  local __k7 = ____id22[2]
+  local __body6 = cut(____id22, 2)
   return add(hoist, {"%for", lower(__t, hoist), __k7, lower_body(__body6)})
 end
 local function lower_function(args)
-  local ____id22 = args
-  local __a4 = ____id22[1]
-  local __body7 = cut(____id22, 1)
+  local ____id23 = args
+  local __a4 = ____id23[1]
+  local __body7 = cut(____id23, 1)
   return {"%function", __a4, lower_body(__body7, true)}
 end
 local function lower_definition(kind, args, hoist)
-  local ____id23 = args
-  local __name4 = ____id23[1]
-  local __args6 = ____id23[2]
-  local __body8 = cut(____id23, 2)
-  return add(hoist, {kind, __name4, __args6, lower_body(__body8, true)})
+  local ____id24 = args
+  local __name4 = ____id24[1]
+  local __args7 = ____id24[2]
+  local __body8 = cut(____id24, 2)
+  return add(hoist, {kind, __name4, __args7, lower_body(__body8, true)})
 end
 local function lower_call(form, hoist)
-  local __form2 = map(function (x)
+  local __form3 = map(function (x)
     return lower(x, hoist)
   end, form)
-  if some63(__form2) then
-    return __form2
+  if some63(__form3) then
+    return __form3
   end
 end
 local function pairwise63(form)
@@ -924,13 +934,13 @@ end
 local function lower_pairwise(form)
   if pairwise63(form) then
     local __e4 = {}
-    local ____id24 = form
-    local __x128 = ____id24[1]
-    local __args7 = cut(____id24, 1)
+    local ____id25 = form
+    local __x126 = ____id25[1]
+    local __args8 = cut(____id25, 1)
     reduce(function (a, b)
-      add(__e4, {__x128, a, b})
+      add(__e4, {__x126, a, b})
       return a
-    end, __args7)
+    end, __args8)
     return join({"and"}, reverse(__e4))
   else
     return form
@@ -940,13 +950,13 @@ local function lower_infix63(form)
   return infix63(hd(form)) and _35(form) > 3
 end
 local function lower_infix(form, hoist)
-  local __form3 = lower_pairwise(form)
-  local ____id25 = __form3
-  local __x131 = ____id25[1]
-  local __args8 = cut(____id25, 1)
+  local __form4 = lower_pairwise(form)
+  local ____id26 = __form4
+  local __x129 = ____id26[1]
+  local __args9 = cut(____id26, 1)
   return lower(reduce(function (a, b)
-    return {__x131, b, a}
-  end, reverse(__args8)), hoist)
+    return {__x129, b, a}
+  end, reverse(__args9)), hoist)
 end
 local function lower_special(form, hoist)
   local __e5 = lower_call(form, hoist)
@@ -967,37 +977,37 @@ function lower(form, hoist, stmt63, tail63)
         if lower_infix63(form) then
           return lower_infix(form, hoist)
         else
-          local ____id26 = form
-          local __x134 = ____id26[1]
-          local __args9 = cut(____id26, 1)
-          if __x134 == "do" then
-            return lower_do(__args9, hoist, stmt63, tail63)
+          local ____id27 = form
+          local __x132 = ____id27[1]
+          local __args10 = cut(____id27, 1)
+          if __x132 == "do" then
+            return lower_do(__args10, hoist, stmt63, tail63)
           else
-            if __x134 == "%set" then
-              return lower_set(__args9, hoist, stmt63, tail63)
+            if __x132 == "%set" then
+              return lower_set(__args10, hoist, stmt63, tail63)
             else
-              if __x134 == "%if" then
-                return lower_if(__args9, hoist, stmt63, tail63)
+              if __x132 == "%if" then
+                return lower_if(__args10, hoist, stmt63, tail63)
               else
-                if __x134 == "%try" then
-                  return lower_try(__args9, hoist, tail63)
+                if __x132 == "%try" then
+                  return lower_try(__args10, hoist, tail63)
                 else
-                  if __x134 == "while" then
-                    return lower_while(__args9, hoist)
+                  if __x132 == "while" then
+                    return lower_while(__args10, hoist)
                   else
-                    if __x134 == "%for" then
-                      return lower_for(__args9, hoist)
+                    if __x132 == "%for" then
+                      return lower_for(__args10, hoist)
                     else
-                      if __x134 == "%function" then
-                        return lower_function(__args9)
+                      if __x132 == "%function" then
+                        return lower_function(__args10)
                       else
-                        if __x134 == "%local-function" or __x134 == "%global-function" then
-                          return lower_definition(__x134, __args9, hoist)
+                        if __x132 == "%local-function" or __x132 == "%global-function" then
+                          return lower_definition(__x132, __args10, hoist)
                         else
-                          if in63(__x134, {"and", "or"}) then
-                            return lower_short(__x134, __args9, hoist)
+                          if in63(__x132, {"and", "or"}) then
+                            return lower_short(__x132, __args10, hoist)
                           else
-                            if statement63(__x134) then
+                            if statement63(__x132) then
                               return lower_special(form, hoist)
                             else
                               return lower_call(form, hoist)
@@ -1043,16 +1053,16 @@ end
 setenv("do", {_stash = true, special = function (...)
   local __forms1 = unstash({...})
   local __s3 = ""
-  local ____x140 = __forms1
+  local ____x138 = __forms1
   local ____i19 = 0
-  while ____i19 < _35(____x140) do
-    local __x141 = ____x140[____i19 + 1]
-    if target == "lua" and immediate_call63(__x141) and "\n" == char(__s3, edge(__s3)) then
+  while ____i19 < _35(____x138) do
+    local __x139 = ____x138[____i19 + 1]
+    if target == "lua" and immediate_call63(__x139) and "\n" == char(__s3, edge(__s3)) then
       __s3 = clip(__s3, 0, edge(__s3)) .. ";\n"
     end
-    __s3 = __s3 .. compile(__x141, {_stash = true, stmt = true})
-    if not atom63(__x141) then
-      if hd(__x141) == "return" or hd(__x141) == "break" then
+    __s3 = __s3 .. compile(__x139, {_stash = true, stmt = true})
+    if not atom63(__x139) then
+      if hd(__x139) == "return" or hd(__x139) == "break" then
         break
       end
     end
@@ -1063,15 +1073,15 @@ end, stmt = true, tr = true})
 setenv("%if", {_stash = true, special = function (cond, cons, alt)
   local __cond2 = compile(cond)
   indent_level = indent_level + 1
-  local ____x144 = compile(cons, {_stash = true, stmt = true})
+  local ____x142 = compile(cons, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __cons1 = ____x144
+  local __cons1 = ____x142
   local __e46
   if alt then
     indent_level = indent_level + 1
-    local ____x145 = compile(alt, {_stash = true, stmt = true})
+    local ____x143 = compile(alt, {_stash = true, stmt = true})
     indent_level = indent_level - 1
-    __e46 = ____x145
+    __e46 = ____x143
   end
   local __alt1 = __e46
   local __ind3 = indentation()
@@ -1097,9 +1107,9 @@ end, stmt = true, tr = true})
 setenv("while", {_stash = true, special = function (cond, form)
   local __cond4 = compile(cond)
   indent_level = indent_level + 1
-  local ____x147 = compile(form, {_stash = true, stmt = true})
+  local ____x145 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __body10 = ____x147
+  local __body10 = ____x145
   local __ind5 = indentation()
   if target == "js" then
     return __ind5 .. "while (" .. __cond4 .. ") {\n" .. __body10 .. __ind5 .. "}\n"
@@ -1111,9 +1121,9 @@ setenv("%for", {_stash = true, special = function (t, k, form)
   local __t2 = compile(t)
   local __ind7 = indentation()
   indent_level = indent_level + 1
-  local ____x149 = compile(form, {_stash = true, stmt = true})
+  local ____x147 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __body12 = ____x149
+  local __body12 = ____x147
   if target == "lua" then
     return __ind7 .. "for " .. k .. " in next, " .. __t2 .. " do\n" .. __body12 .. __ind7 .. "end\n"
   else
@@ -1124,14 +1134,14 @@ setenv("%try", {_stash = true, special = function (form)
   local __e8 = unique("e")
   local __ind9 = indentation()
   indent_level = indent_level + 1
-  local ____x154 = compile(form, {_stash = true, stmt = true})
+  local ____x152 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __body14 = ____x154
+  local __body14 = ____x152
   local __hf1 = {"return", {"%array", false, __e8}}
   indent_level = indent_level + 1
-  local ____x157 = compile(__hf1, {_stash = true, stmt = true})
+  local ____x155 = compile(__hf1, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __h1 = ____x157
+  local __h1 = ____x155
   return __ind9 .. "try {\n" .. __body14 .. __ind9 .. "}\n" .. __ind9 .. "catch (" .. __e8 .. ") {\n" .. __h1 .. __ind9 .. "}\n"
 end, stmt = true, tr = true})
 setenv("%delete", {_stash = true, special = function (place)
@@ -1145,16 +1155,16 @@ setenv("%function", {_stash = true, special = function (args, body)
 end})
 setenv("%global-function", {_stash = true, special = function (name, args, body)
   if target == "lua" then
-    local __x161 = compile_function(args, body, {_stash = true, name = name})
-    return indentation() .. __x161
+    local __x159 = compile_function(args, body, {_stash = true, name = name})
+    return indentation() .. __x159
   else
     return compile({"%set", name, {"%function", args, body}}, {_stash = true, stmt = true})
   end
 end, stmt = true, tr = true})
 setenv("%local-function", {_stash = true, special = function (name, args, body)
   if target == "lua" then
-    local __x167 = compile_function(args, body, {_stash = true, name = name, prefix = "local"})
-    return indentation() .. __x167
+    local __x165 = compile_function(args, body, {_stash = true, name = name, prefix = "local"})
+    return indentation() .. __x165
   else
     return compile({"%local", name, {"%function", args, body}}, {_stash = true, stmt = true})
   end
@@ -1166,8 +1176,8 @@ setenv("return", {_stash = true, special = function (x)
   else
     __e47 = "return " .. compile(x)
   end
-  local __x171 = __e47
-  return indentation() .. __x171
+  local __x169 = __e47
+  return indentation() .. __x169
 end, stmt = true})
 setenv("new", {_stash = true, special = function (x)
   return "new " .. compile(x)
@@ -1186,7 +1196,7 @@ setenv("error", {_stash = true, special = function (x)
   return indentation() .. __e12
 end, stmt = true})
 setenv("%local", {_stash = true, special = function (name, value)
-  local __id28 = compile(name)
+  local __id29 = compile(name)
   local __value11 = compile(value)
   local __e49
   if is63(value) then
@@ -1203,7 +1213,7 @@ setenv("%local", {_stash = true, special = function (name, value)
   end
   local __keyword1 = __e50
   local __ind11 = indentation()
-  return __ind11 .. __keyword1 .. __id28 .. __rh2
+  return __ind11 .. __keyword1 .. __id29 .. __rh2
 end, stmt = true})
 setenv("%set", {_stash = true, special = function (lh, rh)
   local __lh2 = compile(lh)
@@ -1273,9 +1283,9 @@ setenv("%object", {_stash = true, special = function (...)
   for __k14 in next, ____o12 do
     local __v12 = ____o12[__k14]
     if number63(__k14) then
-      local ____id30 = __v12
-      local __k15 = ____id30[1]
-      local __v13 = ____id30[2]
+      local ____id31 = __v12
+      local __k15 = ____id31[1]
+      local __v13 = ____id31[2]
       if not string63(__k15) then
         error("Illegal key: " .. str(__k15))
       end
@@ -1286,7 +1296,7 @@ setenv("%object", {_stash = true, special = function (...)
   return __s9 .. "}"
 end})
 setenv("%literal", {_stash = true, special = function (...)
-  local __args111 = unstash({...})
-  return apply(cat, map(compile, __args111))
+  local __args121 = unstash({...})
+  return apply(cat, map(compile, __args121))
 end})
 return {run = run, ["eval"] = _eval, expand = expand, compile = compile}

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -153,6 +153,10 @@ string_literal63 = function (x) {
 id_literal63 = function (x) {
   return string63(x) && char(x, 0) === "|";
 };
+insert = function (l, x, pos) {
+  l.splice(pos, 0, x);
+  return undefined;
+};
 add = function (l, x) {
   l.push(x);
   return undefined;
@@ -188,13 +192,13 @@ reduce = function (f, x) {
 };
 join = function () {
   var __ls = unstash(Array.prototype.slice.call(arguments, 0));
-  var __r37 = [];
+  var __r38 = [];
   var ____x1 = __ls;
   var ____i4 = 0;
   while (____i4 < _35(____x1)) {
     var __l11 = ____x1[____i4];
     if (__l11) {
-      var __n3 = _35(__r37);
+      var __n3 = _35(__r38);
       var ____o2 = __l11;
       var __k4 = undefined;
       for (__k4 in ____o2) {
@@ -209,12 +213,12 @@ join = function () {
         if (number63(__k5)) {
           __k5 = __k5 + __n3;
         }
-        __r37[__k5] = __v2;
+        __r38[__k5] = __v2;
       }
     }
     ____i4 = ____i4 + 1;
   }
-  return __r37;
+  return __r38;
 };
 find = function (f, t) {
   var ____o3 = t;
@@ -671,16 +675,16 @@ apply = function (f, args) {
   return f.apply(f, __args);
 };
 call = function (f) {
-  var ____r74 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __f = destash33(f, ____r74);
-  var ____id = ____r74;
+  var ____r75 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __f = destash33(f, ____r75);
+  var ____id = ____r75;
   var __args11 = cut(____id, 0);
   return apply(__f, __args11);
 };
 setenv = function (k) {
-  var ____r75 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __k18 = destash33(k, ____r75);
-  var ____id1 = ____r75;
+  var ____r76 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __k18 = destash33(k, ____r76);
+  var ____id1 = ____r76;
   var __keys = cut(____id1, 0);
   if (string63(__k18)) {
     var __e19;

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -140,6 +140,9 @@ end
 function id_literal63(x)
   return string63(x) and char(x, 0) == "|"
 end
+function insert(l, x, pos)
+  return table.insert(l, pos + 1, x)
+end
 function add(l, x)
   return table.insert(l, x)
 end
@@ -174,13 +177,13 @@ function reduce(f, x)
 end
 function join(...)
   local __ls = unstash({...})
-  local __r36 = {}
+  local __r37 = {}
   local ____x2 = __ls
   local ____i4 = 0
   while ____i4 < _35(____x2) do
     local __l11 = ____x2[____i4 + 1]
     if __l11 then
-      local __n3 = _35(__r36)
+      local __n3 = _35(__r37)
       local ____o2 = __l11
       local __k2 = nil
       for __k2 in next, ____o2 do
@@ -188,12 +191,12 @@ function join(...)
         if number63(__k2) then
           __k2 = __k2 + __n3
         end
-        __r36[__k2] = __v2
+        __r37[__k2] = __v2
       end
     end
     ____i4 = ____i4 + 1
   end
-  return __r36
+  return __r37
 end
 function find(f, t)
   local ____o3 = t
@@ -579,16 +582,16 @@ function apply(f, args)
   return f(values(__args))
 end
 function call(f, ...)
-  local ____r71 = unstash({...})
-  local __f = destash33(f, ____r71)
-  local ____id = ____r71
+  local ____r72 = unstash({...})
+  local __f = destash33(f, ____r72)
+  local ____id = ____r72
   local __args11 = cut(____id, 0)
   return apply(__f, __args11)
 end
 function setenv(k, ...)
-  local ____r72 = unstash({...})
-  local __k9 = destash33(k, ____r72)
-  local ____id1 = ____r72
+  local ____r73 = unstash({...})
+  local __k9 = destash33(k, ____r73)
+  local ____id1 = ____r73
   local __keys = cut(____id1, 0)
   if string63(__k9) then
     local __e8

--- a/compiler.l
+++ b/compiler.l
@@ -120,20 +120,20 @@
        (not (atom? x))
        (= (hd x) 'unquote-splicing)))
 
-(define expand-local ((x name value))
+(define expand-local (x (name value))
   (setenv name :variable)
   `(%local ,name ,(macroexpand value)))
 
-(define expand-function ((x args rest: body))
+(define expand-function (x (args rest: body))
   (with-bindings (args)
     `(%function ,args ,@(macroexpand body))))
 
-(define expand-definition ((x name args rest: body))
+(define expand-definition (x (name args rest: body))
   (with-bindings (args)
     `(,x ,name ,args ,@(macroexpand body))))
 
-(define expand-macro (form)
-  (macroexpand (expand1 form)))
+(define expand-macro (x args)
+  (macroexpand (apply (macro-function x) args)))
 
 (define-global expand1 ((name rest: body))
   (apply (macro-function name) body))
@@ -142,13 +142,17 @@
   (if (symbol? form)
       (macroexpand (symbol-expansion form))
       (atom? form) form
-    (let x (hd form)
-      (if (= x '%local) (expand-local form)
-          (= x '%function) (expand-function form)
-          (= x '%global-function) (expand-definition form)
-          (= x '%local-function) (expand-definition form)
-          (macro? x) (expand-macro form)
-        (map macroexpand form)))))
+      (none? form) (map macroexpand form)
+    (let ((x rest: args) form
+          x (macroexpand x))
+      (if (nil? x) (macroexpand args)
+          (= x '%local) (expand-local x args)
+          (= x '%function) (expand-function x args)
+          (= x '%global-function) (expand-definition x args)
+          (= x '%local-function) (expand-definition x args)
+          (macro? x) (expand-macro x args)
+        (with form (map macroexpand args)
+          (insert form x 0))))))
 
 (define quasiquote-list (form depth)
   (let xs (list '(list))

--- a/runtime.l
+++ b/runtime.l
@@ -96,6 +96,10 @@
 (define-global id-literal? (x)
   (and (string? x) (= (char x 0) "|")))
 
+(define-global insert (l x pos)
+  (target js: (do ((get l 'splice) pos 0 x) nil)
+          lua: ((get table 'insert) l (+ pos 1) x)))
+
 (define-global add (l x)
   (target js: (do ((get l 'push) x) nil)
           lua: ((get table 'insert) l x)))


### PR DESCRIPTION
Closes #153, closes #154.

This is a third attempt at solving the issues presented in #153.

Please consider this. If you have concerns, please let me know what
they are so I can try to address them. If you really want to stick
with the existing behavior, let me know so I can give up on this. :)

LuaJIT 2.1.0-beta2 performance is identical.
Lua 5.2.4 is 10% slower.
Node v7.9.0 is 6% slower.

The goal of all three PRs is to expand the head of a list before
checking whether it's a macro. All three of my attempts incur a
slowdown, but I feel this behavior is worth the tradeoff. We can
regain the speed in other areas (such as by optimizing `let`).

The advantages are:

- symbol macros behave correctly when they refer to a macro,
e.g. `(define-symbol def define-global)`

- expressions like `((target js: get lua: at) foo 0)` work correctly.

- if the head expands to `nil`, the next argument becomes the head.
