### PR TITLE
Lower %CALL

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -1027,34 +1027,38 @@ lower = function (form, hoist, stmt63, tail63) {
           if (__x131 === "do") {
             return lower_do(__args9, hoist, stmt63, tail63);
           } else {
-            if (__x131 === "%set") {
-              return lower_set(__args9, hoist, stmt63, tail63);
+            if (__x131 === "%call") {
+              return lower(__args9, hoist, stmt63, tail63);
             } else {
-              if (__x131 === "%if") {
-                return lower_if(__args9, hoist, stmt63, tail63);
+              if (__x131 === "%set") {
+                return lower_set(__args9, hoist, stmt63, tail63);
               } else {
-                if (__x131 === "%try") {
-                  return lower_try(__args9, hoist, tail63);
+                if (__x131 === "%if") {
+                  return lower_if(__args9, hoist, stmt63, tail63);
                 } else {
-                  if (__x131 === "while") {
-                    return lower_while(__args9, hoist);
+                  if (__x131 === "%try") {
+                    return lower_try(__args9, hoist, tail63);
                   } else {
-                    if (__x131 === "%for") {
-                      return lower_for(__args9, hoist);
+                    if (__x131 === "while") {
+                      return lower_while(__args9, hoist);
                     } else {
-                      if (__x131 === "%function") {
-                        return lower_function(__args9);
+                      if (__x131 === "%for") {
+                        return lower_for(__args9, hoist);
                       } else {
-                        if (__x131 === "%local-function" || __x131 === "%global-function") {
-                          return lower_definition(__x131, __args9, hoist);
+                        if (__x131 === "%function") {
+                          return lower_function(__args9);
                         } else {
-                          if (in63(__x131, ["and", "or"])) {
-                            return lower_short(__x131, __args9, hoist);
+                          if (__x131 === "%local-function" || __x131 === "%global-function") {
+                            return lower_definition(__x131, __args9, hoist);
                           } else {
-                            if (statement63(__x131)) {
-                              return lower_special(form, hoist);
+                            if (in63(__x131, ["and", "or"])) {
+                              return lower_short(__x131, __args9, hoist);
                             } else {
-                              return lower_call(form, hoist);
+                              if (statement63(__x131)) {
+                                return lower_special(form, hoist);
+                              } else {
+                                return lower_call(form, hoist);
+                              }
                             }
                           }
                         }

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -973,34 +973,38 @@ function lower(form, hoist, stmt63, tail63)
           if __x134 == "do" then
             return lower_do(__args9, hoist, stmt63, tail63)
           else
-            if __x134 == "%set" then
-              return lower_set(__args9, hoist, stmt63, tail63)
+            if __x134 == "%call" then
+              return lower(__args9, hoist, stmt63, tail63)
             else
-              if __x134 == "%if" then
-                return lower_if(__args9, hoist, stmt63, tail63)
+              if __x134 == "%set" then
+                return lower_set(__args9, hoist, stmt63, tail63)
               else
-                if __x134 == "%try" then
-                  return lower_try(__args9, hoist, tail63)
+                if __x134 == "%if" then
+                  return lower_if(__args9, hoist, stmt63, tail63)
                 else
-                  if __x134 == "while" then
-                    return lower_while(__args9, hoist)
+                  if __x134 == "%try" then
+                    return lower_try(__args9, hoist, tail63)
                   else
-                    if __x134 == "%for" then
-                      return lower_for(__args9, hoist)
+                    if __x134 == "while" then
+                      return lower_while(__args9, hoist)
                     else
-                      if __x134 == "%function" then
-                        return lower_function(__args9)
+                      if __x134 == "%for" then
+                        return lower_for(__args9, hoist)
                       else
-                        if __x134 == "%local-function" or __x134 == "%global-function" then
-                          return lower_definition(__x134, __args9, hoist)
+                        if __x134 == "%function" then
+                          return lower_function(__args9)
                         else
-                          if in63(__x134, {"and", "or"}) then
-                            return lower_short(__x134, __args9, hoist)
+                          if __x134 == "%local-function" or __x134 == "%global-function" then
+                            return lower_definition(__x134, __args9, hoist)
                           else
-                            if statement63(__x134) then
-                              return lower_special(form, hoist)
+                            if in63(__x134, {"and", "or"}) then
+                              return lower_short(__x134, __args9, hoist)
                             else
-                              return lower_call(form, hoist)
+                              if statement63(__x134) then
+                                return lower_special(form, hoist)
+                              else
+                                return lower_call(form, hoist)
+                              end
                             end
                           end
                         end

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -1028,24 +1028,24 @@ setenv("apply", {_stash: true, macro: function (f) {
   var ____id49 = ____r57;
   var __args9 = cut(____id49, 0);
   if (_35(__args9) > 1) {
-    return [["do", "apply"], __f1, ["join", join(["list"], almost(__args9)), last(__args9)]];
+    return ["%call", "apply", __f1, ["join", join(["list"], almost(__args9)), last(__args9)]];
   } else {
-    return join([["do", "apply"], __f1], __args9);
+    return join(["%call", "apply", __f1], __args9);
   }
 }});
 setenv("guard", {_stash: true, macro: function (expr) {
   if (target === "js") {
     return [["fn", join(), ["%try", ["list", true, expr]]]];
   } else {
-    var ____x233 = ["obj"];
-    ____x233.stack = [["get", "debug", ["quote", "traceback"]]];
-    ____x233.message = ["if", ["string?", "m"], ["clip", "m", ["+", ["search", "m", "\": \""], 2]], ["nil?", "m"], "\"\"", ["str", "m"]];
-    return ["list", ["xpcall", ["fn", join(), expr], ["fn", ["m"], ["if", ["obj?", "m"], "m", ____x233]]]];
+    var ____x229 = ["obj"];
+    ____x229.stack = [["get", "debug", ["quote", "traceback"]]];
+    ____x229.message = ["if", ["string?", "m"], ["clip", "m", ["+", ["search", "m", "\": \""], 2]], ["nil?", "m"], "\"\"", ["str", "m"]];
+    return ["list", ["xpcall", ["fn", join(), expr], ["fn", ["m"], ["if", ["obj?", "m"], "m", ____x229]]]];
   }
 }});
 setenv("each", {_stash: true, macro: function (x, t) {
   var ____r61 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __x258 = destash33(x, ____r61);
+  var __x254 = destash33(x, ____r61);
   var __t1 = destash33(t, ____r61);
   var ____id52 = ____r61;
   var __body37 = cut(____id52, 0);
@@ -1053,14 +1053,14 @@ setenv("each", {_stash: true, macro: function (x, t) {
   var __n3 = unique("n");
   var __i3 = unique("i");
   var __e9;
-  if (atom63(__x258)) {
-    __e9 = [__i3, __x258];
+  if (atom63(__x254)) {
+    __e9 = [__i3, __x254];
   } else {
     var __e10;
-    if (_35(__x258) > 1) {
-      __e10 = __x258;
+    if (_35(__x254) > 1) {
+      __e10 = __x254;
     } else {
-      __e10 = [__i3, hd(__x258)];
+      __e10 = [__i3, hd(__x254)];
     }
     __e9 = __e10;
   }
@@ -1089,9 +1089,9 @@ setenv("step", {_stash: true, macro: function (v, t) {
   var __t3 = destash33(t, ____r65);
   var ____id57 = ____r65;
   var __body41 = cut(____id57, 0);
-  var __x290 = unique("x");
+  var __x286 = unique("x");
   var __i7 = unique("i");
-  return ["let", [__x290, __t3], ["for", __i7, ["#", __x290], join(["let", [__v9, ["at", __x290, __i7]]], __body41)]];
+  return ["let", [__x286, __t3], ["for", __i7, ["#", __x286], join(["let", [__v9, ["at", __x286, __i7]]], __body41)]];
 }});
 setenv("set-of", {_stash: true, macro: function () {
   var __xs1 = unstash(Array.prototype.slice.call(arguments, 0));
@@ -1099,7 +1099,7 @@ setenv("set-of", {_stash: true, macro: function () {
   var ____o5 = __xs1;
   var ____i9 = undefined;
   for (____i9 in ____o5) {
-    var __x300 = ____o5[____i9];
+    var __x296 = ____o5[____i9];
     var __e12;
     if (numeric63(____i9)) {
       __e12 = parseInt(____i9);
@@ -1107,7 +1107,7 @@ setenv("set-of", {_stash: true, macro: function () {
       __e12 = ____i9;
     }
     var ____i91 = __e12;
-    __l3[__x300] = true;
+    __l3[__x296] = true;
   }
   return join(["obj"], __l3);
 }});
@@ -1151,8 +1151,8 @@ setenv("dec", {_stash: true, macro: function (n, by) {
   return ["set", n, ["-", n, __e14]];
 }});
 setenv("with-indent", {_stash: true, macro: function (form) {
-  var __x325 = unique("x");
-  return ["do", ["inc", "indent-level"], ["with", __x325, form, ["dec", "indent-level"]]];
+  var __x321 = unique("x");
+  return ["do", ["inc", "indent-level"], ["with", __x321, form, ["dec", "indent-level"]]];
 }});
 setenv("export", {_stash: true, macro: function () {
   var __names5 = unstash(Array.prototype.slice.call(arguments, 0));
@@ -1161,7 +1161,7 @@ setenv("export", {_stash: true, macro: function () {
       return ["set", ["get", "exports", ["quote", k]], k];
     }, __names5));
   } else {
-    var __x341 = {};
+    var __x337 = {};
     var ____o7 = __names5;
     var ____i11 = undefined;
     for (____i11 in ____o7) {
@@ -1173,11 +1173,11 @@ setenv("export", {_stash: true, macro: function () {
         __e15 = ____i11;
       }
       var ____i111 = __e15;
-      __x341[__k7] = __k7;
+      __x337[__k7] = __k7;
     }
     return ["return", join(["%object"], mapo(function (x) {
       return x;
-    }, __x341))];
+    }, __x337))];
   }
 }});
 setenv("when-compiling", {_stash: true, macro: function () {

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -919,24 +919,24 @@ setenv("apply", {_stash = true, macro = function (f, ...)
   local ____id49 = ____r57
   local __args9 = cut(____id49, 0)
   if _35(__args9) > 1 then
-    return {{"do", "apply"}, __f1, {"join", join({"list"}, almost(__args9)), last(__args9)}}
+    return {"%call", "apply", __f1, {"join", join({"list"}, almost(__args9)), last(__args9)}}
   else
-    return join({{"do", "apply"}, __f1}, __args9)
+    return join({"%call", "apply", __f1}, __args9)
   end
 end})
 setenv("guard", {_stash = true, macro = function (expr)
   if target == "js" then
     return {{"fn", join(), {"%try", {"list", true, expr}}}}
   else
-    local ____x255 = {"obj"}
-    ____x255.stack = {{"get", "debug", {"quote", "traceback"}}}
-    ____x255.message = {"if", {"string?", "m"}, {"clip", "m", {"+", {"search", "m", "\": \""}, 2}}, {"nil?", "m"}, "\"\"", {"str", "m"}}
-    return {"list", {"xpcall", {"fn", join(), expr}, {"fn", {"m"}, {"if", {"obj?", "m"}, "m", ____x255}}}}
+    local ____x251 = {"obj"}
+    ____x251.stack = {{"get", "debug", {"quote", "traceback"}}}
+    ____x251.message = {"if", {"string?", "m"}, {"clip", "m", {"+", {"search", "m", "\": \""}, 2}}, {"nil?", "m"}, "\"\"", {"str", "m"}}
+    return {"list", {"xpcall", {"fn", join(), expr}, {"fn", {"m"}, {"if", {"obj?", "m"}, "m", ____x251}}}}
   end
 end})
 setenv("each", {_stash = true, macro = function (x, t, ...)
   local ____r61 = unstash({...})
-  local __x281 = destash33(x, ____r61)
+  local __x277 = destash33(x, ____r61)
   local __t1 = destash33(t, ____r61)
   local ____id52 = ____r61
   local __body37 = cut(____id52, 0)
@@ -944,14 +944,14 @@ setenv("each", {_stash = true, macro = function (x, t, ...)
   local __n3 = unique("n")
   local __i3 = unique("i")
   local __e8
-  if atom63(__x281) then
-    __e8 = {__i3, __x281}
+  if atom63(__x277) then
+    __e8 = {__i3, __x277}
   else
     local __e9
-    if _35(__x281) > 1 then
-      __e9 = __x281
+    if _35(__x277) > 1 then
+      __e9 = __x277
     else
-      __e9 = {__i3, hd(__x281)}
+      __e9 = {__i3, hd(__x277)}
     end
     __e8 = __e9
   end
@@ -980,9 +980,9 @@ setenv("step", {_stash = true, macro = function (v, t, ...)
   local __t3 = destash33(t, ____r65)
   local ____id57 = ____r65
   local __body41 = cut(____id57, 0)
-  local __x315 = unique("x")
+  local __x311 = unique("x")
   local __i7 = unique("i")
-  return {"let", {__x315, __t3}, {"for", __i7, {"#", __x315}, join({"let", {__v9, {"at", __x315, __i7}}}, __body41)}}
+  return {"let", {__x311, __t3}, {"for", __i7, {"#", __x311}, join({"let", {__v9, {"at", __x311, __i7}}}, __body41)}}
 end})
 setenv("set-of", {_stash = true, macro = function (...)
   local __xs1 = unstash({...})
@@ -990,8 +990,8 @@ setenv("set-of", {_stash = true, macro = function (...)
   local ____o5 = __xs1
   local ____i9 = nil
   for ____i9 in next, ____o5 do
-    local __x326 = ____o5[____i9]
-    __l3[__x326] = true
+    local __x322 = ____o5[____i9]
+    __l3[__x322] = true
   end
   return join({"obj"}, __l3)
 end})
@@ -1035,8 +1035,8 @@ setenv("dec", {_stash = true, macro = function (n, by)
   return {"set", n, {"-", n, __e12}}
 end})
 setenv("with-indent", {_stash = true, macro = function (form)
-  local __x354 = unique("x")
-  return {"do", {"inc", "indent-level"}, {"with", __x354, form, {"dec", "indent-level"}}}
+  local __x350 = unique("x")
+  return {"do", {"inc", "indent-level"}, {"with", __x350, form, {"dec", "indent-level"}}}
 end})
 setenv("export", {_stash = true, macro = function (...)
   local __names5 = unstash({...})
@@ -1045,16 +1045,16 @@ setenv("export", {_stash = true, macro = function (...)
       return {"set", {"get", "exports", {"quote", k}}, k}
     end, __names5))
   else
-    local __x371 = {}
+    local __x367 = {}
     local ____o7 = __names5
     local ____i11 = nil
     for ____i11 in next, ____o7 do
       local __k6 = ____o7[____i11]
-      __x371[__k6] = __k6
+      __x367[__k6] = __k6
     end
     return {"return", join({"%object"}, mapo(function (x)
       return x
-    end, __x371))}
+    end, __x367))}
   end
 end})
 setenv("when-compiling", {_stash = true, macro = function (...)

--- a/compiler.l
+++ b/compiler.l
@@ -551,6 +551,7 @@
       (lower-infix? form) (lower-infix form hoist)
     (let ((x rest: args) form)
       (if (= x 'do) (lower-do args hoist stmt? tail?)
+          (= x '%call) (lower args hoist stmt? tail?)
           (= x '%set) (lower-set args hoist stmt? tail?)
           (= x '%if) (lower-if args hoist stmt? tail?)
           (= x '%try) (lower-try args hoist tail?)

--- a/macros.l
+++ b/macros.l
@@ -146,8 +146,8 @@
 
 (define-macro apply (f rest: args)
   (if (> (# args) 1)
-      `((do apply) ,f (join (list ,@(almost args)) ,(last args)))
-      `((do apply) ,f ,@args)))
+      `(%call apply ,f (join (list ,@(almost args)) ,(last args)))
+      `(%call apply ,f ,@args)))
 
 (define-macro guard (expr)
   (if (= target 'js)


### PR DESCRIPTION
An expression like `(%call f x)` becomes `(f x)` during lowering.

This is useful for macros that return a call to a function or infix operator with an identical name.