### PR TITLE
Fix STR on JS for Symbol types

### DIFF
--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -612,7 +612,7 @@ str = function (x, stack) {
                   if (stack && in63(x, stack)) {
                     return "circular";
                   } else {
-                    if (false) {
+                    if (!( type(x) === "object")) {
                       return escape(tostring(x));
                     } else {
                       var __s = "(";

--- a/runtime.l
+++ b/runtime.l
@@ -299,7 +299,7 @@
       (atom? x) (tostring x)
       (function? x) "function"
       (and stack (in? x stack)) "circular"
-      (target js: false lua: (not (= (type x) 'table)))
+      (not (= (type x) (target js: 'object lua: 'table)))
       (escape (tostring x))
     (let (s "(" sp ""
           xs () ks ()


### PR DESCRIPTION
On JS, `Symbol.for("foo")` shows up as `()` in Lumen's pretty printer.

Before:
```
$ LUMEN_HOST=node bin/lumen -e "((get Symbol 'for) 'foo)"
()
```
After:
```
$ LUMEN_HOST=node bin/lumen -e "((get Symbol 'for) 'foo)"
"Symbol(foo)"
```

I've decided to keep submitting PRs here, then I'll merge the ones I need into my dev branch at https://github.com/shawwn/lumen/tree/dev That way you retain the option of merging some of the PRs.

But yeah, don't worry about looking over a bunch of PRs. I'm a self-sufficient motor.