### PR TITLE
Use INFIX-OPERATOR

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -577,7 +577,7 @@ var infix63 = function (x) {
   return is63(getop(x));
 };
 infix_operator63 = function (x) {
-  return obj63(x) && infix63(hd(x));
+  return obj63(x) && infix63(hd(x)) && ! keys63(x);
 };
 var compile_args = function (args) {
   var __s1 = "(";
@@ -812,7 +812,7 @@ compile = function (form) {
         __e45 = compile_atom(__form);
       } else {
         var __e46;
-        if (infix63(hd(__form))) {
+        if (infix_operator63(__form)) {
           __e46 = compile_infix(__form);
         } else {
           __e46 = compile_call(__form);
@@ -854,7 +854,7 @@ var literal63 = function (form) {
   return atom63(form) || hd(form) === "%array" || hd(form) === "%object";
 };
 var standalone63 = function (form) {
-  return ! atom63(form) && ! infix63(hd(form)) && ! literal63(form) && !( "get" === hd(form)) || id_literal63(form);
+  return ! atom63(form) && ! infix_operator63(form) && ! literal63(form) && !( "get" === hd(form)) || id_literal63(form);
 };
 var lower_do = function (args, hoist, stmt63, tail63) {
   var ____x95 = almost(args);
@@ -991,7 +991,7 @@ var lower_pairwise = function (form) {
   }
 };
 var lower_infix63 = function (form) {
-  return infix63(hd(form)) && _35(form) > 3;
+  return infix_operator63(form) && _35(form) > 3;
 };
 var lower_infix = function (form, hoist) {
   var __form3 = lower_pairwise(form);

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -523,7 +523,7 @@ local function infix63(x)
   return is63(getop(x))
 end
 function infix_operator63(x)
-  return obj63(x) and infix63(hd(x))
+  return obj63(x) and infix63(hd(x)) and not keys63(x)
 end
 local function compile_args(args)
   local __s1 = "("
@@ -758,7 +758,7 @@ function compile(form, ...)
         __e37 = compile_atom(__form)
       else
         local __e38
-        if infix63(hd(__form)) then
+        if infix_operator63(__form) then
           __e38 = compile_infix(__form)
         else
           __e38 = compile_call(__form)
@@ -800,7 +800,7 @@ local function literal63(form)
   return atom63(form) or hd(form) == "%array" or hd(form) == "%object"
 end
 local function standalone63(form)
-  return not atom63(form) and not infix63(hd(form)) and not literal63(form) and not( "get" == hd(form)) or id_literal63(form)
+  return not atom63(form) and not infix_operator63(form) and not literal63(form) and not( "get" == hd(form)) or id_literal63(form)
 end
 local function lower_do(args, hoist, stmt63, tail63)
   local ____x98 = almost(args)
@@ -937,7 +937,7 @@ local function lower_pairwise(form)
   end
 end
 local function lower_infix63(form)
-  return infix63(hd(form)) and _35(form) > 3
+  return infix_operator63(form) and _35(form) > 3
 end
 local function lower_infix(form, hoist)
   local __form3 = lower_pairwise(form)

--- a/compiler.l
+++ b/compiler.l
@@ -308,7 +308,7 @@
   (is? (getop x)))
 
 (define-global infix-operator? (x)
-  (and (obj? x) (infix? (hd x))))
+  (and (obj? x) (infix? (hd x)) (not (keys? x))))
 
 (define compile-args (args)
   (let (s "(" c "")
@@ -409,7 +409,7 @@
     (let (tr (terminator stmt)
           ind (if stmt (indentation) "")
           form (if (atom? form) (compile-atom form)
-                   (infix? (hd form)) (compile-infix form)
+                   (infix-operator? form) (compile-infix form)
                  (compile-call form)))
       (cat ind form tr))))
 
@@ -433,7 +433,7 @@
 
 (define standalone? (form)
   (or (and (not (atom? form))
-           (not (infix? (hd form)))
+           (not (infix-operator? form))
            (not (literal? form))
            (not (= 'get (hd form))))
       (id-literal? form)))
@@ -530,7 +530,7 @@
     form))
 
 (define lower-infix? (form)
-  (and (infix? (hd form)) (> (# form) 3)))
+  (and (infix-operator? form) (> (# form) 3)))
 
 (define lower-infix (form hoist)
   (let (form (lower-pairwise form)


### PR DESCRIPTION
Additionally, if a keyword argument is passed to a form that would
otherwise be an infix operator, treat it as a function call.

E.g. `(cat 'a 'b sep: ",")` will compile to

`cat("a", "b", {_stash = true, sep = ","})`

rather than

`"a" .. "b"`