### PR TITLE
Minor fix in APPLY macro

### DIFF
--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -1027,7 +1027,7 @@ setenv("apply", {_stash: true, macro: function (f) {
   var __f1 = destash33(f, ____r57);
   var ____id49 = ____r57;
   var __args9 = cut(____id49, 0);
-  if (_35(__args9) > 1) {
+  if (_35(__args9) > 1 || keys63(__args9)) {
     return ["%call", "apply", __f1, ["join", join(["list"], almost(__args9)), last(__args9)]];
   } else {
     return join(["%call", "apply", __f1], __args9);

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -918,7 +918,7 @@ setenv("apply", {_stash = true, macro = function (f, ...)
   local __f1 = destash33(f, ____r57)
   local ____id49 = ____r57
   local __args9 = cut(____id49, 0)
-  if _35(__args9) > 1 then
+  if _35(__args9) > 1 or keys63(__args9) then
     return {"%call", "apply", __f1, {"join", join({"list"}, almost(__args9)), last(__args9)}}
   else
     return join({"%call", "apply", __f1}, __args9)

--- a/macros.l
+++ b/macros.l
@@ -145,7 +145,7 @@
   `(%function ,@(bind* args body)))
 
 (define-macro apply (f rest: args)
-  (if (> (# args) 1)
+  (if (or (> (# args) 1) (keys? args))
       `(%call apply ,f (join (list ,@(almost args)) ,(last args)))
       `(%call apply ,f ,@args)))
 


### PR DESCRIPTION
Keyword arguments passed to APPLY are now passed to the function.

E.g. `(apply f '(a b) sep: ",")` expands to `(apply f '(a b sep: ",")`.