### PR TITLE
Allow function calls to be lowered as statements

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -31,7 +31,7 @@ var special_form63 = function (form) {
   return ! atom63(form) && special63(hd(form));
 };
 var statement63 = function (k) {
-  return special63(k) && getenv(k, "stmt");
+  return getenv(k, "stmt");
 };
 var symbol_expansion = function (k) {
   return getenv(k, "symbol");

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -31,7 +31,7 @@ local function special_form63(form)
   return not atom63(form) and special63(hd(form))
 end
 local function statement63(k)
-  return special63(k) and getenv(k, "stmt")
+  return getenv(k, "stmt")
 end
 local function symbol_expansion(k)
   return getenv(k, "symbol")

--- a/compiler.l
+++ b/compiler.l
@@ -22,7 +22,7 @@
   (and (not (atom? form)) (special? (hd form))))
 
 (define statement? (k)
-  (and (special? k) (getenv k 'stmt)))
+  (getenv k 'stmt))
 
 (define symbol-expansion (k)
   (getenv k 'symbol))


### PR DESCRIPTION
This PR allows the user to specify that certain function calls should be lowered as statements.

For example, on Python, `print` and `assert` are statements -- `return print(x)` and `f(print(x))` are errors. So a function like this:

```
(define foo (x)
  (print x))
```

... compiles to `return print(x)`, causing a syntax error.

Currently, a user could deal with this situation by making `print` and `assert` special forms via `define-special`. But that's rather inconvenient since `print` and `assert` aren't really special forms -- their compiled output is identical to regular function calls.

After merging this PR, `(setenv 'print :stmt)` and `(setenv 'assert :stmt)` will cause `(print x)` and `(assert x)` to be lowered as statements, solving the problem.