### PR TITLE
Compile %CALL

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -686,7 +686,7 @@ var compile_special = function (form, stmt63) {
 var parenthesize_call63 = function (x) {
   return ! atom63(x) && hd(x) === "%function" || precedence(x) > 0;
 };
-var compile_call = function (form) {
+compile_call = function (form) {
   var __f = hd(form);
   var __f1 = compile(__f);
   var __args3 = compile_args(stash42(tl(form)));
@@ -1027,38 +1027,34 @@ lower = function (form, hoist, stmt63, tail63) {
           if (__x131 === "do") {
             return lower_do(__args9, hoist, stmt63, tail63);
           } else {
-            if (__x131 === "%call") {
-              return lower(__args9, hoist, stmt63, tail63);
+            if (__x131 === "%set") {
+              return lower_set(__args9, hoist, stmt63, tail63);
             } else {
-              if (__x131 === "%set") {
-                return lower_set(__args9, hoist, stmt63, tail63);
+              if (__x131 === "%if") {
+                return lower_if(__args9, hoist, stmt63, tail63);
               } else {
-                if (__x131 === "%if") {
-                  return lower_if(__args9, hoist, stmt63, tail63);
+                if (__x131 === "%try") {
+                  return lower_try(__args9, hoist, tail63);
                 } else {
-                  if (__x131 === "%try") {
-                    return lower_try(__args9, hoist, tail63);
+                  if (__x131 === "while") {
+                    return lower_while(__args9, hoist);
                   } else {
-                    if (__x131 === "while") {
-                      return lower_while(__args9, hoist);
+                    if (__x131 === "%for") {
+                      return lower_for(__args9, hoist);
                     } else {
-                      if (__x131 === "%for") {
-                        return lower_for(__args9, hoist);
+                      if (__x131 === "%function") {
+                        return lower_function(__args9);
                       } else {
-                        if (__x131 === "%function") {
-                          return lower_function(__args9);
+                        if (__x131 === "%local-function" || __x131 === "%global-function") {
+                          return lower_definition(__x131, __args9, hoist);
                         } else {
-                          if (__x131 === "%local-function" || __x131 === "%global-function") {
-                            return lower_definition(__x131, __args9, hoist);
+                          if (in63(__x131, ["and", "or"])) {
+                            return lower_short(__x131, __args9, hoist);
                           } else {
-                            if (in63(__x131, ["and", "or"])) {
-                              return lower_short(__x131, __args9, hoist);
+                            if (statement63(__x131)) {
+                              return lower_special(form, hoist);
                             } else {
-                              if (statement63(__x131)) {
-                                return lower_special(form, hoist);
-                              } else {
-                                return lower_call(form, hoist);
-                              }
+                              return lower_call(form, hoist);
                             }
                           }
                         }
@@ -1353,6 +1349,10 @@ setenv("%object", {_stash: true, special: function () {
 setenv("%literal", {_stash: true, special: function () {
   var __args111 = unstash(Array.prototype.slice.call(arguments, 0));
   return apply(cat, map(compile, __args111));
+}});
+setenv("%call", {_stash: true, special: function () {
+  var __form5 = unstash(Array.prototype.slice.call(arguments, 0));
+  return compile_call(__form5);
 }});
 exports.run = run;
 exports["eval"] = _eval;

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -632,7 +632,7 @@ end
 local function parenthesize_call63(x)
   return not atom63(x) and hd(x) == "%function" or precedence(x) > 0
 end
-local function compile_call(form)
+function compile_call(form)
   local __f = hd(form)
   local __f1 = compile(__f)
   local __args3 = compile_args(stash42(tl(form)))
@@ -973,38 +973,34 @@ function lower(form, hoist, stmt63, tail63)
           if __x134 == "do" then
             return lower_do(__args9, hoist, stmt63, tail63)
           else
-            if __x134 == "%call" then
-              return lower(__args9, hoist, stmt63, tail63)
+            if __x134 == "%set" then
+              return lower_set(__args9, hoist, stmt63, tail63)
             else
-              if __x134 == "%set" then
-                return lower_set(__args9, hoist, stmt63, tail63)
+              if __x134 == "%if" then
+                return lower_if(__args9, hoist, stmt63, tail63)
               else
-                if __x134 == "%if" then
-                  return lower_if(__args9, hoist, stmt63, tail63)
+                if __x134 == "%try" then
+                  return lower_try(__args9, hoist, tail63)
                 else
-                  if __x134 == "%try" then
-                    return lower_try(__args9, hoist, tail63)
+                  if __x134 == "while" then
+                    return lower_while(__args9, hoist)
                   else
-                    if __x134 == "while" then
-                      return lower_while(__args9, hoist)
+                    if __x134 == "%for" then
+                      return lower_for(__args9, hoist)
                     else
-                      if __x134 == "%for" then
-                        return lower_for(__args9, hoist)
+                      if __x134 == "%function" then
+                        return lower_function(__args9)
                       else
-                        if __x134 == "%function" then
-                          return lower_function(__args9)
+                        if __x134 == "%local-function" or __x134 == "%global-function" then
+                          return lower_definition(__x134, __args9, hoist)
                         else
-                          if __x134 == "%local-function" or __x134 == "%global-function" then
-                            return lower_definition(__x134, __args9, hoist)
+                          if in63(__x134, {"and", "or"}) then
+                            return lower_short(__x134, __args9, hoist)
                           else
-                            if in63(__x134, {"and", "or"}) then
-                              return lower_short(__x134, __args9, hoist)
+                            if statement63(__x134) then
+                              return lower_special(form, hoist)
                             else
-                              if statement63(__x134) then
-                                return lower_special(form, hoist)
-                              else
-                                return lower_call(form, hoist)
-                              end
+                              return lower_call(form, hoist)
                             end
                           end
                         end
@@ -1292,5 +1288,9 @@ end})
 setenv("%literal", {_stash = true, special = function (...)
   local __args111 = unstash({...})
   return apply(cat, map(compile, __args111))
+end})
+setenv("%call", {_stash = true, special = function (...)
+  local __form5 = unstash({...})
+  return compile_call(__form5)
 end})
 return {run = run, ["eval"] = _eval, expand = expand, compile = compile}

--- a/compiler.l
+++ b/compiler.l
@@ -354,7 +354,7 @@
            (= (hd x) '%function))
       (> (precedence x) 0)))
 
-(define compile-call (form)
+(define-global compile-call (form)
   (let (f (hd form)
         f1 (compile f)
         args (compile-args (stash* (tl form))))
@@ -551,7 +551,6 @@
       (lower-infix? form) (lower-infix form hoist)
     (let ((x rest: args) form)
       (if (= x 'do) (lower-do args hoist stmt? tail?)
-          (= x '%call) (lower args hoist stmt? tail?)
           (= x '%set) (lower-set args hoist stmt? tail?)
           (= x '%if) (lower-if args hoist stmt? tail?)
           (= x '%try) (lower-try args hoist tail?)
@@ -733,6 +732,9 @@
 
 (define-special %literal args
   (apply cat (map compile args)))
+
+(define-special %call form
+  (compile-call form))
 
 (export run
         eval


### PR DESCRIPTION
`(%call cat 'a 'b)` compiles to `"a" .. "b"` instead of `cat("a", "b")` because `cat` is an infix operator.

`(%call do)` fails for similar reasons.

This PR ensures `(%call f args)` will compile to `f(args)` in all cases.