### PR TITLE
Allow node to require bin/lumen.js as a library

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -1,4 +1,3 @@
-var reader = require("reader");
 var getenv = function (k, p) {
   if (string63(k)) {
     var __i = edge(environment);

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -1,4 +1,3 @@
-local reader = require("reader")
 local function getenv(k, p)
   if string63(k) then
     local __i = edge(environment)

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -1184,9 +1184,9 @@ setenv("when-compiling", {_stash: true, macro: function () {
   var __body43 = unstash(Array.prototype.slice.call(arguments, 0));
   return _eval(join(["do"], __body43));
 }});
-var reader = require("reader");
-var compiler = require("compiler");
-var system = require("system");
+var reader = require("./reader");
+var compiler = require("./compiler");
+var system = require("./system");
 var eval_print = function (form) {
   var ____id = (function () {
     try {
@@ -1333,4 +1333,18 @@ var main = function () {
     }
   }
 };
-main();
+if (require.main === module) {
+  main();
+}
+exports.reader = reader;
+exports.compiler = compiler;
+exports.system = system;
+exports["eval-print"] = eval_print;
+exports.rep = rep;
+exports.repl = repl;
+exports["compile-file"] = compile_file;
+exports["load"] = _load;
+exports["script-file?"] = script_file63;
+exports["run-file"] = run_file;
+exports.usage = usage;
+exports.main = main;

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -1228,4 +1228,7 @@ local function main()
     end
   end
 end
-main()
+if true then
+  main()
+end
+return {reader = reader, compiler = compiler, system = system, ["eval-print"] = eval_print, rep = rep, repl = repl, ["compile-file"] = compile_file, ["load"] = _load, ["script-file?"] = script_file63, ["run-file"] = run_file, usage = usage, main = main}

--- a/compiler.l
+++ b/compiler.l
@@ -1,5 +1,3 @@
-(define reader (require 'reader))
-
 (define getenv (k p)
   (when (string? k)
     (let i (edge environment)

--- a/main.l
+++ b/main.l
@@ -1,6 +1,6 @@
-(define reader (require 'reader))
-(define compiler (require 'compiler))
-(define system (require 'system))
+(define reader (require (target js: "./reader" lua: 'reader)))
+(define compiler (require (target js: "./compiler" lua: 'compiler)))
+(define system (require (target js: "./system" lua: 'system)))
 
 (define eval-print (form)
   (let ((ok v) (guard ((get compiler 'eval) form)))
@@ -100,4 +100,18 @@
                     (print code)
                   ((get system 'write-file) output code)))))))))
 
-(main)
+(when (target js: (= (get require 'main) module) lua: true)
+  (main))
+
+(export reader
+        compiler
+        system
+        eval-print
+        rep
+        repl
+        compile-file
+        load
+        script-file?
+        run-file
+        usage
+        main)


### PR DESCRIPTION
This PR allows the following:

```
$ node
> require("./bin/lumen.js")
{ reader: 
   { stream: [Function: stream],
     read: [Function: read],
     'read-all': [Function: read_all],
     'read-string': [Function: read_string],
     'read-table': 
      { '': [Function],
        '(': [Function],
        ')': [Function],
        '"': [Function],
        '|': [Function],
        '\'': [Function],
        '`': [Function],
        ',': [Function] } },
  compiler: 
   { run: [Function: eval],
     eval: [Function: _eval],
     expand: [Function: expand],
     compile: [Function: compile] },
  system: 
   { 'read-file': [Function: read_file],
     'write-file': [Function: write_file],
     'file-exists?': [Function: file_exists63],
     'directory-exists?': [Function: directory_exists63],
     'path-separator': '/',
     'path-join': [Function: path_join],
     'get-environment-variable': [Function: get_environment_variable],
     write: [Function: write],
     exit: [Function: exit],
     argv: [],
     reload: [Function: reload],
     run: [Function: run] },
  'eval-print': [Function: eval_print],
  rep: [Function: rep],
  repl: [Function: repl],
  'compile-file': [Function: compile_file],
  load: [Function: _load],
  'script-file?': [Function: script_file63],
  'run-file': [Function: run_file],
  usage: [Function: usage],
  main: [Function: main] }
```

This is a necessary step for shipping Lumen as a JS library.