### PR TITLE
Exit with code 1 on error during command-line eval

### DIFF
--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -1199,15 +1199,18 @@ var eval_print = function (form) {
   var __ok = ____id[0];
   var __v = ____id[1];
   if (! __ok) {
-    return print(__v.stack);
+    print(__v.stack);
   } else {
     if (is63(__v)) {
-      return print(str(__v));
+      print(str(__v));
     }
   }
+  return __ok;
 };
 var rep = function (s) {
-  return eval_print(reader["read-string"](s));
+  if (! eval_print(reader["read-string"](s))) {
+    return system.exit(1);
+  }
 };
 var repl = function () {
   var __buf = "";

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -1089,15 +1089,18 @@ local function eval_print(form)
   local __ok = ____id[1]
   local __v = ____id[2]
   if not __ok then
-    return print("error: " .. __v.message .. "\n" .. __v.stack)
+    print("error: " .. __v.message .. "\n" .. __v.stack)
   else
     if is63(__v) then
-      return print(str(__v))
+      print(str(__v))
     end
   end
+  return __ok
 end
 local function rep(s)
-  return eval_print(reader["read-string"](s))
+  if not eval_print(reader["read-string"](s)) then
+    return system.exit(1)
+  end
 end
 local function repl()
   local __buf = ""

--- a/main.l
+++ b/main.l
@@ -8,10 +8,12 @@
         (target
           js: (print (get v 'stack))
           lua: (print (cat "error: " (get v 'message) "\n" (get v 'stack))))
-        (is? v) (print (str v)))))
+        (is? v) (print (str v)))
+    ok))
 
 (define rep (s)
-  (eval-print ((get reader 'read-string) s)))
+  (unless (eval-print ((get reader 'read-string) s))
+    ((get system 'exit) 1)))
 
 (define repl ()
   (let buf ""


### PR DESCRIPTION
Currently, passing in an `-e` argument causes Lumen to always exit with code 0:

```
$ bin/lumen -e '(error "foo")' && echo yes || echo no
error: foo
yes
```

This makes it a bit difficult to use Lumen in a shell script pipeline. After merging this PR, an error during eval will cause Lumen to exit with code 1:

```
$ bin/lumen -e '(error "foo")' && echo yes || echo no
error: foo
no
```

Node and Lua both exit with code `1` on error and `0` if the program exits successfully, so this PR helps achieve Lumen's goal of matching the host language as closely as possible.
