### PR TITLE
Define GET-ENVIRONMENT-VARIABLE globally

### DIFF
--- a/bin/system.js
+++ b/bin/system.js
@@ -19,7 +19,7 @@ var path_join = function () {
     return x + path_separator + y;
   }, __parts) || "";
 };
-var get_environment_variable = function (name) {
+get_environment_variable = function (name) {
   return process.env[name];
 };
 var write = function (x) {

--- a/bin/system.lua
+++ b/bin/system.lua
@@ -50,7 +50,7 @@ local function path_join(...)
     return x .. path_separator .. y
   end, __parts) or ""
 end
-local function get_environment_variable(name)
+function get_environment_variable(name)
   return os.getenv(name)
 end
 local function write(x)

--- a/system.l
+++ b/system.l
@@ -51,7 +51,7 @@
 (define path-join parts
   (or (reduce (fn (x y) (cat x path-separator y)) parts) ""))
 
-(define get-environment-variable (name)
+(define-global get-environment-variable (name)
   (target
     js: (get (get process 'env) name)
     lua: ((get os 'getenv) name)))


### PR DESCRIPTION
`(get-environment-variable "FOO")` would be handy in Lumen scripts without having to `(define system (require 'system))`.

It would be particularly useful for configuring the behavior of macros: in the body of a macro, users can do `(if (get-environment-variable "FOO") ... )` and then run lumen with `FOO=1` to toggle it.

Either way, it'd be nice to have `get-environment-variable` available globally. The name seems sufficiently obscure that it shouldn't cause any conflicts.
