### PR TITLE
Add support for setforms

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -1,5 +1,5 @@
 var reader = require("reader");
-var getenv = function (k, p) {
+getenv = function (k, p) {
   if (string63(k)) {
     var __i = edge(environment);
     while (__i >= 0) {

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -1,5 +1,5 @@
 local reader = require("reader")
-local function getenv(k, p)
+function getenv(k, p)
   if string63(k) then
     local __i = edge(environment)
     while __i >= 0 do

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -738,13 +738,78 @@ setenv("quote", {_stash: true, macro: function (form) {
 setenv("quasiquote", {_stash: true, macro: function (form) {
   return quasiexpand(form, 1);
 }});
+gv_get = function (place, _do) {
+  var __place = macroexpand(place);
+  if (atom63(__place) || hd(__place) === "get" && nil63(getenv("get", "gv-expander"))) {
+    return _do(__place, function (v) {
+      return ["%set", __place, v];
+    });
+  } else {
+    var __head = hd(__place);
+    var __gf = getenv(__head, "gv-expander");
+    if (__gf) {
+      return apply(__gf, join([_do], tl(__place)));
+    } else {
+      throw new Error(str(__place) + " is not a valid place expression");
+    }
+  }
+};
+setenv("gv-letplace", {_stash: true, macro: function (vars, place) {
+  var ____r7 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __vars1 = destash33(vars, ____r7);
+  var __place2 = destash33(place, ____r7);
+  var ____id1 = ____r7;
+  var __body1 = cut(____id1, 0);
+  return ["gv-get", __place2, join(["fn", __vars1], __body1)];
+}});
+setenv("gv-define-expander", {_stash: true, macro: function (name, handler) {
+  var ____x8 = ["setenv", ["quote", name]];
+  ____x8["gv-expander"] = handler;
+  var __form1 = ____x8;
+  _eval(__form1);
+  return __form1;
+}});
+gv__defsetter = function (name, setter, _do, args, vars) {
+  if (none63(args)) {
+    var __vars2 = reverse(vars);
+    return _do(join([name], __vars2), function (v) {
+      return apply(setter, join([v], __vars2));
+    });
+  } else {
+    var __v = hd(args);
+    return gv__defsetter(name, setter, _do, tl(args), join([__v], vars));
+  }
+};
+setenv("gv-define-setter", {_stash: true, macro: function (name, arglist) {
+  var ____r13 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __name1 = destash33(name, ____r13);
+  var __arglist1 = destash33(arglist, ____r13);
+  var ____id3 = ____r13;
+  var __body3 = cut(____id3, 0);
+  var ____x21 = ["_do"];
+  ____x21.rest = "args";
+  return ["gv-define-expander", __name1, ["fn", ____x21, ["gv--defsetter", ["quote", __name1], join(["fn", __arglist1], __body3), "_do", "args"]]];
+}});
+setenv("gv-define-simple-setter", {_stash: true, macro: function (name, setter, fix_return) {
+  var ____x43 = ["val"];
+  ____x43.rest = "args";
+  var __e9;
+  if (fix_return) {
+    __e9 = ["let", "v", "val", ["quasiquote", ["do", [["unquote", ["quote", setter]], ["unquote-splicing", "args"], ["unquote", "v"]], ["unquote", "v"]]]];
+  } else {
+    __e9 = ["quasiquote", [["unquote", ["quote", setter]], ["unquote-splicing", "args"], ["unquote", "val"]]];
+  }
+  return ["gv-define-setter", name, ____x43, __e9];
+}});
 setenv("set", {_stash: true, macro: function () {
   var __args1 = unstash(Array.prototype.slice.call(arguments, 0));
-  return join(["do"], map(function (__x4) {
-    var ____id1 = __x4;
-    var __lh1 = ____id1[0];
-    var __rh1 = ____id1[1];
-    return ["%set", __lh1, __rh1];
+  return join(["do"], map(function (__x62) {
+    var ____id5 = __x62;
+    var __lh1 = ____id5[0];
+    var __rh1 = ____id5[1];
+    return gv_get(__lh1, function (_getter, setter) {
+      return setter(__rh1);
+    });
   }, pair(__args1)));
 }});
 setenv("at", {_stash: true, macro: function (l, i) {
@@ -765,29 +830,29 @@ setenv("wipe", {_stash: true, macro: function (place) {
   }
 }});
 setenv("list", {_stash: true, macro: function () {
-  var __body1 = unstash(Array.prototype.slice.call(arguments, 0));
-  var __x22 = unique("x");
+  var __body5 = unstash(Array.prototype.slice.call(arguments, 0));
+  var __x79 = unique("x");
   var __l1 = [];
   var __forms1 = [];
-  var ____o1 = __body1;
+  var ____o1 = __body5;
   var __k2 = undefined;
   for (__k2 in ____o1) {
-    var __v1 = ____o1[__k2];
-    var __e8;
+    var __v2 = ____o1[__k2];
+    var __e10;
     if (numeric63(__k2)) {
-      __e8 = parseInt(__k2);
+      __e10 = parseInt(__k2);
     } else {
-      __e8 = __k2;
+      __e10 = __k2;
     }
-    var __k3 = __e8;
+    var __k3 = __e10;
     if (number63(__k3)) {
-      __l1[__k3] = __v1;
+      __l1[__k3] = __v2;
     } else {
-      add(__forms1, ["set", ["get", __x22, ["quote", __k3]], __v1]);
+      add(__forms1, ["set", ["get", __x79, ["quote", __k3]], __v2]);
     }
   }
   if (some63(__forms1)) {
-    return join(["let", __x22, join(["%array"], __l1)], __forms1, [__x22]);
+    return join(["let", __x79, join(["%array"], __l1)], __forms1, [__x79]);
   } else {
     return join(["%array"], __l1);
   }
@@ -797,18 +862,18 @@ setenv("if", {_stash: true, macro: function () {
   return hd(expand_if(__branches1));
 }});
 setenv("case", {_stash: true, macro: function (expr) {
-  var ____r13 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __expr1 = destash33(expr, ____r13);
-  var ____id4 = ____r13;
-  var __clauses1 = cut(____id4, 0);
-  var __x41 = unique("x");
+  var ____r27 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __expr1 = destash33(expr, ____r27);
+  var ____id8 = ____r27;
+  var __clauses1 = cut(____id8, 0);
+  var __x98 = unique("x");
   var __eq1 = function (_) {
-    return ["=", ["quote", _], __x41];
+    return ["=", ["quote", _], __x98];
   };
-  var __cl1 = function (__x44) {
-    var ____id5 = __x44;
-    var __a1 = ____id5[0];
-    var __b1 = ____id5[1];
+  var __cl1 = function (__x101) {
+    var ____id9 = __x101;
+    var __a1 = ____id9[0];
+    var __b1 = ____id9[1];
     if (nil63(__b1)) {
       return [__a1];
     } else {
@@ -825,208 +890,208 @@ setenv("case", {_stash: true, macro: function (expr) {
       }
     }
   };
-  return ["let", __x41, __expr1, join(["if"], apply(join, map(__cl1, pair(__clauses1))))];
+  return ["let", __x98, __expr1, join(["if"], apply(join, map(__cl1, pair(__clauses1))))];
 }});
 setenv("when", {_stash: true, macro: function (cond) {
-  var ____r17 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __cond1 = destash33(cond, ____r17);
-  var ____id7 = ____r17;
-  var __body3 = cut(____id7, 0);
-  return ["if", __cond1, join(["do"], __body3)];
+  var ____r31 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __cond1 = destash33(cond, ____r31);
+  var ____id11 = ____r31;
+  var __body7 = cut(____id11, 0);
+  return ["if", __cond1, join(["do"], __body7)];
 }});
 setenv("unless", {_stash: true, macro: function (cond) {
-  var ____r19 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __cond3 = destash33(cond, ____r19);
-  var ____id9 = ____r19;
-  var __body5 = cut(____id9, 0);
-  return ["if", ["not", __cond3], join(["do"], __body5)];
+  var ____r33 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __cond3 = destash33(cond, ____r33);
+  var ____id13 = ____r33;
+  var __body9 = cut(____id13, 0);
+  return ["if", ["not", __cond3], join(["do"], __body9)];
 }});
 setenv("obj", {_stash: true, macro: function () {
-  var __body7 = unstash(Array.prototype.slice.call(arguments, 0));
+  var __body11 = unstash(Array.prototype.slice.call(arguments, 0));
   return join(["%object"], mapo(function (x) {
     return x;
-  }, __body7));
+  }, __body11));
 }});
 setenv("let", {_stash: true, macro: function (bs) {
-  var ____r23 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __bs11 = destash33(bs, ____r23);
-  var ____id14 = ____r23;
-  var __body9 = cut(____id14, 0);
+  var ____r37 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __bs11 = destash33(bs, ____r37);
+  var ____id18 = ____r37;
+  var __body13 = cut(____id18, 0);
   if (atom63(__bs11)) {
-    return join(["let", [__bs11, hd(__body9)]], tl(__body9));
+    return join(["let", [__bs11, hd(__body13)]], tl(__body13));
   } else {
     if (none63(__bs11)) {
-      return join(["do"], __body9);
+      return join(["do"], __body13);
     } else {
-      var ____id15 = __bs11;
-      var __lh3 = ____id15[0];
-      var __rh3 = ____id15[1];
-      var __bs21 = cut(____id15, 2);
-      var ____id16 = bind(__lh3, __rh3);
-      var __id17 = ____id16[0];
-      var __val1 = ____id16[1];
-      var __bs12 = cut(____id16, 2);
+      var ____id19 = __bs11;
+      var __lh3 = ____id19[0];
+      var __rh3 = ____id19[1];
+      var __bs21 = cut(____id19, 2);
+      var ____id20 = bind(__lh3, __rh3);
+      var __id21 = ____id20[0];
+      var __val1 = ____id20[1];
+      var __bs12 = cut(____id20, 2);
       var __renames1 = [];
-      if (! id_literal63(__id17)) {
-        var __id121 = unique(__id17);
-        __renames1 = [__id17, __id121];
-        __id17 = __id121;
+      if (! id_literal63(__id21)) {
+        var __id121 = unique(__id21);
+        __renames1 = [__id21, __id121];
+        __id21 = __id121;
       }
-      return ["do", ["%local", __id17, __val1], ["let-symbol", __renames1, join(["let", join(__bs12, __bs21)], __body9)]];
+      return ["do", ["%local", __id21, __val1], ["let-symbol", __renames1, join(["let", join(__bs12, __bs21)], __body13)]];
     }
   }
 }});
 setenv("with", {_stash: true, macro: function (x, v) {
-  var ____r25 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __x84 = destash33(x, ____r25);
-  var __v3 = destash33(v, ____r25);
-  var ____id19 = ____r25;
-  var __body11 = cut(____id19, 0);
-  return join(["let", [__x84, __v3]], __body11, [__x84]);
+  var ____r39 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __x141 = destash33(x, ____r39);
+  var __v4 = destash33(v, ____r39);
+  var ____id23 = ____r39;
+  var __body15 = cut(____id23, 0);
+  return join(["let", [__x141, __v4]], __body15, [__x141]);
 }});
 setenv("let-when", {_stash: true, macro: function (x, v) {
-  var ____r27 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __x94 = destash33(x, ____r27);
-  var __v5 = destash33(v, ____r27);
-  var ____id21 = ____r27;
-  var __body13 = cut(____id21, 0);
+  var ____r41 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __x151 = destash33(x, ____r41);
+  var __v6 = destash33(v, ____r41);
+  var ____id25 = ____r41;
+  var __body17 = cut(____id25, 0);
   var __y1 = unique("y");
-  return ["let", __y1, __v5, ["when", ["yes", __y1], join(["let", [__x94, __y1]], __body13)]];
+  return ["let", __y1, __v6, ["when", ["yes", __y1], join(["let", [__x151, __y1]], __body17)]];
 }});
 setenv("define-macro", {_stash: true, macro: function (name, args) {
-  var ____r29 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __name1 = destash33(name, ____r29);
-  var __args3 = destash33(args, ____r29);
-  var ____id23 = ____r29;
-  var __body15 = cut(____id23, 0);
-  var ____x103 = ["setenv", ["quote", __name1]];
-  ____x103.macro = join(["fn", __args3], __body15);
-  var __form1 = ____x103;
-  _eval(__form1);
-  return __form1;
-}});
-setenv("define-special", {_stash: true, macro: function (name, args) {
-  var ____r31 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __name3 = destash33(name, ____r31);
-  var __args5 = destash33(args, ____r31);
-  var ____id25 = ____r31;
-  var __body17 = cut(____id25, 0);
-  var ____x109 = ["setenv", ["quote", __name3]];
-  ____x109.special = join(["fn", __args5], __body17);
-  var __form3 = join(____x109, keys(__body17));
+  var ____r43 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __name3 = destash33(name, ____r43);
+  var __args3 = destash33(args, ____r43);
+  var ____id27 = ____r43;
+  var __body19 = cut(____id27, 0);
+  var ____x160 = ["setenv", ["quote", __name3]];
+  ____x160.macro = join(["fn", __args3], __body19);
+  var __form3 = ____x160;
   _eval(__form3);
   return __form3;
 }});
+setenv("define-special", {_stash: true, macro: function (name, args) {
+  var ____r45 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __name5 = destash33(name, ____r45);
+  var __args5 = destash33(args, ____r45);
+  var ____id29 = ____r45;
+  var __body21 = cut(____id29, 0);
+  var ____x166 = ["setenv", ["quote", __name5]];
+  ____x166.special = join(["fn", __args5], __body21);
+  var __form5 = join(____x166, keys(__body21));
+  _eval(__form5);
+  return __form5;
+}});
 setenv("define-symbol", {_stash: true, macro: function (name, expansion) {
   setenv(name, {_stash: true, symbol: expansion});
-  var ____x115 = ["setenv", ["quote", name]];
-  ____x115.symbol = ["quote", expansion];
-  return ____x115;
+  var ____x172 = ["setenv", ["quote", name]];
+  ____x172.symbol = ["quote", expansion];
+  return ____x172;
 }});
-setenv("define-reader", {_stash: true, macro: function (__x123) {
-  var ____id28 = __x123;
-  var __char1 = ____id28[0];
-  var __s1 = ____id28[1];
-  var ____r35 = unstash(Array.prototype.slice.call(arguments, 1));
-  var ____x123 = destash33(__x123, ____r35);
-  var ____id29 = ____r35;
-  var __body19 = cut(____id29, 0);
-  return ["set", ["get", "read-table", __char1], join(["fn", [__s1]], __body19)];
+setenv("define-reader", {_stash: true, macro: function (__x180) {
+  var ____id32 = __x180;
+  var __char1 = ____id32[0];
+  var __s1 = ____id32[1];
+  var ____r49 = unstash(Array.prototype.slice.call(arguments, 1));
+  var ____x180 = destash33(__x180, ____r49);
+  var ____id33 = ____r49;
+  var __body23 = cut(____id33, 0);
+  return ["set", ["get", "read-table", __char1], join(["fn", [__s1]], __body23)];
 }});
 setenv("define", {_stash: true, macro: function (name, x) {
-  var ____r37 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __name5 = destash33(name, ____r37);
-  var __x131 = destash33(x, ____r37);
-  var ____id31 = ____r37;
-  var __body21 = cut(____id31, 0);
-  setenv(__name5, {_stash: true, variable: true});
-  if (some63(__body21)) {
-    return join(["%local-function", __name5], bind42(__x131, __body21));
+  var ____r51 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __name7 = destash33(name, ____r51);
+  var __x188 = destash33(x, ____r51);
+  var ____id35 = ____r51;
+  var __body25 = cut(____id35, 0);
+  setenv(__name7, {_stash: true, variable: true});
+  if (some63(__body25)) {
+    return join(["%local-function", __name7], bind42(__x188, __body25));
   } else {
-    return ["%local", __name5, __x131];
+    return ["%local", __name7, __x188];
   }
 }});
 setenv("define-global", {_stash: true, macro: function (name, x) {
-  var ____r39 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __name7 = destash33(name, ____r39);
-  var __x137 = destash33(x, ____r39);
-  var ____id33 = ____r39;
-  var __body23 = cut(____id33, 0);
-  setenv(__name7, {_stash: true, toplevel: true, variable: true});
-  if (some63(__body23)) {
-    return join(["%global-function", __name7], bind42(__x137, __body23));
+  var ____r53 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __name9 = destash33(name, ____r53);
+  var __x194 = destash33(x, ____r53);
+  var ____id37 = ____r53;
+  var __body27 = cut(____id37, 0);
+  setenv(__name9, {_stash: true, toplevel: true, variable: true});
+  if (some63(__body27)) {
+    return join(["%global-function", __name9], bind42(__x194, __body27));
   } else {
-    return ["set", __name7, __x137];
+    return ["set", __name9, __x194];
   }
 }});
 setenv("with-frame", {_stash: true, macro: function () {
-  var __body25 = unstash(Array.prototype.slice.call(arguments, 0));
-  var __x147 = unique("x");
-  return ["do", ["add", "environment", ["obj"]], ["with", __x147, join(["do"], __body25), ["drop", "environment"]]];
+  var __body29 = unstash(Array.prototype.slice.call(arguments, 0));
+  var __x204 = unique("x");
+  return ["do", ["add", "environment", ["obj"]], ["with", __x204, join(["do"], __body29), ["drop", "environment"]]];
 }});
-setenv("with-bindings", {_stash: true, macro: function (__x159) {
-  var ____id36 = __x159;
-  var __names1 = ____id36[0];
-  var ____r41 = unstash(Array.prototype.slice.call(arguments, 1));
-  var ____x159 = destash33(__x159, ____r41);
-  var ____id37 = ____r41;
-  var __body27 = cut(____id37, 0);
-  var __x160 = unique("x");
-  var ____x163 = ["setenv", __x160];
-  ____x163.variable = true;
-  return join(["with-frame", ["each", __x160, __names1, ____x163]], __body27);
+setenv("with-bindings", {_stash: true, macro: function (__x216) {
+  var ____id40 = __x216;
+  var __names1 = ____id40[0];
+  var ____r55 = unstash(Array.prototype.slice.call(arguments, 1));
+  var ____x216 = destash33(__x216, ____r55);
+  var ____id41 = ____r55;
+  var __body31 = cut(____id41, 0);
+  var __x217 = unique("x");
+  var ____x220 = ["setenv", __x217];
+  ____x220.variable = true;
+  return join(["with-frame", ["each", __x217, __names1, ____x220]], __body31);
 }});
 setenv("let-macro", {_stash: true, macro: function (definitions) {
-  var ____r44 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __definitions1 = destash33(definitions, ____r44);
-  var ____id39 = ____r44;
-  var __body29 = cut(____id39, 0);
+  var ____r58 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __definitions1 = destash33(definitions, ____r58);
+  var ____id43 = ____r58;
+  var __body33 = cut(____id43, 0);
   add(environment, {});
   map(function (m) {
     return macroexpand(join(["define-macro"], m));
   }, __definitions1);
-  var ____x167 = join(["do"], macroexpand(__body29));
+  var ____x224 = join(["do"], macroexpand(__body33));
   drop(environment);
-  return ____x167;
+  return ____x224;
 }});
 setenv("let-symbol", {_stash: true, macro: function (expansions) {
-  var ____r48 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __expansions1 = destash33(expansions, ____r48);
-  var ____id42 = ____r48;
-  var __body31 = cut(____id42, 0);
+  var ____r62 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __expansions1 = destash33(expansions, ____r62);
+  var ____id46 = ____r62;
+  var __body35 = cut(____id46, 0);
   add(environment, {});
-  map(function (__x175) {
-    var ____id43 = __x175;
-    var __name9 = ____id43[0];
-    var __exp1 = ____id43[1];
-    return macroexpand(["define-symbol", __name9, __exp1]);
+  map(function (__x232) {
+    var ____id47 = __x232;
+    var __name11 = ____id47[0];
+    var __exp1 = ____id47[1];
+    return macroexpand(["define-symbol", __name11, __exp1]);
   }, pair(__expansions1));
-  var ____x174 = join(["do"], macroexpand(__body31));
+  var ____x231 = join(["do"], macroexpand(__body35));
   drop(environment);
-  return ____x174;
+  return ____x231;
 }});
 setenv("let-unique", {_stash: true, macro: function (names) {
-  var ____r52 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __names3 = destash33(names, ____r52);
-  var ____id45 = ____r52;
-  var __body33 = cut(____id45, 0);
+  var ____r66 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __names3 = destash33(names, ____r66);
+  var ____id49 = ____r66;
+  var __body37 = cut(____id49, 0);
   var __bs3 = map(function (n) {
     return [n, ["unique", ["quote", n]]];
   }, __names3);
-  return join(["let", apply(join, __bs3)], __body33);
+  return join(["let", apply(join, __bs3)], __body37);
 }});
 setenv("fn", {_stash: true, macro: function (args) {
-  var ____r55 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __args7 = destash33(args, ____r55);
-  var ____id47 = ____r55;
-  var __body35 = cut(____id47, 0);
-  return join(["%function"], bind42(__args7, __body35));
+  var ____r69 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __args7 = destash33(args, ____r69);
+  var ____id51 = ____r69;
+  var __body39 = cut(____id51, 0);
+  return join(["%function"], bind42(__args7, __body39));
 }});
 setenv("apply", {_stash: true, macro: function (f) {
-  var ____r57 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __f1 = destash33(f, ____r57);
-  var ____id49 = ____r57;
-  var __args9 = cut(____id49, 0);
+  var ____r71 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __f1 = destash33(f, ____r71);
+  var ____id53 = ____r71;
+  var __args9 = cut(____id53, 0);
   if (_35(__args9) > 1) {
     return [["do", "apply"], __f1, ["join", join(["list"], almost(__args9)), last(__args9)]];
   } else {
@@ -1037,61 +1102,61 @@ setenv("guard", {_stash: true, macro: function (expr) {
   if (target === "js") {
     return [["fn", join(), ["%try", ["list", true, expr]]]];
   } else {
-    var ____x233 = ["obj"];
-    ____x233.stack = [["get", "debug", ["quote", "traceback"]]];
-    ____x233.message = ["if", ["string?", "m"], ["clip", "m", ["+", ["search", "m", "\": \""], 2]], ["nil?", "m"], "\"\"", ["str", "m"]];
-    return ["list", ["xpcall", ["fn", join(), expr], ["fn", ["m"], ["if", ["obj?", "m"], "m", ____x233]]]];
+    var ____x290 = ["obj"];
+    ____x290.stack = [["get", "debug", ["quote", "traceback"]]];
+    ____x290.message = ["if", ["string?", "m"], ["clip", "m", ["+", ["search", "m", "\": \""], 2]], ["nil?", "m"], "\"\"", ["str", "m"]];
+    return ["list", ["xpcall", ["fn", join(), expr], ["fn", ["m"], ["if", ["obj?", "m"], "m", ____x290]]]];
   }
 }});
 setenv("each", {_stash: true, macro: function (x, t) {
-  var ____r61 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __x258 = destash33(x, ____r61);
-  var __t1 = destash33(t, ____r61);
-  var ____id52 = ____r61;
-  var __body37 = cut(____id52, 0);
+  var ____r75 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __x315 = destash33(x, ____r75);
+  var __t1 = destash33(t, ____r75);
+  var ____id56 = ____r75;
+  var __body41 = cut(____id56, 0);
   var __o3 = unique("o");
   var __n3 = unique("n");
   var __i3 = unique("i");
-  var __e9;
-  if (atom63(__x258)) {
-    __e9 = [__i3, __x258];
-  } else {
-    var __e10;
-    if (_35(__x258) > 1) {
-      __e10 = __x258;
-    } else {
-      __e10 = [__i3, hd(__x258)];
-    }
-    __e9 = __e10;
-  }
-  var ____id53 = __e9;
-  var __k5 = ____id53[0];
-  var __v7 = ____id53[1];
   var __e11;
-  if (target === "lua") {
-    __e11 = __body37;
+  if (atom63(__x315)) {
+    __e11 = [__i3, __x315];
   } else {
-    __e11 = [join(["let", __k5, ["if", ["numeric?", __k5], ["parseInt", __k5], __k5]], __body37)];
+    var __e12;
+    if (_35(__x315) > 1) {
+      __e12 = __x315;
+    } else {
+      __e12 = [__i3, hd(__x315)];
+    }
+    __e11 = __e12;
   }
-  return ["let", [__o3, __t1, __k5, "nil"], ["%for", __o3, __k5, join(["let", [__v7, ["get", __o3, __k5]]], __e11)]];
+  var ____id57 = __e11;
+  var __k5 = ____id57[0];
+  var __v8 = ____id57[1];
+  var __e13;
+  if (target === "lua") {
+    __e13 = __body41;
+  } else {
+    __e13 = [join(["let", __k5, ["if", ["numeric?", __k5], ["parseInt", __k5], __k5]], __body41)];
+  }
+  return ["let", [__o3, __t1, __k5, "nil"], ["%for", __o3, __k5, join(["let", [__v8, ["get", __o3, __k5]]], __e13)]];
 }});
 setenv("for", {_stash: true, macro: function (i, to) {
-  var ____r63 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __i5 = destash33(i, ____r63);
-  var __to1 = destash33(to, ____r63);
-  var ____id55 = ____r63;
-  var __body39 = cut(____id55, 0);
-  return ["let", __i5, 0, join(["while", ["<", __i5, __to1]], __body39, [["inc", __i5]])];
+  var ____r77 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __i5 = destash33(i, ____r77);
+  var __to1 = destash33(to, ____r77);
+  var ____id59 = ____r77;
+  var __body43 = cut(____id59, 0);
+  return ["let", __i5, 0, join(["while", ["<", __i5, __to1]], __body43, [["inc", __i5]])];
 }});
 setenv("step", {_stash: true, macro: function (v, t) {
-  var ____r65 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __v9 = destash33(v, ____r65);
-  var __t3 = destash33(t, ____r65);
-  var ____id57 = ____r65;
-  var __body41 = cut(____id57, 0);
-  var __x290 = unique("x");
+  var ____r79 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __v10 = destash33(v, ____r79);
+  var __t3 = destash33(t, ____r79);
+  var ____id61 = ____r79;
+  var __body45 = cut(____id61, 0);
+  var __x347 = unique("x");
   var __i7 = unique("i");
-  return ["let", [__x290, __t3], ["for", __i7, ["#", __x290], join(["let", [__v9, ["at", __x290, __i7]]], __body41)]];
+  return ["let", [__x347, __t3], ["for", __i7, ["#", __x347], join(["let", [__v10, ["at", __x347, __i7]]], __body45)]];
 }});
 setenv("set-of", {_stash: true, macro: function () {
   var __xs1 = unstash(Array.prototype.slice.call(arguments, 0));
@@ -1099,15 +1164,15 @@ setenv("set-of", {_stash: true, macro: function () {
   var ____o5 = __xs1;
   var ____i9 = undefined;
   for (____i9 in ____o5) {
-    var __x300 = ____o5[____i9];
-    var __e12;
+    var __x357 = ____o5[____i9];
+    var __e14;
     if (numeric63(____i9)) {
-      __e12 = parseInt(____i9);
+      __e14 = parseInt(____i9);
     } else {
-      __e12 = ____i9;
+      __e14 = ____i9;
     }
-    var ____i91 = __e12;
-    __l3[__x300] = true;
+    var ____i91 = __e14;
+    __l3[__x357] = true;
   }
   return join(["obj"], __l3);
 }});
@@ -1119,40 +1184,40 @@ setenv("target", {_stash: true, macro: function () {
   return __clauses3[target];
 }});
 setenv("join!", {_stash: true, macro: function (a) {
-  var ____r69 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __a3 = destash33(a, ____r69);
-  var ____id59 = ____r69;
-  var __bs5 = cut(____id59, 0);
+  var ____r83 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __a3 = destash33(a, ____r83);
+  var ____id63 = ____r83;
+  var __bs5 = cut(____id63, 0);
   return ["set", __a3, join(["join", __a3], __bs5)];
 }});
 setenv("cat!", {_stash: true, macro: function (a) {
-  var ____r71 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __a5 = destash33(a, ____r71);
-  var ____id61 = ____r71;
-  var __bs7 = cut(____id61, 0);
+  var ____r85 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __a5 = destash33(a, ____r85);
+  var ____id65 = ____r85;
+  var __bs7 = cut(____id65, 0);
   return ["set", __a5, join(["cat", __a5], __bs7)];
 }});
 setenv("inc", {_stash: true, macro: function (n, by) {
-  var __e13;
+  var __e15;
   if (nil63(by)) {
-    __e13 = 1;
+    __e15 = 1;
   } else {
-    __e13 = by;
+    __e15 = by;
   }
-  return ["set", n, ["+", n, __e13]];
+  return ["set", n, ["+", n, __e15]];
 }});
 setenv("dec", {_stash: true, macro: function (n, by) {
-  var __e14;
+  var __e16;
   if (nil63(by)) {
-    __e14 = 1;
+    __e16 = 1;
   } else {
-    __e14 = by;
+    __e16 = by;
   }
-  return ["set", n, ["-", n, __e14]];
+  return ["set", n, ["-", n, __e16]];
 }});
 setenv("with-indent", {_stash: true, macro: function (form) {
-  var __x325 = unique("x");
-  return ["do", ["inc", "indent-level"], ["with", __x325, form, ["dec", "indent-level"]]];
+  var __x382 = unique("x");
+  return ["do", ["inc", "indent-level"], ["with", __x382, form, ["dec", "indent-level"]]];
 }});
 setenv("export", {_stash: true, macro: function () {
   var __names5 = unstash(Array.prototype.slice.call(arguments, 0));
@@ -1161,28 +1226,28 @@ setenv("export", {_stash: true, macro: function () {
       return ["set", ["get", "exports", ["quote", k]], k];
     }, __names5));
   } else {
-    var __x341 = {};
+    var __x398 = {};
     var ____o7 = __names5;
     var ____i11 = undefined;
     for (____i11 in ____o7) {
       var __k7 = ____o7[____i11];
-      var __e15;
+      var __e17;
       if (numeric63(____i11)) {
-        __e15 = parseInt(____i11);
+        __e17 = parseInt(____i11);
       } else {
-        __e15 = ____i11;
+        __e17 = ____i11;
       }
-      var ____i111 = __e15;
-      __x341[__k7] = __k7;
+      var ____i111 = __e17;
+      __x398[__k7] = __k7;
     }
     return ["return", join(["%object"], mapo(function (x) {
       return x;
-    }, __x341))];
+    }, __x398))];
   }
 }});
 setenv("when-compiling", {_stash: true, macro: function () {
-  var __body43 = unstash(Array.prototype.slice.call(arguments, 0));
-  return _eval(join(["do"], __body43));
+  var __body47 = unstash(Array.prototype.slice.call(arguments, 0));
+  return _eval(join(["do"], __body47));
 }});
 var reader = require("reader");
 var compiler = require("compiler");

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -636,13 +636,78 @@ end})
 setenv("quasiquote", {_stash = true, macro = function (form)
   return quasiexpand(form, 1)
 end})
+function gv_get(place, _do)
+  local __place = macroexpand(place)
+  if atom63(__place) or hd(__place) == "get" and nil63(getenv("get", "gv-expander")) then
+    return _do(__place, function (v)
+      return {"%set", __place, v}
+    end)
+  else
+    local __head = hd(__place)
+    local __gf = getenv(__head, "gv-expander")
+    if __gf then
+      return apply(__gf, join({_do}, tl(__place)))
+    else
+      error(str(__place) .. " is not a valid place expression")
+    end
+  end
+end
+setenv("gv-letplace", {_stash = true, macro = function (vars, place, ...)
+  local ____r7 = unstash({...})
+  local __vars1 = destash33(vars, ____r7)
+  local __place2 = destash33(place, ____r7)
+  local ____id1 = ____r7
+  local __body1 = cut(____id1, 0)
+  return {"gv-get", __place2, join({"fn", __vars1}, __body1)}
+end})
+setenv("gv-define-expander", {_stash = true, macro = function (name, handler)
+  local ____x9 = {"setenv", {"quote", name}}
+  ____x9["gv-expander"] = handler
+  local __form1 = ____x9
+  _eval(__form1)
+  return __form1
+end})
+function gv__defsetter(name, setter, _do, args, vars)
+  if none63(args) then
+    local __vars2 = reverse(vars)
+    return _do(join({name}, __vars2), function (v)
+      return apply(setter, join({v}, __vars2))
+    end)
+  else
+    local __v = hd(args)
+    return gv__defsetter(name, setter, _do, tl(args), join({__v}, vars))
+  end
+end
+setenv("gv-define-setter", {_stash = true, macro = function (name, arglist, ...)
+  local ____r13 = unstash({...})
+  local __name1 = destash33(name, ____r13)
+  local __arglist1 = destash33(arglist, ____r13)
+  local ____id3 = ____r13
+  local __body3 = cut(____id3, 0)
+  local ____x23 = {"_do"}
+  ____x23.rest = "args"
+  return {"gv-define-expander", __name1, {"fn", ____x23, {"gv--defsetter", {"quote", __name1}, join({"fn", __arglist1}, __body3), "_do", "args"}}}
+end})
+setenv("gv-define-simple-setter", {_stash = true, macro = function (name, setter, fix_return)
+  local ____x45 = {"val"}
+  ____x45.rest = "args"
+  local __e9
+  if fix_return then
+    __e9 = {"let", "v", "val", {"quasiquote", {"do", {{"unquote", {"quote", setter}}, {"unquote-splicing", "args"}, {"unquote", "v"}}, {"unquote", "v"}}}}
+  else
+    __e9 = {"quasiquote", {{"unquote", {"quote", setter}}, {"unquote-splicing", "args"}, {"unquote", "val"}}}
+  end
+  return {"gv-define-setter", name, ____x45, __e9}
+end})
 setenv("set", {_stash = true, macro = function (...)
   local __args1 = unstash({...})
-  return join({"do"}, map(function (__x5)
-    local ____id1 = __x5
-    local __lh1 = ____id1[1]
-    local __rh1 = ____id1[2]
-    return {"%set", __lh1, __rh1}
+  return join({"do"}, map(function (__x65)
+    local ____id5 = __x65
+    local __lh1 = ____id5[1]
+    local __rh1 = ____id5[2]
+    return gv_get(__lh1, function (_getter, setter)
+      return setter(__rh1)
+    end)
   end, pair(__args1)))
 end})
 setenv("at", {_stash = true, macro = function (l, i)
@@ -663,22 +728,22 @@ setenv("wipe", {_stash = true, macro = function (place)
   end
 end})
 setenv("list", {_stash = true, macro = function (...)
-  local __body1 = unstash({...})
-  local __x24 = unique("x")
+  local __body5 = unstash({...})
+  local __x83 = unique("x")
   local __l1 = {}
   local __forms1 = {}
-  local ____o1 = __body1
+  local ____o1 = __body5
   local __k2 = nil
   for __k2 in next, ____o1 do
-    local __v1 = ____o1[__k2]
+    local __v2 = ____o1[__k2]
     if number63(__k2) then
-      __l1[__k2] = __v1
+      __l1[__k2] = __v2
     else
-      add(__forms1, {"set", {"get", __x24, {"quote", __k2}}, __v1})
+      add(__forms1, {"set", {"get", __x83, {"quote", __k2}}, __v2})
     end
   end
   if some63(__forms1) then
-    return join({"let", __x24, join({"%array"}, __l1)}, __forms1, {__x24})
+    return join({"let", __x83, join({"%array"}, __l1)}, __forms1, {__x83})
   else
     return join({"%array"}, __l1)
   end
@@ -688,18 +753,18 @@ setenv("if", {_stash = true, macro = function (...)
   return hd(expand_if(__branches1))
 end})
 setenv("case", {_stash = true, macro = function (expr, ...)
-  local ____r13 = unstash({...})
-  local __expr1 = destash33(expr, ____r13)
-  local ____id4 = ____r13
-  local __clauses1 = cut(____id4, 0)
-  local __x45 = unique("x")
+  local ____r27 = unstash({...})
+  local __expr1 = destash33(expr, ____r27)
+  local ____id8 = ____r27
+  local __clauses1 = cut(____id8, 0)
+  local __x104 = unique("x")
   local __eq1 = function (_)
-    return {"=", {"quote", _}, __x45}
+    return {"=", {"quote", _}, __x104}
   end
-  local __cl1 = function (__x48)
-    local ____id5 = __x48
-    local __a1 = ____id5[1]
-    local __b1 = ____id5[2]
+  local __cl1 = function (__x107)
+    local ____id9 = __x107
+    local __a1 = ____id9[1]
+    local __b1 = ____id9[2]
     if nil63(__b1) then
       return {__a1}
     else
@@ -716,208 +781,208 @@ setenv("case", {_stash = true, macro = function (expr, ...)
       end
     end
   end
-  return {"let", __x45, __expr1, join({"if"}, apply(join, map(__cl1, pair(__clauses1))))}
+  return {"let", __x104, __expr1, join({"if"}, apply(join, map(__cl1, pair(__clauses1))))}
 end})
 setenv("when", {_stash = true, macro = function (cond, ...)
-  local ____r17 = unstash({...})
-  local __cond1 = destash33(cond, ____r17)
-  local ____id7 = ____r17
-  local __body3 = cut(____id7, 0)
-  return {"if", __cond1, join({"do"}, __body3)}
+  local ____r31 = unstash({...})
+  local __cond1 = destash33(cond, ____r31)
+  local ____id11 = ____r31
+  local __body7 = cut(____id11, 0)
+  return {"if", __cond1, join({"do"}, __body7)}
 end})
 setenv("unless", {_stash = true, macro = function (cond, ...)
-  local ____r19 = unstash({...})
-  local __cond3 = destash33(cond, ____r19)
-  local ____id9 = ____r19
-  local __body5 = cut(____id9, 0)
-  return {"if", {"not", __cond3}, join({"do"}, __body5)}
+  local ____r33 = unstash({...})
+  local __cond3 = destash33(cond, ____r33)
+  local ____id13 = ____r33
+  local __body9 = cut(____id13, 0)
+  return {"if", {"not", __cond3}, join({"do"}, __body9)}
 end})
 setenv("obj", {_stash = true, macro = function (...)
-  local __body7 = unstash({...})
+  local __body11 = unstash({...})
   return join({"%object"}, mapo(function (x)
     return x
-  end, __body7))
+  end, __body11))
 end})
 setenv("let", {_stash = true, macro = function (bs, ...)
-  local ____r23 = unstash({...})
-  local __bs11 = destash33(bs, ____r23)
-  local ____id14 = ____r23
-  local __body9 = cut(____id14, 0)
+  local ____r37 = unstash({...})
+  local __bs11 = destash33(bs, ____r37)
+  local ____id18 = ____r37
+  local __body13 = cut(____id18, 0)
   if atom63(__bs11) then
-    return join({"let", {__bs11, hd(__body9)}}, tl(__body9))
+    return join({"let", {__bs11, hd(__body13)}}, tl(__body13))
   else
     if none63(__bs11) then
-      return join({"do"}, __body9)
+      return join({"do"}, __body13)
     else
-      local ____id15 = __bs11
-      local __lh3 = ____id15[1]
-      local __rh3 = ____id15[2]
-      local __bs21 = cut(____id15, 2)
-      local ____id16 = bind(__lh3, __rh3)
-      local __id17 = ____id16[1]
-      local __val1 = ____id16[2]
-      local __bs12 = cut(____id16, 2)
+      local ____id19 = __bs11
+      local __lh3 = ____id19[1]
+      local __rh3 = ____id19[2]
+      local __bs21 = cut(____id19, 2)
+      local ____id20 = bind(__lh3, __rh3)
+      local __id21 = ____id20[1]
+      local __val1 = ____id20[2]
+      local __bs12 = cut(____id20, 2)
       local __renames1 = {}
-      if not id_literal63(__id17) then
-        local __id121 = unique(__id17)
-        __renames1 = {__id17, __id121}
-        __id17 = __id121
+      if not id_literal63(__id21) then
+        local __id121 = unique(__id21)
+        __renames1 = {__id21, __id121}
+        __id21 = __id121
       end
-      return {"do", {"%local", __id17, __val1}, {"let-symbol", __renames1, join({"let", join(__bs12, __bs21)}, __body9)}}
+      return {"do", {"%local", __id21, __val1}, {"let-symbol", __renames1, join({"let", join(__bs12, __bs21)}, __body13)}}
     end
   end
 end})
 setenv("with", {_stash = true, macro = function (x, v, ...)
-  local ____r25 = unstash({...})
-  local __x93 = destash33(x, ____r25)
-  local __v3 = destash33(v, ____r25)
-  local ____id19 = ____r25
-  local __body11 = cut(____id19, 0)
-  return join({"let", {__x93, __v3}}, __body11, {__x93})
+  local ____r39 = unstash({...})
+  local __x152 = destash33(x, ____r39)
+  local __v4 = destash33(v, ____r39)
+  local ____id23 = ____r39
+  local __body15 = cut(____id23, 0)
+  return join({"let", {__x152, __v4}}, __body15, {__x152})
 end})
 setenv("let-when", {_stash = true, macro = function (x, v, ...)
-  local ____r27 = unstash({...})
-  local __x104 = destash33(x, ____r27)
-  local __v5 = destash33(v, ____r27)
-  local ____id21 = ____r27
-  local __body13 = cut(____id21, 0)
+  local ____r41 = unstash({...})
+  local __x163 = destash33(x, ____r41)
+  local __v6 = destash33(v, ____r41)
+  local ____id25 = ____r41
+  local __body17 = cut(____id25, 0)
   local __y1 = unique("y")
-  return {"let", __y1, __v5, {"when", {"yes", __y1}, join({"let", {__x104, __y1}}, __body13)}}
+  return {"let", __y1, __v6, {"when", {"yes", __y1}, join({"let", {__x163, __y1}}, __body17)}}
 end})
 setenv("define-macro", {_stash = true, macro = function (name, args, ...)
-  local ____r29 = unstash({...})
-  local __name1 = destash33(name, ____r29)
-  local __args3 = destash33(args, ____r29)
-  local ____id23 = ____r29
-  local __body15 = cut(____id23, 0)
-  local ____x114 = {"setenv", {"quote", __name1}}
-  ____x114.macro = join({"fn", __args3}, __body15)
-  local __form1 = ____x114
-  _eval(__form1)
-  return __form1
-end})
-setenv("define-special", {_stash = true, macro = function (name, args, ...)
-  local ____r31 = unstash({...})
-  local __name3 = destash33(name, ____r31)
-  local __args5 = destash33(args, ____r31)
-  local ____id25 = ____r31
-  local __body17 = cut(____id25, 0)
-  local ____x121 = {"setenv", {"quote", __name3}}
-  ____x121.special = join({"fn", __args5}, __body17)
-  local __form3 = join(____x121, keys(__body17))
+  local ____r43 = unstash({...})
+  local __name3 = destash33(name, ____r43)
+  local __args3 = destash33(args, ____r43)
+  local ____id27 = ____r43
+  local __body19 = cut(____id27, 0)
+  local ____x173 = {"setenv", {"quote", __name3}}
+  ____x173.macro = join({"fn", __args3}, __body19)
+  local __form3 = ____x173
   _eval(__form3)
   return __form3
 end})
+setenv("define-special", {_stash = true, macro = function (name, args, ...)
+  local ____r45 = unstash({...})
+  local __name5 = destash33(name, ____r45)
+  local __args5 = destash33(args, ____r45)
+  local ____id29 = ____r45
+  local __body21 = cut(____id29, 0)
+  local ____x180 = {"setenv", {"quote", __name5}}
+  ____x180.special = join({"fn", __args5}, __body21)
+  local __form5 = join(____x180, keys(__body21))
+  _eval(__form5)
+  return __form5
+end})
 setenv("define-symbol", {_stash = true, macro = function (name, expansion)
   setenv(name, {_stash = true, symbol = expansion})
-  local ____x127 = {"setenv", {"quote", name}}
-  ____x127.symbol = {"quote", expansion}
-  return ____x127
+  local ____x186 = {"setenv", {"quote", name}}
+  ____x186.symbol = {"quote", expansion}
+  return ____x186
 end})
-setenv("define-reader", {_stash = true, macro = function (__x135, ...)
-  local ____id28 = __x135
-  local __char1 = ____id28[1]
-  local __s1 = ____id28[2]
-  local ____r35 = unstash({...})
-  local ____x135 = destash33(__x135, ____r35)
-  local ____id29 = ____r35
-  local __body19 = cut(____id29, 0)
-  return {"set", {"get", "read-table", __char1}, join({"fn", {__s1}}, __body19)}
+setenv("define-reader", {_stash = true, macro = function (__x194, ...)
+  local ____id32 = __x194
+  local __char1 = ____id32[1]
+  local __s1 = ____id32[2]
+  local ____r49 = unstash({...})
+  local ____x194 = destash33(__x194, ____r49)
+  local ____id33 = ____r49
+  local __body23 = cut(____id33, 0)
+  return {"set", {"get", "read-table", __char1}, join({"fn", {__s1}}, __body23)}
 end})
 setenv("define", {_stash = true, macro = function (name, x, ...)
-  local ____r37 = unstash({...})
-  local __name5 = destash33(name, ____r37)
-  local __x145 = destash33(x, ____r37)
-  local ____id31 = ____r37
-  local __body21 = cut(____id31, 0)
-  setenv(__name5, {_stash = true, variable = true})
-  if some63(__body21) then
-    return join({"%local-function", __name5}, bind42(__x145, __body21))
+  local ____r51 = unstash({...})
+  local __name7 = destash33(name, ____r51)
+  local __x204 = destash33(x, ____r51)
+  local ____id35 = ____r51
+  local __body25 = cut(____id35, 0)
+  setenv(__name7, {_stash = true, variable = true})
+  if some63(__body25) then
+    return join({"%local-function", __name7}, bind42(__x204, __body25))
   else
-    return {"%local", __name5, __x145}
+    return {"%local", __name7, __x204}
   end
 end})
 setenv("define-global", {_stash = true, macro = function (name, x, ...)
-  local ____r39 = unstash({...})
-  local __name7 = destash33(name, ____r39)
-  local __x152 = destash33(x, ____r39)
-  local ____id33 = ____r39
-  local __body23 = cut(____id33, 0)
-  setenv(__name7, {_stash = true, toplevel = true, variable = true})
-  if some63(__body23) then
-    return join({"%global-function", __name7}, bind42(__x152, __body23))
+  local ____r53 = unstash({...})
+  local __name9 = destash33(name, ____r53)
+  local __x211 = destash33(x, ____r53)
+  local ____id37 = ____r53
+  local __body27 = cut(____id37, 0)
+  setenv(__name9, {_stash = true, toplevel = true, variable = true})
+  if some63(__body27) then
+    return join({"%global-function", __name9}, bind42(__x211, __body27))
   else
-    return {"set", __name7, __x152}
+    return {"set", __name9, __x211}
   end
 end})
 setenv("with-frame", {_stash = true, macro = function (...)
-  local __body25 = unstash({...})
-  local __x163 = unique("x")
-  return {"do", {"add", "environment", {"obj"}}, {"with", __x163, join({"do"}, __body25), {"drop", "environment"}}}
+  local __body29 = unstash({...})
+  local __x222 = unique("x")
+  return {"do", {"add", "environment", {"obj"}}, {"with", __x222, join({"do"}, __body29), {"drop", "environment"}}}
 end})
-setenv("with-bindings", {_stash = true, macro = function (__x175, ...)
-  local ____id36 = __x175
-  local __names1 = ____id36[1]
-  local ____r41 = unstash({...})
-  local ____x175 = destash33(__x175, ____r41)
-  local ____id37 = ____r41
-  local __body27 = cut(____id37, 0)
-  local __x177 = unique("x")
-  local ____x180 = {"setenv", __x177}
-  ____x180.variable = true
-  return join({"with-frame", {"each", __x177, __names1, ____x180}}, __body27)
+setenv("with-bindings", {_stash = true, macro = function (__x234, ...)
+  local ____id40 = __x234
+  local __names1 = ____id40[1]
+  local ____r55 = unstash({...})
+  local ____x234 = destash33(__x234, ____r55)
+  local ____id41 = ____r55
+  local __body31 = cut(____id41, 0)
+  local __x236 = unique("x")
+  local ____x239 = {"setenv", __x236}
+  ____x239.variable = true
+  return join({"with-frame", {"each", __x236, __names1, ____x239}}, __body31)
 end})
 setenv("let-macro", {_stash = true, macro = function (definitions, ...)
-  local ____r44 = unstash({...})
-  local __definitions1 = destash33(definitions, ____r44)
-  local ____id39 = ____r44
-  local __body29 = cut(____id39, 0)
+  local ____r58 = unstash({...})
+  local __definitions1 = destash33(definitions, ____r58)
+  local ____id43 = ____r58
+  local __body33 = cut(____id43, 0)
   add(environment, {})
   map(function (m)
     return macroexpand(join({"define-macro"}, m))
   end, __definitions1)
-  local ____x185 = join({"do"}, macroexpand(__body29))
+  local ____x244 = join({"do"}, macroexpand(__body33))
   drop(environment)
-  return ____x185
+  return ____x244
 end})
 setenv("let-symbol", {_stash = true, macro = function (expansions, ...)
-  local ____r48 = unstash({...})
-  local __expansions1 = destash33(expansions, ____r48)
-  local ____id42 = ____r48
-  local __body31 = cut(____id42, 0)
+  local ____r62 = unstash({...})
+  local __expansions1 = destash33(expansions, ____r62)
+  local ____id46 = ____r62
+  local __body35 = cut(____id46, 0)
   add(environment, {})
-  map(function (__x194)
-    local ____id43 = __x194
-    local __name9 = ____id43[1]
-    local __exp1 = ____id43[2]
-    return macroexpand({"define-symbol", __name9, __exp1})
+  map(function (__x253)
+    local ____id47 = __x253
+    local __name11 = ____id47[1]
+    local __exp1 = ____id47[2]
+    return macroexpand({"define-symbol", __name11, __exp1})
   end, pair(__expansions1))
-  local ____x193 = join({"do"}, macroexpand(__body31))
+  local ____x252 = join({"do"}, macroexpand(__body35))
   drop(environment)
-  return ____x193
+  return ____x252
 end})
 setenv("let-unique", {_stash = true, macro = function (names, ...)
-  local ____r52 = unstash({...})
-  local __names3 = destash33(names, ____r52)
-  local ____id45 = ____r52
-  local __body33 = cut(____id45, 0)
+  local ____r66 = unstash({...})
+  local __names3 = destash33(names, ____r66)
+  local ____id49 = ____r66
+  local __body37 = cut(____id49, 0)
   local __bs3 = map(function (n)
     return {n, {"unique", {"quote", n}}}
   end, __names3)
-  return join({"let", apply(join, __bs3)}, __body33)
+  return join({"let", apply(join, __bs3)}, __body37)
 end})
 setenv("fn", {_stash = true, macro = function (args, ...)
-  local ____r55 = unstash({...})
-  local __args7 = destash33(args, ____r55)
-  local ____id47 = ____r55
-  local __body35 = cut(____id47, 0)
-  return join({"%function"}, bind42(__args7, __body35))
+  local ____r69 = unstash({...})
+  local __args7 = destash33(args, ____r69)
+  local ____id51 = ____r69
+  local __body39 = cut(____id51, 0)
+  return join({"%function"}, bind42(__args7, __body39))
 end})
 setenv("apply", {_stash = true, macro = function (f, ...)
-  local ____r57 = unstash({...})
-  local __f1 = destash33(f, ____r57)
-  local ____id49 = ____r57
-  local __args9 = cut(____id49, 0)
+  local ____r71 = unstash({...})
+  local __f1 = destash33(f, ____r71)
+  local ____id53 = ____r71
+  local __args9 = cut(____id53, 0)
   if _35(__args9) > 1 then
     return {{"do", "apply"}, __f1, {"join", join({"list"}, almost(__args9)), last(__args9)}}
   else
@@ -928,61 +993,61 @@ setenv("guard", {_stash = true, macro = function (expr)
   if target == "js" then
     return {{"fn", join(), {"%try", {"list", true, expr}}}}
   else
-    local ____x255 = {"obj"}
-    ____x255.stack = {{"get", "debug", {"quote", "traceback"}}}
-    ____x255.message = {"if", {"string?", "m"}, {"clip", "m", {"+", {"search", "m", "\": \""}, 2}}, {"nil?", "m"}, "\"\"", {"str", "m"}}
-    return {"list", {"xpcall", {"fn", join(), expr}, {"fn", {"m"}, {"if", {"obj?", "m"}, "m", ____x255}}}}
+    local ____x314 = {"obj"}
+    ____x314.stack = {{"get", "debug", {"quote", "traceback"}}}
+    ____x314.message = {"if", {"string?", "m"}, {"clip", "m", {"+", {"search", "m", "\": \""}, 2}}, {"nil?", "m"}, "\"\"", {"str", "m"}}
+    return {"list", {"xpcall", {"fn", join(), expr}, {"fn", {"m"}, {"if", {"obj?", "m"}, "m", ____x314}}}}
   end
 end})
 setenv("each", {_stash = true, macro = function (x, t, ...)
-  local ____r61 = unstash({...})
-  local __x281 = destash33(x, ____r61)
-  local __t1 = destash33(t, ____r61)
-  local ____id52 = ____r61
-  local __body37 = cut(____id52, 0)
+  local ____r75 = unstash({...})
+  local __x340 = destash33(x, ____r75)
+  local __t1 = destash33(t, ____r75)
+  local ____id56 = ____r75
+  local __body41 = cut(____id56, 0)
   local __o3 = unique("o")
   local __n3 = unique("n")
   local __i3 = unique("i")
-  local __e8
-  if atom63(__x281) then
-    __e8 = {__i3, __x281}
-  else
-    local __e9
-    if _35(__x281) > 1 then
-      __e9 = __x281
-    else
-      __e9 = {__i3, hd(__x281)}
-    end
-    __e8 = __e9
-  end
-  local ____id53 = __e8
-  local __k4 = ____id53[1]
-  local __v7 = ____id53[2]
   local __e10
-  if target == "lua" then
-    __e10 = __body37
+  if atom63(__x340) then
+    __e10 = {__i3, __x340}
   else
-    __e10 = {join({"let", __k4, {"if", {"numeric?", __k4}, {"parseInt", __k4}, __k4}}, __body37)}
+    local __e11
+    if _35(__x340) > 1 then
+      __e11 = __x340
+    else
+      __e11 = {__i3, hd(__x340)}
+    end
+    __e10 = __e11
   end
-  return {"let", {__o3, __t1, __k4, "nil"}, {"%for", __o3, __k4, join({"let", {__v7, {"get", __o3, __k4}}}, __e10)}}
+  local ____id57 = __e10
+  local __k4 = ____id57[1]
+  local __v8 = ____id57[2]
+  local __e12
+  if target == "lua" then
+    __e12 = __body41
+  else
+    __e12 = {join({"let", __k4, {"if", {"numeric?", __k4}, {"parseInt", __k4}, __k4}}, __body41)}
+  end
+  return {"let", {__o3, __t1, __k4, "nil"}, {"%for", __o3, __k4, join({"let", {__v8, {"get", __o3, __k4}}}, __e12)}}
 end})
 setenv("for", {_stash = true, macro = function (i, to, ...)
-  local ____r63 = unstash({...})
-  local __i5 = destash33(i, ____r63)
-  local __to1 = destash33(to, ____r63)
-  local ____id55 = ____r63
-  local __body39 = cut(____id55, 0)
-  return {"let", __i5, 0, join({"while", {"<", __i5, __to1}}, __body39, {{"inc", __i5}})}
+  local ____r77 = unstash({...})
+  local __i5 = destash33(i, ____r77)
+  local __to1 = destash33(to, ____r77)
+  local ____id59 = ____r77
+  local __body43 = cut(____id59, 0)
+  return {"let", __i5, 0, join({"while", {"<", __i5, __to1}}, __body43, {{"inc", __i5}})}
 end})
 setenv("step", {_stash = true, macro = function (v, t, ...)
-  local ____r65 = unstash({...})
-  local __v9 = destash33(v, ____r65)
-  local __t3 = destash33(t, ____r65)
-  local ____id57 = ____r65
-  local __body41 = cut(____id57, 0)
-  local __x315 = unique("x")
+  local ____r79 = unstash({...})
+  local __v10 = destash33(v, ____r79)
+  local __t3 = destash33(t, ____r79)
+  local ____id61 = ____r79
+  local __body45 = cut(____id61, 0)
+  local __x374 = unique("x")
   local __i7 = unique("i")
-  return {"let", {__x315, __t3}, {"for", __i7, {"#", __x315}, join({"let", {__v9, {"at", __x315, __i7}}}, __body41)}}
+  return {"let", {__x374, __t3}, {"for", __i7, {"#", __x374}, join({"let", {__v10, {"at", __x374, __i7}}}, __body45)}}
 end})
 setenv("set-of", {_stash = true, macro = function (...)
   local __xs1 = unstash({...})
@@ -990,8 +1055,8 @@ setenv("set-of", {_stash = true, macro = function (...)
   local ____o5 = __xs1
   local ____i9 = nil
   for ____i9 in next, ____o5 do
-    local __x326 = ____o5[____i9]
-    __l3[__x326] = true
+    local __x385 = ____o5[____i9]
+    __l3[__x385] = true
   end
   return join({"obj"}, __l3)
 end})
@@ -1003,40 +1068,40 @@ setenv("target", {_stash = true, macro = function (...)
   return __clauses3[target]
 end})
 setenv("join!", {_stash = true, macro = function (a, ...)
-  local ____r69 = unstash({...})
-  local __a3 = destash33(a, ____r69)
-  local ____id59 = ____r69
-  local __bs5 = cut(____id59, 0)
+  local ____r83 = unstash({...})
+  local __a3 = destash33(a, ____r83)
+  local ____id63 = ____r83
+  local __bs5 = cut(____id63, 0)
   return {"set", __a3, join({"join", __a3}, __bs5)}
 end})
 setenv("cat!", {_stash = true, macro = function (a, ...)
-  local ____r71 = unstash({...})
-  local __a5 = destash33(a, ____r71)
-  local ____id61 = ____r71
-  local __bs7 = cut(____id61, 0)
+  local ____r85 = unstash({...})
+  local __a5 = destash33(a, ____r85)
+  local ____id65 = ____r85
+  local __bs7 = cut(____id65, 0)
   return {"set", __a5, join({"cat", __a5}, __bs7)}
 end})
 setenv("inc", {_stash = true, macro = function (n, by)
-  local __e11
+  local __e13
   if nil63(by) then
-    __e11 = 1
+    __e13 = 1
   else
-    __e11 = by
+    __e13 = by
   end
-  return {"set", n, {"+", n, __e11}}
+  return {"set", n, {"+", n, __e13}}
 end})
 setenv("dec", {_stash = true, macro = function (n, by)
-  local __e12
+  local __e14
   if nil63(by) then
-    __e12 = 1
+    __e14 = 1
   else
-    __e12 = by
+    __e14 = by
   end
-  return {"set", n, {"-", n, __e12}}
+  return {"set", n, {"-", n, __e14}}
 end})
 setenv("with-indent", {_stash = true, macro = function (form)
-  local __x354 = unique("x")
-  return {"do", {"inc", "indent-level"}, {"with", __x354, form, {"dec", "indent-level"}}}
+  local __x413 = unique("x")
+  return {"do", {"inc", "indent-level"}, {"with", __x413, form, {"dec", "indent-level"}}}
 end})
 setenv("export", {_stash = true, macro = function (...)
   local __names5 = unstash({...})
@@ -1045,21 +1110,21 @@ setenv("export", {_stash = true, macro = function (...)
       return {"set", {"get", "exports", {"quote", k}}, k}
     end, __names5))
   else
-    local __x371 = {}
+    local __x430 = {}
     local ____o7 = __names5
     local ____i11 = nil
     for ____i11 in next, ____o7 do
       local __k6 = ____o7[____i11]
-      __x371[__k6] = __k6
+      __x430[__k6] = __k6
     end
     return {"return", join({"%object"}, mapo(function (x)
       return x
-    end, __x371))}
+    end, __x430))}
   end
 end})
 setenv("when-compiling", {_stash = true, macro = function (...)
-  local __body43 = unstash({...})
-  return _eval(join({"do"}, __body43))
+  local __body47 = unstash({...})
+  return _eval(join({"do"}, __body47))
 end})
 local reader = require("reader")
 local compiler = require("compiler")

--- a/compiler.l
+++ b/compiler.l
@@ -1,6 +1,6 @@
 (define reader (require 'reader))
 
-(define getenv (k p)
+(define-global getenv (k p)
   (when (string? k)
     (let i (edge environment)
       (while (>= i 0)

--- a/macros.l
+++ b/macros.l
@@ -4,8 +4,48 @@
 (define-macro quasiquote (form)
   (quasiexpand form 1))
 
+(define-global gv-get (place _do)
+  (let place (macroexpand place)
+    (if (or (atom? place)
+            (and (= (hd place) 'get)
+                 (nil? (getenv 'get 'gv-expander))))
+        (_do place (fn (v) `(%set ,place ,v)))
+      (let (head (hd place)
+            gf (getenv head 'gv-expander))
+        (if gf (apply gf _do (tl place))
+          (error (cat (str place) " is not a valid place expression")))))))
+
+(define-macro gv-letplace (vars place rest: body)
+  `(gv-get ,place (fn ,vars ,@body)))
+
+(define-macro gv-define-expander (name handler)
+  (with form `(setenv ',name gv-expander: ,handler)
+    (eval form)))
+
+(define-global gv--defsetter (name setter _do args vars)
+  (if (none? args)
+      (let vars (reverse vars)
+        (_do `(,name ,@vars) (fn (v) (apply setter v vars))))
+    (let v (hd args)
+      (gv--defsetter name setter _do (tl args) `(,v ,@vars)))))
+
+(define-macro gv-define-setter (name arglist rest: body)
+  `(gv-define-expander ,name
+     (fn (_do rest: args)
+       (gv--defsetter ',name (fn ,arglist ,@body) _do args))))
+
+(define-macro gv-define-simple-setter (name setter fix-return)
+  `(gv-define-setter ,name (val rest: args)
+     ,(if fix-return
+          `(let v val
+             `(do (,',setter ,@args ,v)
+                  ,v))
+        ``(,',setter ,@args ,val))))
+
 (define-macro set args
-  `(do ,@(map (fn ((lh rh)) `(%set ,lh ,rh))
+  `(do ,@(map (fn ((lh rh))
+                (gv-letplace (_getter setter) lh
+                  (setter rh)))
               (pair args))))
 
 (define-macro at (l i)


### PR DESCRIPTION
It's unlikely that this PR will be merged, but I'm submitting it as an example of adding support for setforms. It uses the same machinery that Emacs uses, which has proven to be very versatile.

Performance is nearly identical, for what it's worth.

```
> (gv-define-setter char (c str pos)
    `(set ,str (cat (clip ,str 0 ,pos) ,c (clip ,str (+ ,pos 1)))))
> (set s "abc")
"abc"
> (set (char s 0) "z")
"zbc"
> (set (char s (edge s)) "z")
"zbz"
```
