### PR TITLE
Minor fix in LOWER-SET

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -881,9 +881,11 @@ var lower_set = function (args, hoist, stmt63, tail63) {
   var ____id16 = args;
   var __lh = ____id16[0];
   var __rh = ____id16[1];
-  add(hoist, ["%set", lower(__lh, hoist), lower(__rh, hoist)]);
+  var __lh1 = lower(__lh, hoist);
+  var __rh1 = lower(__rh, hoist);
+  add(hoist, ["%set", __lh1, __rh1]);
   if (!( stmt63 && ! tail63)) {
-    return __lh;
+    return __lh1;
   }
 };
 var lower_if = function (args, hoist, stmt63, tail63) {

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -827,9 +827,11 @@ local function lower_set(args, hoist, stmt63, tail63)
   local ____id16 = args
   local __lh = ____id16[1]
   local __rh = ____id16[2]
-  add(hoist, {"%set", lower(__lh, hoist), lower(__rh, hoist)})
+  local __lh1 = lower(__lh, hoist)
+  local __rh1 = lower(__rh, hoist)
+  add(hoist, {"%set", __lh1, __rh1})
   if not( stmt63 and not tail63) then
-    return __lh
+    return __lh1
   end
 end
 local function lower_if(args, hoist, stmt63, tail63)

--- a/compiler.l
+++ b/compiler.l
@@ -449,10 +449,12 @@
       e)))
 
 (define lower-set (args hoist stmt? tail?)
-  (let ((lh rh) args)
-    (add hoist `(%set ,(lower lh hoist) ,(lower rh hoist)))
+  (let ((lh rh) args
+        lh1 (lower lh hoist)
+        rh1 (lower rh hoist))
+    (add hoist `(%set ,lh1 ,rh1))
     (unless (and stmt? (not tail?))
-      lh)))
+      lh1)))
 
 (define lower-if (args hoist stmt? tail?)
   (let ((cond then else) args)


### PR DESCRIPTION
Closes #187.

Previously, the return value of `lower-set` wasn't being lowered.

I ran into this bug on my own branch of Lumen. It was an extremely subtle bug, so I'll describe how it bit me.

I changed `(target ...)` forms to be handled during lowering rather than during expansion:

```
(define lower-target (form hoist stmt? tail?)
  (lower (get form target) hoist stmt? tail?))
```

I removed the `target` macro, then I tried redefining the `at` macro as:

```
(define-macro at (l i)
  `(get ,l (target js: ,i lua: (+ ,i 1))))
```

That resulted in the following problem:

```
> (print (str (expand '(return (inc (at n 0))))))
("do" ("%set" ("get" "n" 0) ("+" ("get" "n" 0) 1)) ("return" ("get" "n" ("target" js: 0 lua: ("+" 0 1)))))
```

Notice that a `(target ...)` form appears *after* lowering! That's the bug that this PR fixes.

After merging this PR, we'd get correct behavior:

```
> (print (str (expand '(return (inc (at n 0))))))
("do" ("%set" ("get" "n" 0) ("+" ("get" "n" 0) 1)) ("return" ("get" "n" 0)))
```
