### PR TITLE
RFC: Experimental dot syntax

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -1,43 +1,42 @@
-var reader = require("reader");
 var getenv = function (k, p) {
   if (string63(k)) {
     var __i = edge(environment);
     while (__i >= 0) {
       var __b = environment[__i][k];
       if (is63(__b)) {
-        var __e21;
+        var __e8;
         if (p) {
-          __e21 = __b[p];
+          __e8 = __b[p];
         } else {
-          __e21 = __b;
+          __e8 = __b;
         }
-        return __e21;
+        return __e8;
       } else {
         __i = __i - 1;
       }
     }
   }
 };
-var macro_function = function (k) {
+var macroFunction = function (k) {
   return getenv(k, "macro");
 };
 var macro63 = function (k) {
-  return is63(macro_function(k));
+  return is63(macroFunction(k));
 };
 var special63 = function (k) {
   return is63(getenv(k, "special"));
 };
-var special_form63 = function (form) {
+var specialForm63 = function (form) {
   return ! atom63(form) && special63(hd(form));
 };
 var statement63 = function (k) {
   return special63(k) && getenv(k, "stmt");
 };
-var symbol_expansion = function (k) {
+var symbolExpansion = function (k) {
   return getenv(k, "symbol");
 };
 var symbol63 = function (k) {
-  return is63(symbol_expansion(k));
+  return is63(symbolExpansion(k));
 };
 var variable63 = function (k) {
   return is63(getenv(k, "variable"));
@@ -57,7 +56,7 @@ quoted = function (form) {
   }
 };
 var literal = function (s) {
-  if (string_literal63(s)) {
+  if (stringLiteral63(s)) {
     return s;
   } else {
     return quoted(s);
@@ -70,13 +69,13 @@ var stash42 = function (args) {
     var __k = undefined;
     for (__k in ____o) {
       var __v = ____o[__k];
-      var __e22;
+      var __e9;
       if (numeric63(__k)) {
-        __e22 = parseInt(__k);
+        __e9 = parseInt(__k);
       } else {
-        __e22 = __k;
+        __e9 = __k;
       }
-      var __k1 = __e22;
+      var __k1 = __e9;
       if (! number63(__k1)) {
         add(__l, literal(__k1));
         add(__l, __v);
@@ -107,28 +106,28 @@ bind = function (lh, rh) {
     var __k2 = undefined;
     for (__k2 in ____o1) {
       var __v1 = ____o1[__k2];
-      var __e23;
+      var __e10;
       if (numeric63(__k2)) {
-        __e23 = parseInt(__k2);
+        __e10 = parseInt(__k2);
       } else {
-        __e23 = __k2;
+        __e10 = __k2;
       }
-      var __k3 = __e23;
-      var __e24;
+      var __k3 = __e10;
+      var __e11;
       if (__k3 === "rest") {
-        __e24 = ["cut", __id, _35(lh)];
+        __e11 = ["cut", __id, _35(lh)];
       } else {
-        __e24 = ["get", __id, ["quote", bias(__k3)]];
+        __e11 = ["get", __id, ["quote", bias(__k3)]];
       }
-      var __x5 = __e24;
+      var __x5 = __e11;
       if (is63(__k3)) {
-        var __e25;
+        var __e12;
         if (__v1 === true) {
-          __e25 = __k3;
+          __e12 = __k3;
         } else {
-          __e25 = __v1;
+          __e12 = __v1;
         }
-        var __k4 = __e25;
+        var __k4 = __e12;
         __bs = join(__bs, bind(__k4, __x5));
       }
     }
@@ -136,7 +135,7 @@ bind = function (lh, rh) {
   }
 };
 setenv("arguments%", {_stash: true, macro: function (from) {
-  return [["get", ["get", ["get", "Array", ["quote", "prototype"]], ["quote", "slice"]], ["quote", "call"]], "arguments", from];
+  return ["Array", ".prototype", ".slice", ".call", "arguments", from];
 }});
 bind42 = function (args, body) {
   var __args1 = [];
@@ -152,38 +151,38 @@ bind42 = function (args, body) {
     return [__args1, join(["let", [args, rest()]], body)];
   } else {
     var __bs1 = [];
-    var __r19 = unique("r");
+    var __r18 = unique("r");
     var ____o2 = args;
     var __k5 = undefined;
     for (__k5 in ____o2) {
       var __v2 = ____o2[__k5];
-      var __e26;
+      var __e13;
       if (numeric63(__k5)) {
-        __e26 = parseInt(__k5);
+        __e13 = parseInt(__k5);
       } else {
-        __e26 = __k5;
+        __e13 = __k5;
       }
-      var __k6 = __e26;
+      var __k6 = __e13;
       if (number63(__k6)) {
         if (atom63(__v2)) {
           add(__args1, __v2);
         } else {
-          var __x30 = unique("x");
-          add(__args1, __x30);
-          __bs1 = join(__bs1, [__v2, __x30]);
+          var __x17 = unique("x");
+          add(__args1, __x17);
+          __bs1 = join(__bs1, [__v2, __x17]);
         }
       }
     }
     if (keys63(args)) {
-      __bs1 = join(__bs1, [__r19, rest()]);
+      __bs1 = join(__bs1, [__r18, rest()]);
       var __n3 = _35(__args1);
       var __i4 = 0;
       while (__i4 < __n3) {
         var __v3 = __args1[__i4];
-        __bs1 = join(__bs1, [__v3, ["destash!", __v3, __r19]]);
+        __bs1 = join(__bs1, [__v3, ["destash!", __v3, __r18]]);
         __i4 = __i4 + 1;
       }
-      __bs1 = join(__bs1, [keys(args), __r19]);
+      __bs1 = join(__bs1, [keys(args), __r18]);
     }
     return [__args1, join(["let", __bs1], body)];
   }
@@ -194,46 +193,46 @@ var quoting63 = function (depth) {
 var quasiquoting63 = function (depth) {
   return quoting63(depth) && depth > 0;
 };
-var can_unquote63 = function (depth) {
+var canUnquote63 = function (depth) {
   return quoting63(depth) && depth === 1;
 };
 var quasisplice63 = function (x, depth) {
-  return can_unquote63(depth) && ! atom63(x) && hd(x) === "unquote-splicing";
+  return canUnquote63(depth) && ! atom63(x) && hd(x) === "unquote-splicing";
 };
-var expand_local = function (__x38) {
-  var ____id1 = __x38;
-  var __x39 = ____id1[0];
+var expandLocal = function (__x25) {
+  var ____id1 = __x25;
+  var __x26 = ____id1[0];
   var __name = ____id1[1];
   var __value = ____id1[2];
   setenv(__name, {_stash: true, variable: true});
   return ["%local", __name, macroexpand(__value)];
 };
-var expand_function = function (__x41) {
-  var ____id2 = __x41;
-  var __x42 = ____id2[0];
+var expandFunction = function (__x28) {
+  var ____id2 = __x28;
+  var __x29 = ____id2[0];
   var __args = ____id2[1];
   var __body = cut(____id2, 2);
   add(environment, {});
   var ____o3 = __args;
   var ____i5 = undefined;
   for (____i5 in ____o3) {
-    var ____x43 = ____o3[____i5];
-    var __e27;
+    var ____x30 = ____o3[____i5];
+    var __e14;
     if (numeric63(____i5)) {
-      __e27 = parseInt(____i5);
+      __e14 = parseInt(____i5);
     } else {
-      __e27 = ____i5;
+      __e14 = ____i5;
     }
-    var ____i51 = __e27;
-    setenv(____x43, {_stash: true, variable: true});
+    var ____i51 = __e14;
+    setenv(____x30, {_stash: true, variable: true});
   }
-  var ____x44 = join(["%function", __args], macroexpand(__body));
+  var ____x31 = join(["%function", __args], macroexpand(__body));
   drop(environment);
-  return ____x44;
+  return ____x31;
 };
-var expand_definition = function (__x46) {
-  var ____id3 = __x46;
-  var __x47 = ____id3[0];
+var expandDefinition = function (__x33) {
+  var ____id3 = __x33;
+  var __x34 = ____id3[0];
   var __name1 = ____id3[1];
   var __args11 = ____id3[2];
   var __body1 = cut(____id3, 3);
@@ -241,51 +240,51 @@ var expand_definition = function (__x46) {
   var ____o4 = __args11;
   var ____i6 = undefined;
   for (____i6 in ____o4) {
-    var ____x48 = ____o4[____i6];
-    var __e28;
+    var ____x35 = ____o4[____i6];
+    var __e15;
     if (numeric63(____i6)) {
-      __e28 = parseInt(____i6);
+      __e15 = parseInt(____i6);
     } else {
-      __e28 = ____i6;
+      __e15 = ____i6;
     }
-    var ____i61 = __e28;
-    setenv(____x48, {_stash: true, variable: true});
+    var ____i61 = __e15;
+    setenv(____x35, {_stash: true, variable: true});
   }
-  var ____x49 = join([__x47, __name1, __args11], macroexpand(__body1));
+  var ____x36 = join([__x34, __name1, __args11], macroexpand(__body1));
   drop(environment);
-  return ____x49;
+  return ____x36;
 };
-var expand_macro = function (form) {
+var expandMacro = function (form) {
   return macroexpand(expand1(form));
 };
-expand1 = function (__x51) {
-  var ____id4 = __x51;
+expand1 = function (__x38) {
+  var ____id4 = __x38;
   var __name2 = ____id4[0];
   var __body2 = cut(____id4, 1);
-  return apply(macro_function(__name2), __body2);
+  return apply(macroFunction(__name2), __body2);
 };
 macroexpand = function (form) {
   if (symbol63(form)) {
-    return macroexpand(symbol_expansion(form));
+    return macroexpand(symbolExpansion(form));
   } else {
     if (atom63(form)) {
       return form;
     } else {
-      var __x52 = hd(form);
-      if (__x52 === "%local") {
-        return expand_local(form);
+      var __x39 = hd(form);
+      if (__x39 === "%local") {
+        return expandLocal(form);
       } else {
-        if (__x52 === "%function") {
-          return expand_function(form);
+        if (__x39 === "%function") {
+          return expandFunction(form);
         } else {
-          if (__x52 === "%global-function") {
-            return expand_definition(form);
+          if (__x39 === "%global-function") {
+            return expandDefinition(form);
           } else {
-            if (__x52 === "%local-function") {
-              return expand_definition(form);
+            if (__x39 === "%local-function") {
+              return expandDefinition(form);
             } else {
-              if (macro63(__x52)) {
-                return expand_macro(form);
+              if (macro63(__x39)) {
+                return expandMacro(form);
               } else {
                 return map(macroexpand, form);
               }
@@ -296,40 +295,40 @@ macroexpand = function (form) {
     }
   }
 };
-var quasiquote_list = function (form, depth) {
+var quasiquoteList = function (form, depth) {
   var __xs = [["list"]];
   var ____o5 = form;
   var __k7 = undefined;
   for (__k7 in ____o5) {
     var __v4 = ____o5[__k7];
-    var __e29;
+    var __e16;
     if (numeric63(__k7)) {
-      __e29 = parseInt(__k7);
+      __e16 = parseInt(__k7);
     } else {
-      __e29 = __k7;
+      __e16 = __k7;
     }
-    var __k8 = __e29;
+    var __k8 = __e16;
     if (! number63(__k8)) {
-      var __e30;
+      var __e17;
       if (quasisplice63(__v4, depth)) {
-        __e30 = quasiexpand(__v4[1]);
+        __e17 = quasiexpand(__v4[1]);
       } else {
-        __e30 = quasiexpand(__v4, depth);
+        __e17 = quasiexpand(__v4, depth);
       }
-      var __v5 = __e30;
+      var __v5 = __e17;
       last(__xs)[__k8] = __v5;
     }
   }
-  var ____x55 = form;
+  var ____x42 = form;
   var ____i8 = 0;
-  while (____i8 < _35(____x55)) {
-    var __x56 = ____x55[____i8];
-    if (quasisplice63(__x56, depth)) {
-      var __x57 = quasiexpand(__x56[1]);
-      add(__xs, __x57);
+  while (____i8 < _35(____x42)) {
+    var __x43 = ____x42[____i8];
+    if (quasisplice63(__x43, depth)) {
+      var __x44 = quasiexpand(__x43[1]);
+      add(__xs, __x44);
       add(__xs, ["list"]);
     } else {
-      add(last(__xs), quasiexpand(__x56, depth));
+      add(last(__xs), quasiexpand(__x43, depth));
     }
     ____i8 = ____i8 + 1;
   }
@@ -347,16 +346,16 @@ quasiexpand = function (form, depth) {
     if (atom63(form)) {
       return ["quote", form];
     } else {
-      if (can_unquote63(depth) && hd(form) === "unquote") {
+      if (canUnquote63(depth) && hd(form) === "unquote") {
         return quasiexpand(form[1]);
       } else {
         if (hd(form) === "unquote" || hd(form) === "unquote-splicing") {
-          return quasiquote_list(form, depth - 1);
+          return quasiquoteList(form, depth - 1);
         } else {
           if (hd(form) === "quasiquote") {
-            return quasiquote_list(form, depth + 1);
+            return quasiquoteList(form, depth + 1);
           } else {
-            return quasiquote_list(form, depth);
+            return quasiquoteList(form, depth);
           }
         }
       }
@@ -379,101 +378,107 @@ quasiexpand = function (form, depth) {
     }
   }
 };
-expand_if = function (__x61) {
-  var ____id5 = __x61;
+expandIf = function (__x48) {
+  var ____id5 = __x48;
   var __a = ____id5[0];
   var __b1 = ____id5[1];
   var __c = cut(____id5, 2);
   if (is63(__b1)) {
-    return [join(["%if", __a, __b1], expand_if(__c))];
+    return [join(["%if", __a, __b1], expandIf(__c))];
   } else {
     if (is63(__a)) {
       return [__a];
     }
   }
 };
-indent_level = 0;
+indentLevel = 0;
 indentation = function () {
   var __s = "";
   var __i9 = 0;
-  while (__i9 < indent_level) {
+  while (__i9 < indentLevel) {
     __s = __s + "  ";
     __i9 = __i9 + 1;
   }
   return __s;
 };
-var reserved = {"=": true, "==": true, "+": true, "-": true, "%": true, "*": true, "/": true, "<": true, ">": true, "<=": true, ">=": true, "break": true, "case": true, "catch": true, "class": true, "const": true, "continue": true, "debugger": true, "default": true, "delete": true, "do": true, "else": true, "eval": true, "finally": true, "for": true, "function": true, "if": true, "import": true, "in": true, "instanceof": true, "let": true, "new": true, "return": true, "switch": true, "throw": true, "try": true, "typeof": true, "var": true, "void": true, "with": true, "and": true, "end": true, "load": true, "repeat": true, "while": true, "false": true, "local": true, "nil": true, "then": true, "not": true, "true": true, "elseif": true, "or": true, "until": true};
+var reserved = {"=": true, "==": true, "+": true, "-": true, "%": true, "*": true, "/": true, "<": true, ">": true, "<=": true, ">=": true, break: true, case: true, catch: true, class: true, const: true, continue: true, debugger: true, default: true, delete: true, do: true, else: true, eval: true, finally: true, for: true, function: true, if: true, import: true, in: true, instanceof: true, let: true, new: true, return: true, switch: true, throw: true, try: true, typeof: true, var: true, void: true, with: true, and: true, end: true, load: true, repeat: true, while: true, false: true, local: true, nil: true, then: true, not: true, true: true, elseif: true, or: true, until: true};
 reserved63 = function (x) {
   return has63(reserved, x);
 };
-var valid_code63 = function (n) {
-  return number_code63(n) || n > 64 && n < 91 || n > 96 && n < 123 || n === 95;
+var validCode63 = function (n) {
+  return numberCode63(n) || n > 64 && n < 91 || n > 96 && n < 123 || n === 95;
 };
 accessor63 = function (x) {
   return string63(x) && _35(x) > 1 && code(x, 0) === 46 && !( code(x, 1) === 46) || obj63(x) && hd(x) === "%brackets";
 };
-var id = function (id, raw63) {
-  var __e31;
-  if (number_code63(code(id, 0))) {
-    __e31 = "_";
+compileId = function (id) {
+  var __id6 = camelCase(id);
+  var __e18;
+  if (numberCode63(code(__id6, 0))) {
+    __e18 = "_";
   } else {
-    __e31 = "";
+    __e18 = "";
   }
-  var __id11 = __e31;
+  var __id11 = __e18;
   var __i10 = 0;
-  while (__i10 < _35(id)) {
-    var __c1 = char(id, __i10);
+  while (__i10 < _35(__id6)) {
+    var __c1 = char(__id6, __i10);
     var __n7 = code(__c1);
-    var __e32;
-    if (__c1 === "-" && !( id === "-")) {
-      __e32 = "_";
+    var __e19;
+    if (__c1 === "-" && !( __id6 === "-")) {
+      __e19 = "_";
     } else {
-      var __e33;
-      if (valid_code63(__n7)) {
-        __e33 = __c1;
+      var __e20;
+      if (validCode63(__n7)) {
+        __e20 = __c1;
       } else {
-        var __e34;
+        var __e21;
         if (__i10 === 0) {
-          __e34 = "_" + __n7;
+          __e21 = "_" + __n7;
         } else {
-          __e34 = __n7;
+          __e21 = __n7;
         }
-        __e33 = __e34;
+        __e20 = __e21;
       }
-      __e32 = __e33;
+      __e19 = __e20;
     }
-    var __c11 = __e32;
+    var __c11 = __e19;
     __id11 = __id11 + __c11;
     __i10 = __i10 + 1;
   }
-  if (raw63) {
-    return __id11;
-  } else {
-    if (reserved63(__id11)) {
-      return "_" + __id11;
-    } else {
-      return __id11;
-    }
-  }
+  return __id11;
 };
-valid_id63 = function (x) {
-  return some63(x) && x === id(x);
+validId63 = function (x) {
+  var __id31 = some63(x) && x === compileId(x);
+  var __e23;
+  if (__id31) {
+    var __e24;
+    if (target === "lua") {
+      __e24 = ! reserved63(x);
+    } else {
+      __e24 = true;
+    }
+    __e23 = __e24;
+  } else {
+    __e23 = __id31;
+  }
+  return __e23;
 };
 var __names = {};
 unique = function (x) {
-  var __x65 = id(x);
-  if (__names[__x65]) {
-    var __i11 = __names[__x65];
-    __names[__x65] = __names[__x65] + 1;
-    return unique(__x65 + __i11);
+  var __x52 = compileId(x);
+  if (__names[__x52]) {
+    var __i11 = __names[__x52];
+    __names[__x52] = __names[__x52] + 1;
+    return unique(__x52 + __i11);
   } else {
-    __names[__x65] = 1;
-    return "__" + __x65;
+    __names[__x52] = 1;
+    return "__" + __x52;
   }
 };
 key = function (k) {
   var __i12 = inner(k);
-  if (valid_id63(__i12)) {
+  if (validId63(__i12)) {
     return __i12;
   } else {
     if (target === "js") {
@@ -489,59 +494,59 @@ mapo = function (f, t) {
   var __k9 = undefined;
   for (__k9 in ____o7) {
     var __v6 = ____o7[__k9];
-    var __e35;
+    var __e25;
     if (numeric63(__k9)) {
-      __e35 = parseInt(__k9);
+      __e25 = parseInt(__k9);
     } else {
-      __e35 = __k9;
+      __e25 = __k9;
     }
-    var __k10 = __e35;
-    var __x66 = f(__v6);
-    if (is63(__x66)) {
+    var __k10 = __e25;
+    var __x53 = f(__v6);
+    if (is63(__x53)) {
       add(__o6, literal(__k10));
-      add(__o6, __x66);
+      add(__o6, __x53);
     }
   }
   return __o6;
 };
-var ____x68 = [];
-var ____x69 = [];
-____x69.js = "!";
-____x69.lua = "not";
-____x68["not"] = ____x69;
-var ____x70 = [];
-____x70["*"] = true;
-____x70["/"] = true;
-____x70["%"] = true;
-var ____x71 = [];
-var ____x72 = [];
-____x72.js = "+";
-____x72.lua = "..";
-____x71.cat = ____x72;
-var ____x73 = [];
-____x73["+"] = true;
-____x73["-"] = true;
-var ____x74 = [];
-____x74["<"] = true;
-____x74[">"] = true;
-____x74["<="] = true;
-____x74[">="] = true;
-var ____x75 = [];
-var ____x76 = [];
-____x76.js = "===";
-____x76.lua = "==";
-____x75["="] = ____x76;
-var ____x77 = [];
-var ____x78 = [];
-____x78.js = "&&";
-____x78.lua = "and";
-____x77["and"] = ____x78;
-var ____x79 = [];
-var ____x80 = [];
-____x80.js = "||";
-____x80.lua = "or";
-____x79["or"] = ____x80;
-var infix = [____x68, ____x70, ____x71, ____x73, ____x74, ____x75, ____x77, ____x79];
+var ____x55 = [];
+var ____x56 = [];
+____x56.js = "!";
+____x56.lua = "not";
+____x55.not = ____x56;
+var ____x57 = [];
+____x57["*"] = true;
+____x57["/"] = true;
+____x57["%"] = true;
+var ____x58 = [];
+var ____x59 = [];
+____x59.js = "+";
+____x59.lua = "..";
+____x58.cat = ____x59;
+var ____x60 = [];
+____x60["+"] = true;
+____x60["-"] = true;
+var ____x61 = [];
+____x61["<"] = true;
+____x61[">"] = true;
+____x61["<="] = true;
+____x61[">="] = true;
+var ____x62 = [];
+var ____x63 = [];
+____x63.js = "===";
+____x63.lua = "==";
+____x62["="] = ____x63;
+var ____x64 = [];
+var ____x65 = [];
+____x65.js = "&&";
+____x65.lua = "and";
+____x64.and = ____x65;
+var ____x66 = [];
+var ____x67 = [];
+____x67.js = "||";
+____x67.lua = "or";
+____x66.or = ____x67;
+var infix = [____x55, ____x57, ____x58, ____x60, ____x61, ____x62, ____x64, ____x66];
 var unary63 = function (form) {
   return two63(form) && in63(hd(form), ["not", "-"]);
 };
@@ -554,13 +559,13 @@ var precedence = function (form) {
     var __k11 = undefined;
     for (__k11 in ____o8) {
       var __v7 = ____o8[__k11];
-      var __e36;
+      var __e26;
       if (numeric63(__k11)) {
-        __e36 = parseInt(__k11);
+        __e26 = parseInt(__k11);
       } else {
-        __e36 = __k11;
+        __e26 = __k11;
       }
-      var __k12 = __e36;
+      var __k12 = __e26;
       if (__v7[hd(form)]) {
         return index(__k12);
       }
@@ -570,12 +575,12 @@ var precedence = function (form) {
 };
 var getop = function (op) {
   return find(function (level) {
-    var __x82 = level[op];
-    if (__x82 === true) {
+    var __x69 = level[op];
+    if (__x69 === true) {
       return op;
     } else {
-      if (is63(__x82)) {
-        return __x82[target];
+      if (is63(__x69)) {
+        return __x69[target];
       }
     }
   }, infix);
@@ -583,10 +588,10 @@ var getop = function (op) {
 var infix63 = function (x) {
   return is63(getop(x));
 };
-infix_operator63 = function (x) {
+infixOperator63 = function (x) {
   return obj63(x) && infix63(hd(x));
 };
-compile_next = function (x, args, call63) {
+compileNext = function (x, args, call63) {
   if (none63(args)) {
     if (call63) {
       return x + "()";
@@ -594,30 +599,30 @@ compile_next = function (x, args, call63) {
       return x;
     }
   } else {
-    return x + compile_args(args, call63);
+    return x + compileArgs(args, call63);
   }
 };
-compile_args = function (args, call63) {
+compileArgs = function (args, call63) {
   var __a1 = hd(args);
   if (accessor63(__a1)) {
-    return compile_next(compile(__a1), tl(args), call63);
+    return compileNext(compile(__a1), tl(args), call63);
   } else {
     if (obj63(__a1) && accessor63(hd(__a1))) {
-      var ____id6 = __a1;
-      var __x83 = ____id6[0];
-      var __ys = cut(____id6, 1);
-      var __s1 = compile_next(compile(__x83), __ys, true);
-      return compile_next(__s1, tl(args), call63);
+      var ____id7 = __a1;
+      var __x70 = ____id7[0];
+      var __ys = cut(____id7, 1);
+      var __s1 = compileNext(compile(__x70), __ys, true);
+      return compileNext(__s1, tl(args), call63);
     } else {
       var __s2 = "";
       var __c2 = "";
       var __i15 = 0;
       while (__i15 < _35(args)) {
-        var __x84 = args[__i15];
-        if (accessor63(__x84) || obj63(__x84) && accessor63(hd(__x84))) {
-          return compile_next("(" + __s2 + ")", cut(args, __i15), call63);
+        var __x71 = args[__i15];
+        if (accessor63(__x71) || obj63(__x71) && accessor63(hd(__x71))) {
+          return compileNext("(" + __s2 + ")", cut(args, __i15), call63);
         } else {
-          __s2 = __s2 + __c2 + compile(__x84);
+          __s2 = __s2 + __c2 + compile(__x71);
         }
         __c2 = ", ";
         __i15 = __i15 + 1;
@@ -626,37 +631,37 @@ compile_args = function (args, call63) {
     }
   }
 };
-var escape_newlines = function (s) {
+var escapeNewlines = function (s) {
   var __s11 = "";
   var __i16 = 0;
   while (__i16 < _35(s)) {
     var __c3 = char(s, __i16);
-    var __e37;
+    var __e27;
     if (__c3 === "\n") {
-      __e37 = "\\n";
+      __e27 = "\\n";
     } else {
-      var __e38;
+      var __e28;
       if (__c3 === "\r") {
-        __e38 = "\\r";
+        __e28 = "\\r";
       } else {
-        __e38 = __c3;
+        __e28 = __c3;
       }
-      __e37 = __e38;
+      __e27 = __e28;
     }
-    __s11 = __s11 + __e37;
+    __s11 = __s11 + __e27;
     __i16 = __i16 + 1;
   }
   return __s11;
 };
 accessor = function (x) {
-  var __prop = id(clip(x, 1), true);
-  if (valid_id63(__prop)) {
+  var __prop = compileId(clip(x, 1));
+  if (validId63(__prop)) {
     return "." + __prop;
   } else {
     return "[" + escape(__prop) + "]";
   }
 };
-var compile_atom = function (x) {
+var compileAtom = function (x) {
   if (accessor63(x)) {
     return accessor(x);
   } else {
@@ -666,14 +671,19 @@ var compile_atom = function (x) {
       if (x === "nil") {
         return "undefined";
       } else {
-        if (id_literal63(x)) {
+        if (idLiteral63(x)) {
           return inner(x);
         } else {
-          if (string_literal63(x)) {
-            return escape_newlines(x);
+          if (stringLiteral63(x)) {
+            return escapeNewlines(x);
           } else {
             if (string63(x)) {
-              return id(x);
+              var __s3 = compileId(x);
+              if (reserved63(__s3)) {
+                return "_" + __s3;
+              } else {
+                return __s3;
+              }
             } else {
               if (boolean63(x)) {
                 if (x) {
@@ -718,196 +728,196 @@ var terminator = function (stmt63) {
     }
   }
 };
-var compile_special = function (form, stmt63) {
-  var ____id6 = form;
-  var __x85 = ____id6[0];
-  var __args2 = cut(____id6, 1);
-  var ____id7 = getenv(__x85);
-  var __special = ____id7.special;
-  var __stmt = ____id7.stmt;
-  var __self_tr63 = ____id7.tr;
-  var __tr = terminator(stmt63 && ! __self_tr63);
+var compileSpecial = function (form, stmt63) {
+  var ____id8 = form;
+  var __x72 = ____id8[0];
+  var __args2 = cut(____id8, 1);
+  var ____id9 = getenv(__x72);
+  var __special = ____id9.special;
+  var __stmt = ____id9.stmt;
+  var __selfTr63 = ____id9.tr;
+  var __tr = terminator(stmt63 && ! __selfTr63);
   return apply(__special, __args2) + __tr;
 };
-var parenthesize_call63 = function (x) {
+var parenthesizeCall63 = function (x) {
   return ! atom63(x) && hd(x) === "%function" || precedence(x) > 0;
 };
-var compile_call = function (form) {
+var compileCall = function (form) {
   var __f = hd(form);
   var __f1 = compile(__f);
-  var __args3 = compile_args(stash42(tl(form)));
-  if (parenthesize_call63(__f)) {
+  var __args3 = compileArgs(stash42(tl(form)));
+  if (parenthesizeCall63(__f)) {
     return "(" + __f1 + ")" + __args3;
   } else {
     return __f1 + __args3;
   }
 };
-var op_delims = function (parent, child) {
-  var ____r57 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __parent = destash33(parent, ____r57);
-  var __child = destash33(child, ____r57);
-  var ____id8 = ____r57;
-  var __right = ____id8.right;
-  var __e39;
+var opDelims = function (parent, child) {
+  var ____r59 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __parent = destash33(parent, ____r59);
+  var __child = destash33(child, ____r59);
+  var ____id10 = ____r59;
+  var __right = ____id10.right;
+  var __e29;
   if (__right) {
-    __e39 = _6261;
+    __e29 = _6261;
   } else {
-    __e39 = _62;
+    __e29 = _62;
   }
-  if (__e39(precedence(__child), precedence(__parent))) {
+  if (__e29(precedence(__child), precedence(__parent))) {
     return ["(", ")"];
   } else {
     return ["", ""];
   }
 };
-var compile_infix = function (form) {
-  var ____id9 = form;
-  var __op = ____id9[0];
-  var ____id10 = cut(____id9, 1);
-  var __a1 = ____id10[0];
-  var __b2 = ____id10[1];
-  var ____id111 = op_delims(form, __a1);
-  var __ao = ____id111[0];
-  var __ac = ____id111[1];
-  var ____id12 = op_delims(form, __b2, {_stash: true, right: true});
-  var __bo = ____id12[0];
-  var __bc = ____id12[1];
-  var __a2 = compile(__a1);
+var compileInfix = function (form) {
+  var ____id111 = form;
+  var __op = ____id111[0];
+  var ____id12 = cut(____id111, 1);
+  var __a2 = ____id12[0];
+  var __b2 = ____id12[1];
+  var ____id13 = opDelims(form, __a2);
+  var __ao = ____id13[0];
+  var __ac = ____id13[1];
+  var ____id14 = opDelims(form, __b2, {_stash: true, right: true});
+  var __bo = ____id14[0];
+  var __bc = ____id14[1];
+  var __a3 = compile(__a2);
   var __b3 = compile(__b2);
   var __op1 = getop(__op);
   if (unary63(form)) {
-    return __op1 + __ao + " " + __a2 + __ac;
+    return __op1 + __ao + " " + __a3 + __ac;
   } else {
-    return __ao + __a2 + __ac + " " + __op1 + " " + __bo + __b3 + __bc;
+    return __ao + __a3 + __ac + " " + __op1 + " " + __bo + __b3 + __bc;
   }
 };
-compile_function = function (args, body) {
-  var ____r59 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __args4 = destash33(args, ____r59);
-  var __body3 = destash33(body, ____r59);
-  var ____id13 = ____r59;
-  var __name3 = ____id13.name;
-  var __prefix = ____id13.prefix;
-  var __e40;
+compileFunction = function (args, body) {
+  var ____r61 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __args4 = destash33(args, ____r61);
+  var __body3 = destash33(body, ____r61);
+  var ____id15 = ____r61;
+  var __name3 = ____id15.name;
+  var __prefix = ____id15.prefix;
+  var __e30;
   if (__name3) {
-    __e40 = compile(__name3);
+    __e30 = compile(__name3);
   } else {
-    __e40 = "";
+    __e30 = "";
   }
-  var __id14 = __e40;
-  var __e41;
+  var __id16 = __e30;
+  var __e31;
   if (target === "lua" && __args4.rest) {
-    __e41 = join(__args4, ["|...|"]);
+    __e31 = join(__args4, ["|...|"]);
   } else {
-    __e41 = __args4;
+    __e31 = __args4;
   }
-  var __args12 = __e41;
-  var __args5 = compile_args(__args12);
-  indent_level = indent_level + 1;
-  var ____x89 = compile(__body3, {_stash: true, stmt: true});
-  indent_level = indent_level - 1;
-  var __body4 = ____x89;
+  var __args12 = __e31;
+  var __args5 = compileArgs(__args12);
+  indentLevel = indentLevel + 1;
+  var ____x76 = compile(__body3, {_stash: true, stmt: true});
+  indentLevel = indentLevel - 1;
+  var __body4 = ____x76;
   var __ind = indentation();
-  var __e42;
+  var __e32;
   if (__prefix) {
-    __e42 = __prefix + " ";
+    __e32 = __prefix + " ";
   } else {
-    __e42 = "";
+    __e32 = "";
   }
-  var __p = __e42;
-  var __e43;
+  var __p = __e32;
+  var __e33;
   if (target === "js") {
-    __e43 = "";
+    __e33 = "";
   } else {
-    __e43 = "end";
+    __e33 = "end";
   }
-  var __tr1 = __e43;
+  var __tr1 = __e33;
   if (__name3) {
     __tr1 = __tr1 + "\n";
   }
   if (target === "js") {
-    return "function " + __id14 + __args5 + " {\n" + __body4 + __ind + "}" + __tr1;
+    return "function " + __id16 + __args5 + " {\n" + __body4 + __ind + "}" + __tr1;
   } else {
-    return __p + "function " + __id14 + __args5 + "\n" + __body4 + __ind + __tr1;
+    return __p + "function " + __id16 + __args5 + "\n" + __body4 + __ind + __tr1;
   }
 };
-var can_return63 = function (form) {
+var canReturn63 = function (form) {
   return is63(form) && (atom63(form) || !( hd(form) === "return") && ! statement63(hd(form)));
 };
 compile = function (form) {
-  var ____r61 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __form = destash33(form, ____r61);
-  var ____id15 = ____r61;
-  var __stmt1 = ____id15.stmt;
+  var ____r63 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __form = destash33(form, ____r63);
+  var ____id17 = ____r63;
+  var __stmt1 = ____id17.stmt;
   if (nil63(__form)) {
     return "";
   } else {
-    if (special_form63(__form)) {
-      return compile_special(__form, __stmt1);
+    if (specialForm63(__form)) {
+      return compileSpecial(__form, __stmt1);
     } else {
       var __tr2 = terminator(__stmt1);
-      var __e44;
+      var __e34;
       if (__stmt1) {
-        __e44 = indentation();
+        __e34 = indentation();
       } else {
-        __e44 = "";
+        __e34 = "";
       }
-      var __ind1 = __e44;
-      var __e45;
+      var __ind1 = __e34;
+      var __e35;
       if (atom63(__form)) {
-        __e45 = compile_atom(__form);
+        __e35 = compileAtom(__form);
       } else {
-        var __e46;
+        var __e36;
         if (infix63(hd(__form))) {
-          __e46 = compile_infix(__form);
+          __e36 = compileInfix(__form);
         } else {
-          __e46 = compile_call(__form);
+          __e36 = compileCall(__form);
         }
-        __e45 = __e46;
+        __e35 = __e36;
       }
-      var __form1 = __e45;
+      var __form1 = __e35;
       return __ind1 + __form1 + __tr2;
     }
   }
 };
-var lower_statement = function (form, tail63) {
+var lowerStatement = function (form, tail63) {
   var __hoist = [];
   var __e = lower(form, __hoist, true, tail63);
-  var __e47;
+  var __e37;
   if (some63(__hoist) && is63(__e)) {
-    __e47 = join(["do"], __hoist, [__e]);
+    __e37 = join(["do"], __hoist, [__e]);
   } else {
-    var __e48;
+    var __e38;
     if (is63(__e)) {
-      __e48 = __e;
+      __e38 = __e;
     } else {
-      var __e49;
+      var __e39;
       if (_35(__hoist) > 1) {
-        __e49 = join(["do"], __hoist);
+        __e39 = join(["do"], __hoist);
       } else {
-        __e49 = hd(__hoist);
+        __e39 = hd(__hoist);
       }
-      __e48 = __e49;
+      __e38 = __e39;
     }
-    __e47 = __e48;
+    __e37 = __e38;
   }
-  return either(__e47, ["do"]);
+  return either(__e37, ["do"]);
 };
-var lower_body = function (body, tail63) {
-  return lower_statement(join(["do"], body), tail63);
+var lowerBody = function (body, tail63) {
+  return lowerStatement(join(["do"], body), tail63);
 };
 var literal63 = function (form) {
   return atom63(form) || hd(form) === "%array" || hd(form) === "%object";
 };
 var standalone63 = function (form) {
-  return ! atom63(form) && ! infix63(hd(form)) && ! literal63(form) && !( "get" === hd(form)) || id_literal63(form);
+  return ! atom63(form) && ! infix63(hd(form)) && ! literal63(form) && !( "get" === hd(form)) || idLiteral63(form);
 };
-var lower_do = function (args, hoist, stmt63, tail63) {
-  var ____x95 = almost(args);
+var lowerDo = function (args, hoist, stmt63, tail63) {
+  var ____x82 = almost(args);
   var ____i17 = 0;
-  while (____i17 < _35(____x95)) {
-    var __x96 = ____x95[____i17];
-    var ____y = lower(__x96, hoist, stmt63);
+  while (____i17 < _35(____x82)) {
+    var __x83 = ____x82[____i17];
+    var ____y = lower(__x83, hoist, stmt63);
     if (yes(____y)) {
       var __e1 = ____y;
       if (standalone63(__e1)) {
@@ -917,100 +927,100 @@ var lower_do = function (args, hoist, stmt63, tail63) {
     ____i17 = ____i17 + 1;
   }
   var __e2 = lower(last(args), hoist, stmt63, tail63);
-  if (tail63 && can_return63(__e2)) {
+  if (tail63 && canReturn63(__e2)) {
     return ["return", __e2];
   } else {
     return __e2;
   }
 };
-var lower_set = function (args, hoist, stmt63, tail63) {
-  var ____id16 = args;
-  var __lh = ____id16[0];
-  var __rh = ____id16[1];
+var lowerSet = function (args, hoist, stmt63, tail63) {
+  var ____id18 = args;
+  var __lh = ____id18[0];
+  var __rh = ____id18[1];
   add(hoist, ["%set", lower(__lh, hoist), lower(__rh, hoist)]);
   if (!( stmt63 && ! tail63)) {
     return __lh;
   }
 };
-var lower_if = function (args, hoist, stmt63, tail63) {
-  var ____id17 = args;
-  var __cond = ____id17[0];
-  var ___then = ____id17[1];
-  var ___else = ____id17[2];
+var lowerIf = function (args, hoist, stmt63, tail63) {
+  var ____id19 = args;
+  var __cond = ____id19[0];
+  var __then = ____id19[1];
+  var __else = ____id19[2];
   if (stmt63) {
-    var __e51;
-    if (is63(___else)) {
-      __e51 = [lower_body([___else], tail63)];
+    var __e41;
+    if (is63(__else)) {
+      __e41 = [lowerBody([__else], tail63)];
     }
-    return add(hoist, join(["%if", lower(__cond, hoist), lower_body([___then], tail63)], __e51));
+    return add(hoist, join(["%if", lower(__cond, hoist), lowerBody([__then], tail63)], __e41));
   } else {
     var __e3 = unique("e");
     add(hoist, ["%local", __e3]);
-    var __e50;
-    if (is63(___else)) {
-      __e50 = [lower(["%set", __e3, ___else])];
+    var __e40;
+    if (is63(__else)) {
+      __e40 = [lower(["%set", __e3, __else])];
     }
-    add(hoist, join(["%if", lower(__cond, hoist), lower(["%set", __e3, ___then])], __e50));
+    add(hoist, join(["%if", lower(__cond, hoist), lower(["%set", __e3, __then])], __e40));
     return __e3;
   }
 };
-var lower_short = function (x, args, hoist) {
-  var ____id18 = args;
-  var __a3 = ____id18[0];
-  var __b4 = ____id18[1];
+var lowerShort = function (x, args, hoist) {
+  var ____id20 = args;
+  var __a4 = ____id20[0];
+  var __b4 = ____id20[1];
   var __hoist1 = [];
   var __b11 = lower(__b4, __hoist1);
   if (some63(__hoist1)) {
-    var __id19 = unique("id");
-    var __e52;
+    var __id21 = unique("id");
+    var __e42;
     if (x === "and") {
-      __e52 = ["%if", __id19, __b4, __id19];
+      __e42 = ["%if", __id21, __b4, __id21];
     } else {
-      __e52 = ["%if", __id19, __id19, __b4];
+      __e42 = ["%if", __id21, __id21, __b4];
     }
-    return lower(["do", ["%local", __id19, __a3], __e52], hoist);
+    return lower(["do", ["%local", __id21, __a4], __e42], hoist);
   } else {
-    return [x, lower(__a3, hoist), __b11];
+    return [x, lower(__a4, hoist), __b11];
   }
 };
-var lower_try = function (args, hoist, tail63) {
-  return add(hoist, ["%try", lower_body(args, tail63)]);
+var lowerTry = function (args, hoist, tail63) {
+  return add(hoist, ["%try", lowerBody(args, tail63)]);
 };
-var lower_while = function (args, hoist) {
-  var ____id20 = args;
-  var __c4 = ____id20[0];
-  var __body5 = cut(____id20, 1);
+var lowerWhile = function (args, hoist) {
+  var ____id22 = args;
+  var __c4 = ____id22[0];
+  var __body5 = cut(____id22, 1);
   var __pre = [];
   var __c5 = lower(__c4, __pre);
-  var __e53;
+  var __e43;
   if (none63(__pre)) {
-    __e53 = ["while", __c5, lower_body(__body5)];
+    __e43 = ["while", __c5, lowerBody(__body5)];
   } else {
-    __e53 = ["while", true, join(["do"], __pre, [["%if", ["not", __c5], ["break"]], lower_body(__body5)])];
+    __e43 = ["while", true, join(["do"], __pre, [["%if", ["not", __c5], ["break"]], lowerBody(__body5)])];
   }
-  return add(hoist, __e53);
+  return add(hoist, __e43);
 };
-var lower_for = function (args, hoist) {
-  var ____id21 = args;
-  var __t = ____id21[0];
-  var __k13 = ____id21[1];
-  var __body6 = cut(____id21, 2);
-  return add(hoist, ["%for", lower(__t, hoist), __k13, lower_body(__body6)]);
-};
-var lower_function = function (args) {
-  var ____id22 = args;
-  var __a4 = ____id22[0];
-  var __body7 = cut(____id22, 1);
-  return ["%function", __a4, lower_body(__body7, true)];
-};
-var lower_definition = function (kind, args, hoist) {
+var lowerFor = function (args, hoist) {
   var ____id23 = args;
-  var __name4 = ____id23[0];
-  var __args6 = ____id23[1];
-  var __body8 = cut(____id23, 2);
-  return add(hoist, [kind, __name4, __args6, lower_body(__body8, true)]);
+  var __t = ____id23[0];
+  var __k13 = ____id23[1];
+  var __body6 = cut(____id23, 2);
+  return add(hoist, ["%for", lower(__t, hoist), __k13, lowerBody(__body6)]);
 };
-var lower_call = function (form, hoist) {
+var lowerFunction = function (args) {
+  var ____id24 = args;
+  var __a5 = ____id24[0];
+  var __body7 = cut(____id24, 1);
+  return ["%function", __a5, lowerBody(__body7, true)];
+};
+var lowerDefinition = function (kind, args, hoist) {
+  var ____id25 = args;
+  var __name4 = ____id25[0];
+  var __args6 = ____id25[1];
+  var __body8 = cut(____id25, 2);
+  return add(hoist, [kind, __name4, __args6, lowerBody(__body8, true)]);
+};
+var lowerCall = function (form, hoist) {
   var __form2 = map(function (x) {
     return lower(x, hoist);
   }, form);
@@ -1021,14 +1031,14 @@ var lower_call = function (form, hoist) {
 var pairwise63 = function (form) {
   return in63(hd(form), ["<", "<=", "=", ">=", ">"]);
 };
-var lower_pairwise = function (form) {
+var lowerPairwise = function (form) {
   if (pairwise63(form)) {
     var __e4 = [];
-    var ____id24 = form;
-    var __x125 = ____id24[0];
-    var __args7 = cut(____id24, 1);
+    var ____id26 = form;
+    var __x112 = ____id26[0];
+    var __args7 = cut(____id26, 1);
     reduce(function (a, b) {
-      add(__e4, [__x125, a, b]);
+      add(__e4, [__x112, a, b]);
       return a;
     }, __args7);
     return join(["and"], reverse(__e4));
@@ -1036,20 +1046,20 @@ var lower_pairwise = function (form) {
     return form;
   }
 };
-var lower_infix63 = function (form) {
+var lowerInfix63 = function (form) {
   return infix63(hd(form)) && _35(form) > 3;
 };
-var lower_infix = function (form, hoist) {
-  var __form3 = lower_pairwise(form);
-  var ____id25 = __form3;
-  var __x128 = ____id25[0];
-  var __args8 = cut(____id25, 1);
+var lowerInfix = function (form, hoist) {
+  var __form3 = lowerPairwise(form);
+  var ____id27 = __form3;
+  var __x115 = ____id27[0];
+  var __args8 = cut(____id27, 1);
   return lower(reduce(function (a, b) {
-    return [__x128, b, a];
+    return [__x115, b, a];
   }, reverse(__args8)), hoist);
 };
-var lower_special = function (form, hoist) {
-  var __e5 = lower_call(form, hoist);
+var lowerSpecial = function (form, hoist) {
+  var __e5 = lowerCall(form, hoist);
   if (__e5) {
     return add(hoist, __e5);
   }
@@ -1062,48 +1072,48 @@ lower = function (form, hoist, stmt63, tail63) {
       return ["%array"];
     } else {
       if (nil63(hoist)) {
-        return lower_statement(form);
+        return lowerStatement(form);
       } else {
-        if (lower_infix63(form)) {
-          return lower_infix(form, hoist);
+        if (lowerInfix63(form)) {
+          return lowerInfix(form, hoist);
         } else {
-          var ____id26 = form;
-          var __x131 = ____id26[0];
-          var __args9 = cut(____id26, 1);
-          if (__x131 === "do") {
-            return lower_do(__args9, hoist, stmt63, tail63);
+          var ____id28 = form;
+          var __x118 = ____id28[0];
+          var __args9 = cut(____id28, 1);
+          if (__x118 === "do") {
+            return lowerDo(__args9, hoist, stmt63, tail63);
           } else {
-            if (__x131 === "%call") {
+            if (__x118 === "%call") {
               return lower(__args9, hoist, stmt63, tail63);
             } else {
-              if (__x131 === "%set") {
-                return lower_set(__args9, hoist, stmt63, tail63);
+              if (__x118 === "%set") {
+                return lowerSet(__args9, hoist, stmt63, tail63);
               } else {
-                if (__x131 === "%if") {
-                  return lower_if(__args9, hoist, stmt63, tail63);
+                if (__x118 === "%if") {
+                  return lowerIf(__args9, hoist, stmt63, tail63);
                 } else {
-                  if (__x131 === "%try") {
-                    return lower_try(__args9, hoist, tail63);
+                  if (__x118 === "%try") {
+                    return lowerTry(__args9, hoist, tail63);
                   } else {
-                    if (__x131 === "while") {
-                      return lower_while(__args9, hoist);
+                    if (__x118 === "while") {
+                      return lowerWhile(__args9, hoist);
                     } else {
-                      if (__x131 === "%for") {
-                        return lower_for(__args9, hoist);
+                      if (__x118 === "%for") {
+                        return lowerFor(__args9, hoist);
                       } else {
-                        if (__x131 === "%function") {
-                          return lower_function(__args9);
+                        if (__x118 === "%function") {
+                          return lowerFunction(__args9);
                         } else {
-                          if (__x131 === "%local-function" || __x131 === "%global-function") {
-                            return lower_definition(__x131, __args9, hoist);
+                          if (__x118 === "%local-function" || __x118 === "%global-function") {
+                            return lowerDefinition(__x118, __args9, hoist);
                           } else {
-                            if (in63(__x131, ["and", "or"])) {
-                              return lower_short(__x131, __args9, hoist);
+                            if (in63(__x118, ["and", "or"])) {
+                              return lowerShort(__x118, __args9, hoist);
                             } else {
-                              if (statement63(__x131)) {
-                                return lower_special(form, hoist);
+                              if (statement63(__x118)) {
+                                return lowerSpecial(form, hoist);
                               } else {
-                                return lower_call(form, hoist);
+                                return lowerCall(form, hoist);
                               }
                             }
                           }
@@ -1134,102 +1144,102 @@ _eval = function (form) {
   run(__code);
   return _37result;
 };
-immediate_call63 = function (x) {
+immediateCall63 = function (x) {
   return obj63(x) && obj63(hd(x)) && hd(hd(x)) === "%function";
 };
 setenv("do", {_stash: true, special: function () {
-  var __forms1 = unstash(Array.prototype.slice.call(arguments, 0));
-  var __s3 = "";
-  var ____x136 = __forms1;
-  var ____i19 = 0;
-  while (____i19 < _35(____x136)) {
-    var __x137 = ____x136[____i19];
-    if (target === "lua" && immediate_call63(__x137) && "\n" === char(__s3, edge(__s3))) {
-      __s3 = clip(__s3, 0, edge(__s3)) + ";\n";
+  var __forms = unstash(Array.prototype.slice.call(arguments, 0));
+  var __s4 = "";
+  var ____x121 = __forms;
+  var ____i18 = 0;
+  while (____i18 < _35(____x121)) {
+    var __x122 = ____x121[____i18];
+    if (target === "lua" && immediateCall63(__x122) && "\n" === char(__s4, edge(__s4))) {
+      __s4 = clip(__s4, 0, edge(__s4)) + ";\n";
     }
-    __s3 = __s3 + compile(__x137, {_stash: true, stmt: true});
-    if (! atom63(__x137)) {
-      if (hd(__x137) === "return" || hd(__x137) === "break") {
+    __s4 = __s4 + compile(__x122, {_stash: true, stmt: true});
+    if (! atom63(__x122)) {
+      if (hd(__x122) === "return" || hd(__x122) === "break") {
         break;
       }
     }
-    ____i19 = ____i19 + 1;
+    ____i18 = ____i18 + 1;
   }
-  return __s3;
+  return __s4;
 }, stmt: true, tr: true});
 setenv("%if", {_stash: true, special: function (cond, cons, alt) {
-  var __cond2 = compile(cond);
-  indent_level = indent_level + 1;
-  var ____x140 = compile(cons, {_stash: true, stmt: true});
-  indent_level = indent_level - 1;
-  var __cons1 = ____x140;
-  var __e54;
+  var __cond1 = compile(cond);
+  indentLevel = indentLevel + 1;
+  var ____x123 = compile(cons, {_stash: true, stmt: true});
+  indentLevel = indentLevel - 1;
+  var __cons = ____x123;
+  var __e44;
   if (alt) {
-    indent_level = indent_level + 1;
-    var ____x141 = compile(alt, {_stash: true, stmt: true});
-    indent_level = indent_level - 1;
-    __e54 = ____x141;
+    indentLevel = indentLevel + 1;
+    var ____x124 = compile(alt, {_stash: true, stmt: true});
+    indentLevel = indentLevel - 1;
+    __e44 = ____x124;
   }
-  var __alt1 = __e54;
-  var __ind3 = indentation();
+  var __alt = __e44;
+  var __ind2 = indentation();
   var __s5 = "";
   if (target === "js") {
-    __s5 = __s5 + __ind3 + "if (" + __cond2 + ") {\n" + __cons1 + __ind3 + "}";
+    __s5 = __s5 + __ind2 + "if (" + __cond1 + ") {\n" + __cons + __ind2 + "}";
   } else {
-    __s5 = __s5 + __ind3 + "if " + __cond2 + " then\n" + __cons1;
+    __s5 = __s5 + __ind2 + "if " + __cond1 + " then\n" + __cons;
   }
-  if (__alt1 && target === "js") {
-    __s5 = __s5 + " else {\n" + __alt1 + __ind3 + "}";
+  if (__alt && target === "js") {
+    __s5 = __s5 + " else {\n" + __alt + __ind2 + "}";
   } else {
-    if (__alt1) {
-      __s5 = __s5 + __ind3 + "else\n" + __alt1;
+    if (__alt) {
+      __s5 = __s5 + __ind2 + "else\n" + __alt;
     }
   }
   if (target === "lua") {
-    return __s5 + __ind3 + "end\n";
+    return __s5 + __ind2 + "end\n";
   } else {
     return __s5 + "\n";
   }
 }, stmt: true, tr: true});
 setenv("while", {_stash: true, special: function (cond, form) {
-  var __cond4 = compile(cond);
-  indent_level = indent_level + 1;
-  var ____x143 = compile(form, {_stash: true, stmt: true});
-  indent_level = indent_level - 1;
-  var __body10 = ____x143;
-  var __ind5 = indentation();
+  var __cond2 = compile(cond);
+  indentLevel = indentLevel + 1;
+  var ____x125 = compile(form, {_stash: true, stmt: true});
+  indentLevel = indentLevel - 1;
+  var __body9 = ____x125;
+  var __ind3 = indentation();
   if (target === "js") {
-    return __ind5 + "while (" + __cond4 + ") {\n" + __body10 + __ind5 + "}\n";
+    return __ind3 + "while (" + __cond2 + ") {\n" + __body9 + __ind3 + "}\n";
   } else {
-    return __ind5 + "while " + __cond4 + " do\n" + __body10 + __ind5 + "end\n";
+    return __ind3 + "while " + __cond2 + " do\n" + __body9 + __ind3 + "end\n";
   }
 }, stmt: true, tr: true});
 setenv("%for", {_stash: true, special: function (t, k, form) {
-  var __t2 = compile(t);
-  var __ind7 = indentation();
-  indent_level = indent_level + 1;
-  var ____x145 = compile(form, {_stash: true, stmt: true});
-  indent_level = indent_level - 1;
-  var __body12 = ____x145;
+  var __t1 = compile(t);
+  var __ind4 = indentation();
+  indentLevel = indentLevel + 1;
+  var ____x126 = compile(form, {_stash: true, stmt: true});
+  indentLevel = indentLevel - 1;
+  var __body10 = ____x126;
   if (target === "lua") {
-    return __ind7 + "for " + k + " in next, " + __t2 + " do\n" + __body12 + __ind7 + "end\n";
+    return __ind4 + "for " + k + " in next, " + __t1 + " do\n" + __body10 + __ind4 + "end\n";
   } else {
-    return __ind7 + "for (" + k + " in " + __t2 + ") {\n" + __body12 + __ind7 + "}\n";
+    return __ind4 + "for (" + k + " in " + __t1 + ") {\n" + __body10 + __ind4 + "}\n";
   }
 }, stmt: true, tr: true});
 setenv("%try", {_stash: true, special: function (form) {
-  var __e8 = unique("e");
-  var __ind9 = indentation();
-  indent_level = indent_level + 1;
-  var ____x150 = compile(form, {_stash: true, stmt: true});
-  indent_level = indent_level - 1;
-  var __body14 = ____x150;
-  var __hf1 = ["return", ["%array", false, __e8]];
-  indent_level = indent_level + 1;
-  var ____x153 = compile(__hf1, {_stash: true, stmt: true});
-  indent_level = indent_level - 1;
-  var __h1 = ____x153;
-  return __ind9 + "try {\n" + __body14 + __ind9 + "}\n" + __ind9 + "catch (" + __e8 + ") {\n" + __h1 + __ind9 + "}\n";
+  var __e6 = unique("e");
+  var __ind5 = indentation();
+  indentLevel = indentLevel + 1;
+  var ____x127 = compile(form, {_stash: true, stmt: true});
+  indentLevel = indentLevel - 1;
+  var __body11 = ____x127;
+  var __hf = ["return", ["%array", false, __e6]];
+  indentLevel = indentLevel + 1;
+  var ____x130 = compile(__hf, {_stash: true, stmt: true});
+  indentLevel = indentLevel - 1;
+  var __h = ____x130;
+  return __ind5 + "try {\n" + __body11 + __ind5 + "}\n" + __ind5 + "catch (" + __e6 + ") {\n" + __h + __ind5 + "}\n";
 }, stmt: true, tr: true});
 setenv("%delete", {_stash: true, special: function (place) {
   return indentation() + "delete " + compile(place);
@@ -1238,33 +1248,33 @@ setenv("break", {_stash: true, special: function () {
   return indentation() + "break";
 }, stmt: true});
 setenv("%function", {_stash: true, special: function (args, body) {
-  return compile_function(args, body);
+  return compileFunction(args, body);
 }});
 setenv("%global-function", {_stash: true, special: function (name, args, body) {
   if (target === "lua") {
-    var __x157 = compile_function(args, body, {_stash: true, name: name});
-    return indentation() + __x157;
+    var __x131 = compileFunction(args, body, {_stash: true, name: name});
+    return indentation() + __x131;
   } else {
     return compile(["%set", name, ["%function", args, body]], {_stash: true, stmt: true});
   }
 }, stmt: true, tr: true});
 setenv("%local-function", {_stash: true, special: function (name, args, body) {
   if (target === "lua") {
-    var __x163 = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
-    return indentation() + __x163;
+    var __x134 = compileFunction(args, body, {_stash: true, name: name, prefix: "local"});
+    return indentation() + __x134;
   } else {
     return compile(["%local", name, ["%function", args, body]], {_stash: true, stmt: true});
   }
 }, stmt: true, tr: true});
 setenv("return", {_stash: true, special: function (x) {
-  var __e55;
+  var __e45;
   if (nil63(x)) {
-    __e55 = "return";
+    __e45 = "return";
   } else {
-    __e55 = "return " + compile(x);
+    __e45 = "return " + compile(x);
   }
-  var __x167 = __e55;
-  return indentation() + __x167;
+  var __x137 = __e45;
+  return indentation() + __x137;
 }, stmt: true});
 setenv("new", {_stash: true, special: function (x) {
   return "new " + compile(x);
@@ -1273,134 +1283,134 @@ setenv("typeof", {_stash: true, special: function (x) {
   return "typeof(" + compile(x) + ")";
 }});
 setenv("error", {_stash: true, special: function (x) {
-  var __e56;
+  var __e46;
   if (target === "js") {
-    __e56 = "throw " + compile(["new", ["Error", x]]);
+    __e46 = "throw " + compile(["new", ["Error", x]]);
   } else {
-    __e56 = "error(" + compile(x) + ")";
+    __e46 = "error(" + compile(x) + ")";
   }
-  var __e12 = __e56;
-  return indentation() + __e12;
+  var __e7 = __e46;
+  return indentation() + __e7;
 }, stmt: true});
 setenv("%local", {_stash: true, special: function (name, value) {
-  var __id28 = compile(name);
-  var __value11 = compile(value);
-  var __e57;
+  var __id29 = compile(name);
+  var __value1 = compile(value);
+  var __e47;
   if (is63(value)) {
-    __e57 = " = " + __value11;
+    __e47 = " = " + __value1;
   } else {
-    __e57 = "";
+    __e47 = "";
   }
-  var __rh2 = __e57;
-  var __e58;
+  var __rh1 = __e47;
+  var __e48;
   if (target === "js") {
-    __e58 = "var ";
+    __e48 = "var ";
   } else {
-    __e58 = "local ";
+    __e48 = "local ";
   }
-  var __keyword1 = __e58;
-  var __ind11 = indentation();
-  return __ind11 + __keyword1 + __id28 + __rh2;
+  var __keyword = __e48;
+  var __ind6 = indentation();
+  return __ind6 + __keyword + __id29 + __rh1;
 }, stmt: true});
 setenv("%set", {_stash: true, special: function (lh, rh) {
-  var __lh2 = compile(lh);
-  var __e59;
+  var __lh1 = compile(lh);
+  var __e49;
   if (nil63(rh)) {
-    __e59 = "nil";
+    __e49 = "nil";
   } else {
-    __e59 = rh;
+    __e49 = rh;
   }
-  var __rh4 = compile(__e59);
-  return indentation() + __lh2 + " = " + __rh4;
+  var __rh2 = compile(__e49);
+  return indentation() + __lh1 + " = " + __rh2;
 }, stmt: true});
 setenv("get", {_stash: true, special: function (t, k) {
-  var __t12 = compile(t);
-  var __k121 = compile(k);
-  if (target === "lua" && char(__t12, 0) === "{" || infix_operator63(t)) {
-    __t12 = "(" + __t12 + ")";
+  var __t11 = compile(t);
+  var __k111 = compile(k);
+  if (target === "lua" && char(__t11, 0) === "{" || infixOperator63(t)) {
+    __t11 = "(" + __t11 + ")";
   }
-  if (string_literal63(k) && valid_id63(inner(k))) {
-    return __t12 + "." + inner(k);
+  if (stringLiteral63(k) && validId63(inner(k))) {
+    return __t11 + "." + inner(k);
   } else {
-    return __t12 + "[" + __k121 + "]";
+    return __t11 + "[" + __k111 + "]";
   }
 }});
 setenv("%array", {_stash: true, special: function () {
-  var __forms3 = unstash(Array.prototype.slice.call(arguments, 0));
-  var __e60;
+  var __forms1 = unstash(Array.prototype.slice.call(arguments, 0));
+  var __e50;
   if (target === "lua") {
-    __e60 = "{";
+    __e50 = "{";
   } else {
-    __e60 = "[";
+    __e50 = "[";
   }
-  var __open1 = __e60;
-  var __e61;
+  var __open = __e50;
+  var __e51;
   if (target === "lua") {
-    __e61 = "}";
+    __e51 = "}";
   } else {
-    __e61 = "]";
+    __e51 = "]";
   }
-  var __close1 = __e61;
-  var __s7 = "";
+  var __close = __e51;
+  var __s6 = "";
+  var __c6 = "";
+  var ____o9 = __forms1;
+  var __k14 = undefined;
+  for (__k14 in ____o9) {
+    var __v8 = ____o9[__k14];
+    var __e52;
+    if (numeric63(__k14)) {
+      __e52 = parseInt(__k14);
+    } else {
+      __e52 = __k14;
+    }
+    var __k15 = __e52;
+    if (number63(__k15)) {
+      __s6 = __s6 + __c6 + compile(__v8);
+      __c6 = ", ";
+    }
+  }
+  return __open + __s6 + __close;
+}});
+setenv("%object", {_stash: true, special: function () {
+  var __forms2 = unstash(Array.prototype.slice.call(arguments, 0));
+  var __s7 = "{";
   var __c7 = "";
-  var ____o10 = __forms3;
+  var __e53;
+  if (target === "lua") {
+    __e53 = " = ";
+  } else {
+    __e53 = ": ";
+  }
+  var __sep = __e53;
+  var ____o10 = pair(__forms2);
   var __k16 = undefined;
   for (__k16 in ____o10) {
     var __v9 = ____o10[__k16];
-    var __e62;
+    var __e54;
     if (numeric63(__k16)) {
-      __e62 = parseInt(__k16);
+      __e54 = parseInt(__k16);
     } else {
-      __e62 = __k16;
+      __e54 = __k16;
     }
-    var __k17 = __e62;
+    var __k17 = __e54;
     if (number63(__k17)) {
-      __s7 = __s7 + __c7 + compile(__v9);
+      var ____id30 = __v9;
+      var __k18 = ____id30[0];
+      var __v10 = ____id30[1];
+      if (! string63(__k18)) {
+        throw new Error("Illegal key: " + str(__k18));
+      }
+      __s7 = __s7 + __c7 + key(__k18) + __sep + compile(__v10);
       __c7 = ", ";
     }
   }
-  return __open1 + __s7 + __close1;
-}});
-setenv("%object", {_stash: true, special: function () {
-  var __forms5 = unstash(Array.prototype.slice.call(arguments, 0));
-  var __s9 = "{";
-  var __c9 = "";
-  var __e63;
-  if (target === "lua") {
-    __e63 = " = ";
-  } else {
-    __e63 = ": ";
-  }
-  var __sep1 = __e63;
-  var ____o12 = pair(__forms5);
-  var __k21 = undefined;
-  for (__k21 in ____o12) {
-    var __v12 = ____o12[__k21];
-    var __e64;
-    if (numeric63(__k21)) {
-      __e64 = parseInt(__k21);
-    } else {
-      __e64 = __k21;
-    }
-    var __k22 = __e64;
-    if (number63(__k22)) {
-      var ____id30 = __v12;
-      var __k23 = ____id30[0];
-      var __v13 = ____id30[1];
-      if (! string63(__k23)) {
-        throw new Error("Illegal key: " + str(__k23));
-      }
-      __s9 = __s9 + __c9 + key(__k23) + __sep1 + compile(__v13);
-      __c9 = ", ";
-    }
-  }
-  return __s9 + "}";
+  return __s7 + "}";
 }});
 setenv("%literal", {_stash: true, special: function () {
-  var __args111 = unstash(Array.prototype.slice.call(arguments, 0));
-  return apply(cat, map(compile, __args111));
+  var __args10 = unstash(Array.prototype.slice.call(arguments, 0));
+  return apply(cat, map(compile, __args10));
 }});
 exports.run = run;
-exports["eval"] = _eval;
+exports.eval = _eval;
 exports.expand = expand;
 exports.compile = compile;

--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -4,13 +4,13 @@ var getenv = function (k, p) {
     while (__i >= 0) {
       var __b = environment[__i][k];
       if (is63(__b)) {
-        var __e8;
+        var __e21;
         if (p) {
-          __e8 = __b[p];
+          __e21 = __b[p];
         } else {
-          __e8 = __b;
+          __e21 = __b;
         }
-        return __e8;
+        return __e21;
       } else {
         __i = __i - 1;
       }
@@ -69,13 +69,13 @@ var stash42 = function (args) {
     var __k = undefined;
     for (__k in ____o) {
       var __v = ____o[__k];
-      var __e9;
+      var __e22;
       if (numeric63(__k)) {
-        __e9 = parseInt(__k);
+        __e22 = parseInt(__k);
       } else {
-        __e9 = __k;
+        __e22 = __k;
       }
-      var __k1 = __e9;
+      var __k1 = __e22;
       if (! number63(__k1)) {
         add(__l, literal(__k1));
         add(__l, __v);
@@ -106,28 +106,28 @@ bind = function (lh, rh) {
     var __k2 = undefined;
     for (__k2 in ____o1) {
       var __v1 = ____o1[__k2];
-      var __e10;
+      var __e23;
       if (numeric63(__k2)) {
-        __e10 = parseInt(__k2);
+        __e23 = parseInt(__k2);
       } else {
-        __e10 = __k2;
+        __e23 = __k2;
       }
-      var __k3 = __e10;
-      var __e11;
+      var __k3 = __e23;
+      var __e24;
       if (__k3 === "rest") {
-        __e11 = ["cut", __id, _35(lh)];
+        __e24 = ["cut", __id, _35(lh)];
       } else {
-        __e11 = ["get", __id, ["quote", bias(__k3)]];
+        __e24 = ["get", __id, ["quote", bias(__k3)]];
       }
-      var __x5 = __e11;
+      var __x5 = __e24;
       if (is63(__k3)) {
-        var __e12;
+        var __e25;
         if (__v1 === true) {
-          __e12 = __k3;
+          __e25 = __k3;
         } else {
-          __e12 = __v1;
+          __e25 = __v1;
         }
-        var __k4 = __e12;
+        var __k4 = __e25;
         __bs = join(__bs, bind(__k4, __x5));
       }
     }
@@ -151,38 +151,38 @@ bind42 = function (args, body) {
     return [__args1, join(["let", [args, rest()]], body)];
   } else {
     var __bs1 = [];
-    var __r18 = unique("r");
+    var __r19 = unique("r");
     var ____o2 = args;
     var __k5 = undefined;
     for (__k5 in ____o2) {
       var __v2 = ____o2[__k5];
-      var __e13;
+      var __e26;
       if (numeric63(__k5)) {
-        __e13 = parseInt(__k5);
+        __e26 = parseInt(__k5);
       } else {
-        __e13 = __k5;
+        __e26 = __k5;
       }
-      var __k6 = __e13;
+      var __k6 = __e26;
       if (number63(__k6)) {
         if (atom63(__v2)) {
           add(__args1, __v2);
         } else {
-          var __x17 = unique("x");
-          add(__args1, __x17);
-          __bs1 = join(__bs1, [__v2, __x17]);
+          var __x18 = unique("x");
+          add(__args1, __x18);
+          __bs1 = join(__bs1, [__v2, __x18]);
         }
       }
     }
     if (keys63(args)) {
-      __bs1 = join(__bs1, [__r18, rest()]);
+      __bs1 = join(__bs1, [__r19, rest()]);
       var __n3 = _35(__args1);
       var __i4 = 0;
       while (__i4 < __n3) {
         var __v3 = __args1[__i4];
-        __bs1 = join(__bs1, [__v3, ["destash!", __v3, __r18]]);
+        __bs1 = join(__bs1, [__v3, ["destash!", __v3, __r19]]);
         __i4 = __i4 + 1;
       }
-      __bs1 = join(__bs1, [keys(args), __r18]);
+      __bs1 = join(__bs1, [keys(args), __r19]);
     }
     return [__args1, join(["let", __bs1], body)];
   }
@@ -199,40 +199,40 @@ var canUnquote63 = function (depth) {
 var quasisplice63 = function (x, depth) {
   return canUnquote63(depth) && ! atom63(x) && hd(x) === "unquote-splicing";
 };
-var expandLocal = function (__x25) {
-  var ____id1 = __x25;
-  var __x26 = ____id1[0];
+var expandLocal = function (__x26) {
+  var ____id1 = __x26;
+  var __x27 = ____id1[0];
   var __name = ____id1[1];
   var __value = ____id1[2];
   setenv(__name, {_stash: true, variable: true});
   return ["%local", __name, macroexpand(__value)];
 };
-var expandFunction = function (__x28) {
-  var ____id2 = __x28;
-  var __x29 = ____id2[0];
+var expandFunction = function (__x29) {
+  var ____id2 = __x29;
+  var __x30 = ____id2[0];
   var __args = ____id2[1];
   var __body = cut(____id2, 2);
   add(environment, {});
   var ____o3 = __args;
   var ____i5 = undefined;
   for (____i5 in ____o3) {
-    var ____x30 = ____o3[____i5];
-    var __e14;
+    var ____x31 = ____o3[____i5];
+    var __e27;
     if (numeric63(____i5)) {
-      __e14 = parseInt(____i5);
+      __e27 = parseInt(____i5);
     } else {
-      __e14 = ____i5;
+      __e27 = ____i5;
     }
-    var ____i51 = __e14;
-    setenv(____x30, {_stash: true, variable: true});
+    var ____i51 = __e27;
+    setenv(____x31, {_stash: true, variable: true});
   }
-  var ____x31 = join(["%function", __args], macroexpand(__body));
+  var ____x32 = join(["%function", __args], macroexpand(__body));
   drop(environment);
-  return ____x31;
+  return ____x32;
 };
-var expandDefinition = function (__x33) {
-  var ____id3 = __x33;
-  var __x34 = ____id3[0];
+var expandDefinition = function (__x34) {
+  var ____id3 = __x34;
+  var __x35 = ____id3[0];
   var __name1 = ____id3[1];
   var __args11 = ____id3[2];
   var __body1 = cut(____id3, 3);
@@ -240,25 +240,25 @@ var expandDefinition = function (__x33) {
   var ____o4 = __args11;
   var ____i6 = undefined;
   for (____i6 in ____o4) {
-    var ____x35 = ____o4[____i6];
-    var __e15;
+    var ____x36 = ____o4[____i6];
+    var __e28;
     if (numeric63(____i6)) {
-      __e15 = parseInt(____i6);
+      __e28 = parseInt(____i6);
     } else {
-      __e15 = ____i6;
+      __e28 = ____i6;
     }
-    var ____i61 = __e15;
-    setenv(____x35, {_stash: true, variable: true});
+    var ____i61 = __e28;
+    setenv(____x36, {_stash: true, variable: true});
   }
-  var ____x36 = join([__x34, __name1, __args11], macroexpand(__body1));
+  var ____x37 = join([__x35, __name1, __args11], macroexpand(__body1));
   drop(environment);
-  return ____x36;
+  return ____x37;
 };
 var expandMacro = function (form) {
   return macroexpand(expand1(form));
 };
-expand1 = function (__x38) {
-  var ____id4 = __x38;
+expand1 = function (__x39) {
+  var ____id4 = __x39;
   var __name2 = ____id4[0];
   var __body2 = cut(____id4, 1);
   return apply(macroFunction(__name2), __body2);
@@ -270,20 +270,20 @@ macroexpand = function (form) {
     if (atom63(form)) {
       return form;
     } else {
-      var __x39 = hd(form);
-      if (__x39 === "%local") {
+      var __x40 = hd(form);
+      if (__x40 === "%local") {
         return expandLocal(form);
       } else {
-        if (__x39 === "%function") {
+        if (__x40 === "%function") {
           return expandFunction(form);
         } else {
-          if (__x39 === "%global-function") {
+          if (__x40 === "%global-function") {
             return expandDefinition(form);
           } else {
-            if (__x39 === "%local-function") {
+            if (__x40 === "%local-function") {
               return expandDefinition(form);
             } else {
-              if (macro63(__x39)) {
+              if (macro63(__x40)) {
                 return expandMacro(form);
               } else {
                 return map(macroexpand, form);
@@ -301,34 +301,34 @@ var quasiquoteList = function (form, depth) {
   var __k7 = undefined;
   for (__k7 in ____o5) {
     var __v4 = ____o5[__k7];
-    var __e16;
+    var __e29;
     if (numeric63(__k7)) {
-      __e16 = parseInt(__k7);
+      __e29 = parseInt(__k7);
     } else {
-      __e16 = __k7;
+      __e29 = __k7;
     }
-    var __k8 = __e16;
+    var __k8 = __e29;
     if (! number63(__k8)) {
-      var __e17;
+      var __e30;
       if (quasisplice63(__v4, depth)) {
-        __e17 = quasiexpand(__v4[1]);
+        __e30 = quasiexpand(__v4[1]);
       } else {
-        __e17 = quasiexpand(__v4, depth);
+        __e30 = quasiexpand(__v4, depth);
       }
-      var __v5 = __e17;
+      var __v5 = __e30;
       last(__xs)[__k8] = __v5;
     }
   }
-  var ____x42 = form;
+  var ____x43 = form;
   var ____i8 = 0;
-  while (____i8 < _35(____x42)) {
-    var __x43 = ____x42[____i8];
-    if (quasisplice63(__x43, depth)) {
-      var __x44 = quasiexpand(__x43[1]);
-      add(__xs, __x44);
+  while (____i8 < _35(____x43)) {
+    var __x44 = ____x43[____i8];
+    if (quasisplice63(__x44, depth)) {
+      var __x45 = quasiexpand(__x44[1]);
+      add(__xs, __x45);
       add(__xs, ["list"]);
     } else {
-      add(last(__xs), quasiexpand(__x43, depth));
+      add(last(__xs), quasiexpand(__x44, depth));
     }
     ____i8 = ____i8 + 1;
   }
@@ -378,8 +378,8 @@ quasiexpand = function (form, depth) {
     }
   }
 };
-expandIf = function (__x48) {
-  var ____id5 = __x48;
+expandIf = function (__x49) {
+  var ____id5 = __x49;
   var __a = ____id5[0];
   var __b1 = ____id5[1];
   var __c = cut(____id5, 2);
@@ -413,67 +413,67 @@ accessor63 = function (x) {
 };
 compileId = function (id) {
   var __id6 = camelCase(id);
-  var __e18;
+  var __e31;
   if (numberCode63(code(__id6, 0))) {
-    __e18 = "_";
+    __e31 = "_";
   } else {
-    __e18 = "";
+    __e31 = "";
   }
-  var __id11 = __e18;
+  var __id11 = __e31;
   var __i10 = 0;
   while (__i10 < _35(__id6)) {
     var __c1 = char(__id6, __i10);
     var __n7 = code(__c1);
-    var __e19;
+    var __e32;
     if (__c1 === "-" && !( __id6 === "-")) {
-      __e19 = "_";
+      __e32 = "_";
     } else {
-      var __e20;
+      var __e33;
       if (validCode63(__n7)) {
-        __e20 = __c1;
+        __e33 = __c1;
       } else {
-        var __e21;
+        var __e34;
         if (__i10 === 0) {
-          __e21 = "_" + __n7;
+          __e34 = "_" + __n7;
         } else {
-          __e21 = __n7;
+          __e34 = __n7;
         }
-        __e20 = __e21;
+        __e33 = __e34;
       }
-      __e19 = __e20;
+      __e32 = __e33;
     }
-    var __c11 = __e19;
+    var __c11 = __e32;
     __id11 = __id11 + __c11;
     __i10 = __i10 + 1;
   }
   return __id11;
 };
 validId63 = function (x) {
-  var __id31 = some63(x) && x === compileId(x);
-  var __e23;
-  if (__id31) {
-    var __e24;
+  var __id33 = some63(x) && x === compileId(x);
+  var __e36;
+  if (__id33) {
+    var __e37;
     if (target === "lua") {
-      __e24 = ! reserved63(x);
+      __e37 = ! reserved63(x);
     } else {
-      __e24 = true;
+      __e37 = true;
     }
-    __e23 = __e24;
+    __e36 = __e37;
   } else {
-    __e23 = __id31;
+    __e36 = __id33;
   }
-  return __e23;
+  return __e36;
 };
 var __names = {};
 unique = function (x) {
-  var __x52 = compileId(x);
-  if (__names[__x52]) {
-    var __i11 = __names[__x52];
-    __names[__x52] = __names[__x52] + 1;
-    return unique(__x52 + __i11);
+  var __x53 = compileId(x);
+  if (__names[__x53]) {
+    var __i11 = __names[__x53];
+    __names[__x53] = __names[__x53] + 1;
+    return unique(__x53 + __i11);
   } else {
-    __names[__x52] = 1;
-    return "__" + __x52;
+    __names[__x53] = 1;
+    return "__" + __x53;
   }
 };
 key = function (k) {
@@ -494,59 +494,59 @@ mapo = function (f, t) {
   var __k9 = undefined;
   for (__k9 in ____o7) {
     var __v6 = ____o7[__k9];
-    var __e25;
+    var __e38;
     if (numeric63(__k9)) {
-      __e25 = parseInt(__k9);
+      __e38 = parseInt(__k9);
     } else {
-      __e25 = __k9;
+      __e38 = __k9;
     }
-    var __k10 = __e25;
-    var __x53 = f(__v6);
-    if (is63(__x53)) {
+    var __k10 = __e38;
+    var __x54 = f(__v6);
+    if (is63(__x54)) {
       add(__o6, literal(__k10));
-      add(__o6, __x53);
+      add(__o6, __x54);
     }
   }
   return __o6;
 };
-var ____x55 = [];
 var ____x56 = [];
-____x56.js = "!";
-____x56.lua = "not";
-____x55.not = ____x56;
 var ____x57 = [];
-____x57["*"] = true;
-____x57["/"] = true;
-____x57["%"] = true;
+____x57.js = "!";
+____x57.lua = "not";
+____x56.not = ____x57;
 var ____x58 = [];
+____x58["*"] = true;
+____x58["/"] = true;
+____x58["%"] = true;
 var ____x59 = [];
-____x59.js = "+";
-____x59.lua = "..";
-____x58.cat = ____x59;
 var ____x60 = [];
-____x60["+"] = true;
-____x60["-"] = true;
+____x60.js = "+";
+____x60.lua = "..";
+____x59.cat = ____x60;
 var ____x61 = [];
-____x61["<"] = true;
-____x61[">"] = true;
-____x61["<="] = true;
-____x61[">="] = true;
+____x61["+"] = true;
+____x61["-"] = true;
 var ____x62 = [];
+____x62["<"] = true;
+____x62[">"] = true;
+____x62["<="] = true;
+____x62[">="] = true;
 var ____x63 = [];
-____x63.js = "===";
-____x63.lua = "==";
-____x62["="] = ____x63;
 var ____x64 = [];
+____x64.js = "===";
+____x64.lua = "==";
+____x63["="] = ____x64;
 var ____x65 = [];
-____x65.js = "&&";
-____x65.lua = "and";
-____x64.and = ____x65;
 var ____x66 = [];
+____x66.js = "&&";
+____x66.lua = "and";
+____x65.and = ____x66;
 var ____x67 = [];
-____x67.js = "||";
-____x67.lua = "or";
-____x66.or = ____x67;
-var infix = [____x55, ____x57, ____x58, ____x60, ____x61, ____x62, ____x64, ____x66];
+var ____x68 = [];
+____x68.js = "||";
+____x68.lua = "or";
+____x67.or = ____x68;
+var infix = [____x56, ____x58, ____x59, ____x61, ____x62, ____x63, ____x65, ____x67];
 var unary63 = function (form) {
   return two63(form) && in63(hd(form), ["not", "-"]);
 };
@@ -559,13 +559,13 @@ var precedence = function (form) {
     var __k11 = undefined;
     for (__k11 in ____o8) {
       var __v7 = ____o8[__k11];
-      var __e26;
+      var __e39;
       if (numeric63(__k11)) {
-        __e26 = parseInt(__k11);
+        __e39 = parseInt(__k11);
       } else {
-        __e26 = __k11;
+        __e39 = __k11;
       }
-      var __k12 = __e26;
+      var __k12 = __e39;
       if (__v7[hd(form)]) {
         return index(__k12);
       }
@@ -575,12 +575,12 @@ var precedence = function (form) {
 };
 var getop = function (op) {
   return find(function (level) {
-    var __x69 = level[op];
-    if (__x69 === true) {
+    var __x70 = level[op];
+    if (__x70 === true) {
       return op;
     } else {
-      if (is63(__x69)) {
-        return __x69[target];
+      if (is63(__x70)) {
+        return __x70[target];
       }
     }
   }, infix);
@@ -609,20 +609,20 @@ compileArgs = function (args, call63) {
   } else {
     if (obj63(__a1) && accessor63(hd(__a1))) {
       var ____id7 = __a1;
-      var __x70 = ____id7[0];
+      var __x71 = ____id7[0];
       var __ys = cut(____id7, 1);
-      var __s1 = compileNext(compile(__x70), __ys, true);
+      var __s1 = compileNext(compile(__x71), __ys, true);
       return compileNext(__s1, tl(args), call63);
     } else {
       var __s2 = "";
       var __c2 = "";
       var __i15 = 0;
       while (__i15 < _35(args)) {
-        var __x71 = args[__i15];
-        if (accessor63(__x71) || obj63(__x71) && accessor63(hd(__x71))) {
+        var __x72 = args[__i15];
+        if (accessor63(__x72) || obj63(__x72) && accessor63(hd(__x72))) {
           return compileNext("(" + __s2 + ")", cut(args, __i15), call63);
         } else {
-          __s2 = __s2 + __c2 + compile(__x71);
+          __s2 = __s2 + __c2 + compile(__x72);
         }
         __c2 = ", ";
         __i15 = __i15 + 1;
@@ -636,19 +636,19 @@ var escapeNewlines = function (s) {
   var __i16 = 0;
   while (__i16 < _35(s)) {
     var __c3 = char(s, __i16);
-    var __e27;
+    var __e40;
     if (__c3 === "\n") {
-      __e27 = "\\n";
+      __e40 = "\\n";
     } else {
-      var __e28;
+      var __e41;
       if (__c3 === "\r") {
-        __e28 = "\\r";
+        __e41 = "\\r";
       } else {
-        __e28 = __c3;
+        __e41 = __c3;
       }
-      __e27 = __e28;
+      __e40 = __e41;
     }
-    __s11 = __s11 + __e27;
+    __s11 = __s11 + __e40;
     __i16 = __i16 + 1;
   }
   return __s11;
@@ -730,9 +730,9 @@ var terminator = function (stmt63) {
 };
 var compileSpecial = function (form, stmt63) {
   var ____id8 = form;
-  var __x72 = ____id8[0];
+  var __x73 = ____id8[0];
   var __args2 = cut(____id8, 1);
-  var ____id9 = getenv(__x72);
+  var ____id9 = getenv(__x73);
   var __special = ____id9.special;
   var __stmt = ____id9.stmt;
   var __selfTr63 = ____id9.tr;
@@ -753,18 +753,18 @@ var compileCall = function (form) {
   }
 };
 var opDelims = function (parent, child) {
-  var ____r59 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __parent = destash33(parent, ____r59);
-  var __child = destash33(child, ____r59);
-  var ____id10 = ____r59;
+  var ____r60 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __parent = destash33(parent, ____r60);
+  var __child = destash33(child, ____r60);
+  var ____id10 = ____r60;
   var __right = ____id10.right;
-  var __e29;
+  var __e42;
   if (__right) {
-    __e29 = _6261;
+    __e42 = _6261;
   } else {
-    __e29 = _62;
+    __e42 = _62;
   }
-  if (__e29(precedence(__child), precedence(__parent))) {
+  if (__e42(precedence(__child), precedence(__parent))) {
     return ["(", ")"];
   } else {
     return ["", ""];
@@ -792,46 +792,46 @@ var compileInfix = function (form) {
   }
 };
 compileFunction = function (args, body) {
-  var ____r61 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __args4 = destash33(args, ____r61);
-  var __body3 = destash33(body, ____r61);
-  var ____id15 = ____r61;
+  var ____r62 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __args4 = destash33(args, ____r62);
+  var __body3 = destash33(body, ____r62);
+  var ____id15 = ____r62;
   var __name3 = ____id15.name;
   var __prefix = ____id15.prefix;
-  var __e30;
+  var __e43;
   if (__name3) {
-    __e30 = compile(__name3);
+    __e43 = compile(__name3);
   } else {
-    __e30 = "";
+    __e43 = "";
   }
-  var __id16 = __e30;
-  var __e31;
+  var __id16 = __e43;
+  var __e44;
   if (target === "lua" && __args4.rest) {
-    __e31 = join(__args4, ["|...|"]);
+    __e44 = join(__args4, ["|...|"]);
   } else {
-    __e31 = __args4;
+    __e44 = __args4;
   }
-  var __args12 = __e31;
+  var __args12 = __e44;
   var __args5 = compileArgs(__args12);
   indentLevel = indentLevel + 1;
-  var ____x76 = compile(__body3, {_stash: true, stmt: true});
+  var ____x77 = compile(__body3, {_stash: true, stmt: true});
   indentLevel = indentLevel - 1;
-  var __body4 = ____x76;
+  var __body4 = ____x77;
   var __ind = indentation();
-  var __e32;
+  var __e45;
   if (__prefix) {
-    __e32 = __prefix + " ";
+    __e45 = __prefix + " ";
   } else {
-    __e32 = "";
+    __e45 = "";
   }
-  var __p = __e32;
-  var __e33;
+  var __p = __e45;
+  var __e46;
   if (target === "js") {
-    __e33 = "";
+    __e46 = "";
   } else {
-    __e33 = "end";
+    __e46 = "end";
   }
-  var __tr1 = __e33;
+  var __tr1 = __e46;
   if (__name3) {
     __tr1 = __tr1 + "\n";
   }
@@ -845,9 +845,9 @@ var canReturn63 = function (form) {
   return is63(form) && (atom63(form) || !( hd(form) === "return") && ! statement63(hd(form)));
 };
 compile = function (form) {
-  var ____r63 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __form = destash33(form, ____r63);
-  var ____id17 = ____r63;
+  var ____r64 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __form = destash33(form, ____r64);
+  var ____id17 = ____r64;
   var __stmt1 = ____id17.stmt;
   if (nil63(__form)) {
     return "";
@@ -856,26 +856,26 @@ compile = function (form) {
       return compileSpecial(__form, __stmt1);
     } else {
       var __tr2 = terminator(__stmt1);
-      var __e34;
+      var __e47;
       if (__stmt1) {
-        __e34 = indentation();
+        __e47 = indentation();
       } else {
-        __e34 = "";
+        __e47 = "";
       }
-      var __ind1 = __e34;
-      var __e35;
+      var __ind1 = __e47;
+      var __e48;
       if (atom63(__form)) {
-        __e35 = compileAtom(__form);
+        __e48 = compileAtom(__form);
       } else {
-        var __e36;
+        var __e49;
         if (infix63(hd(__form))) {
-          __e36 = compileInfix(__form);
+          __e49 = compileInfix(__form);
         } else {
-          __e36 = compileCall(__form);
+          __e49 = compileCall(__form);
         }
-        __e35 = __e36;
+        __e48 = __e49;
       }
-      var __form1 = __e35;
+      var __form1 = __e48;
       return __ind1 + __form1 + __tr2;
     }
   }
@@ -883,25 +883,25 @@ compile = function (form) {
 var lowerStatement = function (form, tail63) {
   var __hoist = [];
   var __e = lower(form, __hoist, true, tail63);
-  var __e37;
+  var __e50;
   if (some63(__hoist) && is63(__e)) {
-    __e37 = join(["do"], __hoist, [__e]);
+    __e50 = join(["do"], __hoist, [__e]);
   } else {
-    var __e38;
+    var __e51;
     if (is63(__e)) {
-      __e38 = __e;
+      __e51 = __e;
     } else {
-      var __e39;
+      var __e52;
       if (_35(__hoist) > 1) {
-        __e39 = join(["do"], __hoist);
+        __e52 = join(["do"], __hoist);
       } else {
-        __e39 = hd(__hoist);
+        __e52 = hd(__hoist);
       }
-      __e38 = __e39;
+      __e51 = __e52;
     }
-    __e37 = __e38;
+    __e50 = __e51;
   }
-  return either(__e37, ["do"]);
+  return either(__e50, ["do"]);
 };
 var lowerBody = function (body, tail63) {
   return lowerStatement(join(["do"], body), tail63);
@@ -913,11 +913,11 @@ var standalone63 = function (form) {
   return ! atom63(form) && ! infix63(hd(form)) && ! literal63(form) && !( "get" === hd(form)) || idLiteral63(form);
 };
 var lowerDo = function (args, hoist, stmt63, tail63) {
-  var ____x82 = almost(args);
+  var ____x83 = almost(args);
   var ____i17 = 0;
-  while (____i17 < _35(____x82)) {
-    var __x83 = ____x82[____i17];
-    var ____y = lower(__x83, hoist, stmt63);
+  while (____i17 < _35(____x83)) {
+    var __x84 = ____x83[____i17];
+    var ____y = lower(__x84, hoist, stmt63);
     if (yes(____y)) {
       var __e1 = ____y;
       if (standalone63(__e1)) {
@@ -948,19 +948,19 @@ var lowerIf = function (args, hoist, stmt63, tail63) {
   var __then = ____id19[1];
   var __else = ____id19[2];
   if (stmt63) {
-    var __e41;
+    var __e54;
     if (is63(__else)) {
-      __e41 = [lowerBody([__else], tail63)];
+      __e54 = [lowerBody([__else], tail63)];
     }
-    return add(hoist, join(["%if", lower(__cond, hoist), lowerBody([__then], tail63)], __e41));
+    return add(hoist, join(["%if", lower(__cond, hoist), lowerBody([__then], tail63)], __e54));
   } else {
     var __e3 = unique("e");
     add(hoist, ["%local", __e3]);
-    var __e40;
+    var __e53;
     if (is63(__else)) {
-      __e40 = [lower(["%set", __e3, __else])];
+      __e53 = [lower(["%set", __e3, __else])];
     }
-    add(hoist, join(["%if", lower(__cond, hoist), lower(["%set", __e3, __then])], __e40));
+    add(hoist, join(["%if", lower(__cond, hoist), lower(["%set", __e3, __then])], __e53));
     return __e3;
   }
 };
@@ -972,13 +972,13 @@ var lowerShort = function (x, args, hoist) {
   var __b11 = lower(__b4, __hoist1);
   if (some63(__hoist1)) {
     var __id21 = unique("id");
-    var __e42;
+    var __e55;
     if (x === "and") {
-      __e42 = ["%if", __id21, __b4, __id21];
+      __e55 = ["%if", __id21, __b4, __id21];
     } else {
-      __e42 = ["%if", __id21, __id21, __b4];
+      __e55 = ["%if", __id21, __id21, __b4];
     }
-    return lower(["do", ["%local", __id21, __a4], __e42], hoist);
+    return lower(["do", ["%local", __id21, __a4], __e55], hoist);
   } else {
     return [x, lower(__a4, hoist), __b11];
   }
@@ -992,13 +992,13 @@ var lowerWhile = function (args, hoist) {
   var __body5 = cut(____id22, 1);
   var __pre = [];
   var __c5 = lower(__c4, __pre);
-  var __e43;
+  var __e56;
   if (none63(__pre)) {
-    __e43 = ["while", __c5, lowerBody(__body5)];
+    __e56 = ["while", __c5, lowerBody(__body5)];
   } else {
-    __e43 = ["while", true, join(["do"], __pre, [["%if", ["not", __c5], ["break"]], lowerBody(__body5)])];
+    __e56 = ["while", true, join(["do"], __pre, [["%if", ["not", __c5], ["break"]], lowerBody(__body5)])];
   }
-  return add(hoist, __e43);
+  return add(hoist, __e56);
 };
 var lowerFor = function (args, hoist) {
   var ____id23 = args;
@@ -1035,10 +1035,10 @@ var lowerPairwise = function (form) {
   if (pairwise63(form)) {
     var __e4 = [];
     var ____id26 = form;
-    var __x112 = ____id26[0];
+    var __x113 = ____id26[0];
     var __args7 = cut(____id26, 1);
     reduce(function (a, b) {
-      add(__e4, [__x112, a, b]);
+      add(__e4, [__x113, a, b]);
       return a;
     }, __args7);
     return join(["and"], reverse(__e4));
@@ -1052,10 +1052,10 @@ var lowerInfix63 = function (form) {
 var lowerInfix = function (form, hoist) {
   var __form3 = lowerPairwise(form);
   var ____id27 = __form3;
-  var __x115 = ____id27[0];
+  var __x116 = ____id27[0];
   var __args8 = cut(____id27, 1);
   return lower(reduce(function (a, b) {
-    return [__x115, b, a];
+    return [__x116, b, a];
   }, reverse(__args8)), hoist);
 };
 var lowerSpecial = function (form, hoist) {
@@ -1078,39 +1078,39 @@ lower = function (form, hoist, stmt63, tail63) {
           return lowerInfix(form, hoist);
         } else {
           var ____id28 = form;
-          var __x118 = ____id28[0];
+          var __x119 = ____id28[0];
           var __args9 = cut(____id28, 1);
-          if (__x118 === "do") {
+          if (__x119 === "do") {
             return lowerDo(__args9, hoist, stmt63, tail63);
           } else {
-            if (__x118 === "%call") {
+            if (__x119 === "%call") {
               return lower(__args9, hoist, stmt63, tail63);
             } else {
-              if (__x118 === "%set") {
+              if (__x119 === "%set") {
                 return lowerSet(__args9, hoist, stmt63, tail63);
               } else {
-                if (__x118 === "%if") {
+                if (__x119 === "%if") {
                   return lowerIf(__args9, hoist, stmt63, tail63);
                 } else {
-                  if (__x118 === "%try") {
+                  if (__x119 === "%try") {
                     return lowerTry(__args9, hoist, tail63);
                   } else {
-                    if (__x118 === "while") {
+                    if (__x119 === "while") {
                       return lowerWhile(__args9, hoist);
                     } else {
-                      if (__x118 === "%for") {
+                      if (__x119 === "%for") {
                         return lowerFor(__args9, hoist);
                       } else {
-                        if (__x118 === "%function") {
+                        if (__x119 === "%function") {
                           return lowerFunction(__args9);
                         } else {
-                          if (__x118 === "%local-function" || __x118 === "%global-function") {
-                            return lowerDefinition(__x118, __args9, hoist);
+                          if (__x119 === "%local-function" || __x119 === "%global-function") {
+                            return lowerDefinition(__x119, __args9, hoist);
                           } else {
-                            if (in63(__x118, ["and", "or"])) {
-                              return lowerShort(__x118, __args9, hoist);
+                            if (in63(__x119, ["and", "or"])) {
+                              return lowerShort(__x119, __args9, hoist);
                             } else {
-                              if (statement63(__x118)) {
+                              if (statement63(__x119)) {
                                 return lowerSpecial(form, hoist);
                               } else {
                                 return lowerCall(form, hoist);
@@ -1148,98 +1148,98 @@ immediateCall63 = function (x) {
   return obj63(x) && obj63(hd(x)) && hd(hd(x)) === "%function";
 };
 setenv("do", {_stash: true, special: function () {
-  var __forms = unstash(Array.prototype.slice.call(arguments, 0));
-  var __s4 = "";
-  var ____x121 = __forms;
-  var ____i18 = 0;
-  while (____i18 < _35(____x121)) {
-    var __x122 = ____x121[____i18];
-    if (target === "lua" && immediateCall63(__x122) && "\n" === char(__s4, edge(__s4))) {
-      __s4 = clip(__s4, 0, edge(__s4)) + ";\n";
+  var __forms1 = unstash(Array.prototype.slice.call(arguments, 0));
+  var __s5 = "";
+  var ____x124 = __forms1;
+  var ____i19 = 0;
+  while (____i19 < _35(____x124)) {
+    var __x125 = ____x124[____i19];
+    if (target === "lua" && immediateCall63(__x125) && "\n" === char(__s5, edge(__s5))) {
+      __s5 = clip(__s5, 0, edge(__s5)) + ";\n";
     }
-    __s4 = __s4 + compile(__x122, {_stash: true, stmt: true});
-    if (! atom63(__x122)) {
-      if (hd(__x122) === "return" || hd(__x122) === "break") {
+    __s5 = __s5 + compile(__x125, {_stash: true, stmt: true});
+    if (! atom63(__x125)) {
+      if (hd(__x125) === "return" || hd(__x125) === "break") {
         break;
       }
     }
-    ____i18 = ____i18 + 1;
+    ____i19 = ____i19 + 1;
   }
-  return __s4;
+  return __s5;
 }, stmt: true, tr: true});
 setenv("%if", {_stash: true, special: function (cond, cons, alt) {
-  var __cond1 = compile(cond);
+  var __cond2 = compile(cond);
   indentLevel = indentLevel + 1;
-  var ____x123 = compile(cons, {_stash: true, stmt: true});
+  var ____x128 = compile(cons, {_stash: true, stmt: true});
   indentLevel = indentLevel - 1;
-  var __cons = ____x123;
-  var __e44;
+  var __cons1 = ____x128;
+  var __e57;
   if (alt) {
     indentLevel = indentLevel + 1;
-    var ____x124 = compile(alt, {_stash: true, stmt: true});
+    var ____x129 = compile(alt, {_stash: true, stmt: true});
     indentLevel = indentLevel - 1;
-    __e44 = ____x124;
+    __e57 = ____x129;
   }
-  var __alt = __e44;
-  var __ind2 = indentation();
-  var __s5 = "";
+  var __alt1 = __e57;
+  var __ind3 = indentation();
+  var __s7 = "";
   if (target === "js") {
-    __s5 = __s5 + __ind2 + "if (" + __cond1 + ") {\n" + __cons + __ind2 + "}";
+    __s7 = __s7 + __ind3 + "if (" + __cond2 + ") {\n" + __cons1 + __ind3 + "}";
   } else {
-    __s5 = __s5 + __ind2 + "if " + __cond1 + " then\n" + __cons;
+    __s7 = __s7 + __ind3 + "if " + __cond2 + " then\n" + __cons1;
   }
-  if (__alt && target === "js") {
-    __s5 = __s5 + " else {\n" + __alt + __ind2 + "}";
+  if (__alt1 && target === "js") {
+    __s7 = __s7 + " else {\n" + __alt1 + __ind3 + "}";
   } else {
-    if (__alt) {
-      __s5 = __s5 + __ind2 + "else\n" + __alt;
+    if (__alt1) {
+      __s7 = __s7 + __ind3 + "else\n" + __alt1;
     }
   }
   if (target === "lua") {
-    return __s5 + __ind2 + "end\n";
+    return __s7 + __ind3 + "end\n";
   } else {
-    return __s5 + "\n";
+    return __s7 + "\n";
   }
 }, stmt: true, tr: true});
 setenv("while", {_stash: true, special: function (cond, form) {
-  var __cond2 = compile(cond);
+  var __cond4 = compile(cond);
   indentLevel = indentLevel + 1;
-  var ____x125 = compile(form, {_stash: true, stmt: true});
+  var ____x131 = compile(form, {_stash: true, stmt: true});
   indentLevel = indentLevel - 1;
-  var __body9 = ____x125;
-  var __ind3 = indentation();
+  var __body10 = ____x131;
+  var __ind5 = indentation();
   if (target === "js") {
-    return __ind3 + "while (" + __cond2 + ") {\n" + __body9 + __ind3 + "}\n";
+    return __ind5 + "while (" + __cond4 + ") {\n" + __body10 + __ind5 + "}\n";
   } else {
-    return __ind3 + "while " + __cond2 + " do\n" + __body9 + __ind3 + "end\n";
+    return __ind5 + "while " + __cond4 + " do\n" + __body10 + __ind5 + "end\n";
   }
 }, stmt: true, tr: true});
 setenv("%for", {_stash: true, special: function (t, k, form) {
-  var __t1 = compile(t);
-  var __ind4 = indentation();
+  var __t2 = compile(t);
+  var __ind7 = indentation();
   indentLevel = indentLevel + 1;
-  var ____x126 = compile(form, {_stash: true, stmt: true});
+  var ____x133 = compile(form, {_stash: true, stmt: true});
   indentLevel = indentLevel - 1;
-  var __body10 = ____x126;
+  var __body12 = ____x133;
   if (target === "lua") {
-    return __ind4 + "for " + k + " in next, " + __t1 + " do\n" + __body10 + __ind4 + "end\n";
+    return __ind7 + "for " + k + " in next, " + __t2 + " do\n" + __body12 + __ind7 + "end\n";
   } else {
-    return __ind4 + "for (" + k + " in " + __t1 + ") {\n" + __body10 + __ind4 + "}\n";
+    return __ind7 + "for (" + k + " in " + __t2 + ") {\n" + __body12 + __ind7 + "}\n";
   }
 }, stmt: true, tr: true});
 setenv("%try", {_stash: true, special: function (form) {
-  var __e6 = unique("e");
-  var __ind5 = indentation();
+  var __e8 = unique("e");
+  var __ind9 = indentation();
   indentLevel = indentLevel + 1;
-  var ____x127 = compile(form, {_stash: true, stmt: true});
+  var ____x138 = compile(form, {_stash: true, stmt: true});
   indentLevel = indentLevel - 1;
-  var __body11 = ____x127;
-  var __hf = ["return", ["%array", false, __e6]];
+  var __body14 = ____x138;
+  var __hf1 = ["return", ["%array", false, __e8]];
   indentLevel = indentLevel + 1;
-  var ____x130 = compile(__hf, {_stash: true, stmt: true});
+  var ____x141 = compile(__hf1, {_stash: true, stmt: true});
   indentLevel = indentLevel - 1;
-  var __h = ____x130;
-  return __ind5 + "try {\n" + __body11 + __ind5 + "}\n" + __ind5 + "catch (" + __e6 + ") {\n" + __h + __ind5 + "}\n";
+  var __h1 = ____x141;
+  return __ind9 + "try {\n" + __body14 + __ind9 + "}\n" + __ind9 + "catch (" + __e8 + ") {\n" + __h1 + __ind9 + "}\n";
 }, stmt: true, tr: true});
 setenv("%delete", {_stash: true, special: function (place) {
   return indentation() + "delete " + compile(place);
@@ -1252,29 +1252,29 @@ setenv("%function", {_stash: true, special: function (args, body) {
 }});
 setenv("%global-function", {_stash: true, special: function (name, args, body) {
   if (target === "lua") {
-    var __x131 = compileFunction(args, body, {_stash: true, name: name});
-    return indentation() + __x131;
+    var __x145 = compileFunction(args, body, {_stash: true, name: name});
+    return indentation() + __x145;
   } else {
     return compile(["%set", name, ["%function", args, body]], {_stash: true, stmt: true});
   }
 }, stmt: true, tr: true});
 setenv("%local-function", {_stash: true, special: function (name, args, body) {
   if (target === "lua") {
-    var __x134 = compileFunction(args, body, {_stash: true, name: name, prefix: "local"});
-    return indentation() + __x134;
+    var __x151 = compileFunction(args, body, {_stash: true, name: name, prefix: "local"});
+    return indentation() + __x151;
   } else {
     return compile(["%local", name, ["%function", args, body]], {_stash: true, stmt: true});
   }
 }, stmt: true, tr: true});
 setenv("return", {_stash: true, special: function (x) {
-  var __e45;
+  var __e58;
   if (nil63(x)) {
-    __e45 = "return";
+    __e58 = "return";
   } else {
-    __e45 = "return " + compile(x);
+    __e58 = "return " + compile(x);
   }
-  var __x137 = __e45;
-  return indentation() + __x137;
+  var __x155 = __e58;
+  return indentation() + __x155;
 }, stmt: true});
 setenv("new", {_stash: true, special: function (x) {
   return "new " + compile(x);
@@ -1283,132 +1283,132 @@ setenv("typeof", {_stash: true, special: function (x) {
   return "typeof(" + compile(x) + ")";
 }});
 setenv("error", {_stash: true, special: function (x) {
-  var __e46;
+  var __e59;
   if (target === "js") {
-    __e46 = "throw " + compile(["new", ["Error", x]]);
+    __e59 = "throw " + compile(["new", ["Error", x]]);
   } else {
-    __e46 = "error(" + compile(x) + ")";
+    __e59 = "error(" + compile(x) + ")";
   }
-  var __e7 = __e46;
-  return indentation() + __e7;
+  var __e12 = __e59;
+  return indentation() + __e12;
 }, stmt: true});
 setenv("%local", {_stash: true, special: function (name, value) {
-  var __id29 = compile(name);
-  var __value1 = compile(value);
-  var __e47;
+  var __id30 = compile(name);
+  var __value11 = compile(value);
+  var __e60;
   if (is63(value)) {
-    __e47 = " = " + __value1;
+    __e60 = " = " + __value11;
   } else {
-    __e47 = "";
+    __e60 = "";
   }
-  var __rh1 = __e47;
-  var __e48;
+  var __rh2 = __e60;
+  var __e61;
   if (target === "js") {
-    __e48 = "var ";
+    __e61 = "var ";
   } else {
-    __e48 = "local ";
+    __e61 = "local ";
   }
-  var __keyword = __e48;
-  var __ind6 = indentation();
-  return __ind6 + __keyword + __id29 + __rh1;
+  var __keyword1 = __e61;
+  var __ind11 = indentation();
+  return __ind11 + __keyword1 + __id30 + __rh2;
 }, stmt: true});
 setenv("%set", {_stash: true, special: function (lh, rh) {
-  var __lh1 = compile(lh);
-  var __e49;
+  var __lh2 = compile(lh);
+  var __e62;
   if (nil63(rh)) {
-    __e49 = "nil";
+    __e62 = "nil";
   } else {
-    __e49 = rh;
+    __e62 = rh;
   }
-  var __rh2 = compile(__e49);
-  return indentation() + __lh1 + " = " + __rh2;
+  var __rh4 = compile(__e62);
+  return indentation() + __lh2 + " = " + __rh4;
 }, stmt: true});
 setenv("get", {_stash: true, special: function (t, k) {
-  var __t11 = compile(t);
-  var __k111 = compile(k);
-  if (target === "lua" && char(__t11, 0) === "{" || infixOperator63(t)) {
-    __t11 = "(" + __t11 + ")";
+  var __t12 = compile(t);
+  var __k121 = compile(k);
+  if (target === "lua" && char(__t12, 0) === "{" || infixOperator63(t)) {
+    __t12 = "(" + __t12 + ")";
   }
   if (stringLiteral63(k) && validId63(inner(k))) {
-    return __t11 + "." + inner(k);
+    return __t12 + "." + inner(k);
   } else {
-    return __t11 + "[" + __k111 + "]";
+    return __t12 + "[" + __k121 + "]";
   }
 }});
 setenv("%array", {_stash: true, special: function () {
-  var __forms1 = unstash(Array.prototype.slice.call(arguments, 0));
-  var __e50;
+  var __forms3 = unstash(Array.prototype.slice.call(arguments, 0));
+  var __e63;
   if (target === "lua") {
-    __e50 = "{";
+    __e63 = "{";
   } else {
-    __e50 = "[";
+    __e63 = "[";
   }
-  var __open = __e50;
-  var __e51;
+  var __open1 = __e63;
+  var __e64;
   if (target === "lua") {
-    __e51 = "}";
+    __e64 = "}";
   } else {
-    __e51 = "]";
+    __e64 = "]";
   }
-  var __close = __e51;
-  var __s6 = "";
-  var __c6 = "";
-  var ____o9 = __forms1;
-  var __k14 = undefined;
-  for (__k14 in ____o9) {
-    var __v8 = ____o9[__k14];
-    var __e52;
-    if (numeric63(__k14)) {
-      __e52 = parseInt(__k14);
-    } else {
-      __e52 = __k14;
-    }
-    var __k15 = __e52;
-    if (number63(__k15)) {
-      __s6 = __s6 + __c6 + compile(__v8);
-      __c6 = ", ";
-    }
-  }
-  return __open + __s6 + __close;
-}});
-setenv("%object", {_stash: true, special: function () {
-  var __forms2 = unstash(Array.prototype.slice.call(arguments, 0));
-  var __s7 = "{";
+  var __close1 = __e64;
+  var __s9 = "";
   var __c7 = "";
-  var __e53;
-  if (target === "lua") {
-    __e53 = " = ";
-  } else {
-    __e53 = ": ";
-  }
-  var __sep = __e53;
-  var ____o10 = pair(__forms2);
+  var ____o10 = __forms3;
   var __k16 = undefined;
   for (__k16 in ____o10) {
     var __v9 = ____o10[__k16];
-    var __e54;
+    var __e65;
     if (numeric63(__k16)) {
-      __e54 = parseInt(__k16);
+      __e65 = parseInt(__k16);
     } else {
-      __e54 = __k16;
+      __e65 = __k16;
     }
-    var __k17 = __e54;
+    var __k17 = __e65;
     if (number63(__k17)) {
-      var ____id30 = __v9;
-      var __k18 = ____id30[0];
-      var __v10 = ____id30[1];
-      if (! string63(__k18)) {
-        throw new Error("Illegal key: " + str(__k18));
-      }
-      __s7 = __s7 + __c7 + key(__k18) + __sep + compile(__v10);
+      __s9 = __s9 + __c7 + compile(__v9);
       __c7 = ", ";
     }
   }
-  return __s7 + "}";
+  return __open1 + __s9 + __close1;
+}});
+setenv("%object", {_stash: true, special: function () {
+  var __forms5 = unstash(Array.prototype.slice.call(arguments, 0));
+  var __s111 = "{";
+  var __c9 = "";
+  var __e66;
+  if (target === "lua") {
+    __e66 = " = ";
+  } else {
+    __e66 = ": ";
+  }
+  var __sep1 = __e66;
+  var ____o12 = pair(__forms5);
+  var __k21 = undefined;
+  for (__k21 in ____o12) {
+    var __v12 = ____o12[__k21];
+    var __e67;
+    if (numeric63(__k21)) {
+      __e67 = parseInt(__k21);
+    } else {
+      __e67 = __k21;
+    }
+    var __k22 = __e67;
+    if (number63(__k22)) {
+      var ____id32 = __v12;
+      var __k23 = ____id32[0];
+      var __v13 = ____id32[1];
+      if (! string63(__k23)) {
+        throw new Error("Illegal key: " + str(__k23));
+      }
+      __s111 = __s111 + __c9 + key(__k23) + __sep1 + compile(__v13);
+      __c9 = ", ";
+    }
+  }
+  return __s111 + "}";
 }});
 setenv("%literal", {_stash: true, special: function () {
-  var __args10 = unstash(Array.prototype.slice.call(arguments, 0));
-  return apply(cat, map(compile, __args10));
+  var __args111 = unstash(Array.prototype.slice.call(arguments, 0));
+  return apply(cat, map(compile, __args111));
 }});
 exports.run = run;
 exports.eval = _eval;

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -4,13 +4,13 @@ local function getenv(k, p)
     while __i >= 0 do
       local __b = environment[__i + 1][k]
       if is63(__b) then
-        local __e8
+        local __e21
         if p then
-          __e8 = __b[p]
+          __e21 = __b[p]
         else
-          __e8 = __b
+          __e21 = __b
         end
-        return __e8
+        return __e21
       else
         __i = __i - 1
       end
@@ -99,21 +99,21 @@ function bind(lh, rh)
     local __k1 = nil
     for __k1 in next, ____o1 do
       local __v1 = ____o1[__k1]
-      local __e9
+      local __e22
       if __k1 == "rest" then
-        __e9 = {"cut", __id, _35(lh)}
+        __e22 = {"cut", __id, _35(lh)}
       else
-        __e9 = {"get", __id, {"quote", bias(__k1)}}
+        __e22 = {"get", __id, {"quote", bias(__k1)}}
       end
-      local __x5 = __e9
+      local __x5 = __e22
       if is63(__k1) then
-        local __e10
+        local __e23
         if __v1 == true then
-          __e10 = __k1
+          __e23 = __k1
         else
-          __e10 = __v1
+          __e23 = __v1
         end
-        local __k2 = __e10
+        local __k2 = __e23
         __bs = join(__bs, bind(__k2, __x5))
       end
     end
@@ -137,7 +137,7 @@ function bind42(args, body)
     return {__args1, join({"let", {args, rest()}}, body)}
   else
     local __bs1 = {}
-    local __r18 = unique("r")
+    local __r19 = unique("r")
     local ____o2 = args
     local __k3 = nil
     for __k3 in next, ____o2 do
@@ -146,22 +146,22 @@ function bind42(args, body)
         if atom63(__v2) then
           add(__args1, __v2)
         else
-          local __x17 = unique("x")
-          add(__args1, __x17)
-          __bs1 = join(__bs1, {__v2, __x17})
+          local __x18 = unique("x")
+          add(__args1, __x18)
+          __bs1 = join(__bs1, {__v2, __x18})
         end
       end
     end
     if keys63(args) then
-      __bs1 = join(__bs1, {__r18, rest()})
+      __bs1 = join(__bs1, {__r19, rest()})
       local __n3 = _35(__args1)
       local __i4 = 0
       while __i4 < __n3 do
         local __v3 = __args1[__i4 + 1]
-        __bs1 = join(__bs1, {__v3, {"destash!", __v3, __r18}})
+        __bs1 = join(__bs1, {__v3, {"destash!", __v3, __r19}})
         __i4 = __i4 + 1
       end
-      __bs1 = join(__bs1, {keys(args), __r18})
+      __bs1 = join(__bs1, {keys(args), __r19})
     end
     return {__args1, join({"let", __bs1}, body)}
   end
@@ -178,33 +178,33 @@ end
 local function quasisplice63(x, depth)
   return canUnquote63(depth) and not atom63(x) and hd(x) == "unquote-splicing"
 end
-local function expandLocal(__x25)
-  local ____id1 = __x25
-  local __x26 = ____id1[1]
+local function expandLocal(__x26)
+  local ____id1 = __x26
+  local __x27 = ____id1[1]
   local __name = ____id1[2]
   local __value = ____id1[3]
   setenv(__name, {_stash = true, variable = true})
   return {"%local", __name, macroexpand(__value)}
 end
-local function expandFunction(__x28)
-  local ____id2 = __x28
-  local __x29 = ____id2[1]
+local function expandFunction(__x29)
+  local ____id2 = __x29
+  local __x30 = ____id2[1]
   local __args = ____id2[2]
   local __body = cut(____id2, 2)
   add(environment, {})
   local ____o3 = __args
   local ____i5 = nil
   for ____i5 in next, ____o3 do
-    local ____x30 = ____o3[____i5]
-    setenv(____x30, {_stash = true, variable = true})
+    local ____x31 = ____o3[____i5]
+    setenv(____x31, {_stash = true, variable = true})
   end
-  local ____x31 = join({"%function", __args}, macroexpand(__body))
+  local ____x32 = join({"%function", __args}, macroexpand(__body))
   drop(environment)
-  return ____x31
+  return ____x32
 end
-local function expandDefinition(__x33)
-  local ____id3 = __x33
-  local __x34 = ____id3[1]
+local function expandDefinition(__x34)
+  local ____id3 = __x34
+  local __x35 = ____id3[1]
   local __name1 = ____id3[2]
   local __args11 = ____id3[3]
   local __body1 = cut(____id3, 3)
@@ -212,18 +212,18 @@ local function expandDefinition(__x33)
   local ____o4 = __args11
   local ____i6 = nil
   for ____i6 in next, ____o4 do
-    local ____x35 = ____o4[____i6]
-    setenv(____x35, {_stash = true, variable = true})
+    local ____x36 = ____o4[____i6]
+    setenv(____x36, {_stash = true, variable = true})
   end
-  local ____x36 = join({__x34, __name1, __args11}, macroexpand(__body1))
+  local ____x37 = join({__x35, __name1, __args11}, macroexpand(__body1))
   drop(environment)
-  return ____x36
+  return ____x37
 end
 local function expandMacro(form)
   return macroexpand(expand1(form))
 end
-function expand1(__x38)
-  local ____id4 = __x38
+function expand1(__x39)
+  local ____id4 = __x39
   local __name2 = ____id4[1]
   local __body2 = cut(____id4, 1)
   return apply(macroFunction(__name2), __body2)
@@ -235,20 +235,20 @@ function macroexpand(form)
     if atom63(form) then
       return form
     else
-      local __x39 = hd(form)
-      if __x39 == "%local" then
+      local __x40 = hd(form)
+      if __x40 == "%local" then
         return expandLocal(form)
       else
-        if __x39 == "%function" then
+        if __x40 == "%function" then
           return expandFunction(form)
         else
-          if __x39 == "%global-function" then
+          if __x40 == "%global-function" then
             return expandDefinition(form)
           else
-            if __x39 == "%local-function" then
+            if __x40 == "%local-function" then
               return expandDefinition(form)
             else
-              if macro63(__x39) then
+              if macro63(__x40) then
                 return expandMacro(form)
               else
                 return map(macroexpand, form)
@@ -267,26 +267,26 @@ local function quasiquoteList(form, depth)
   for __k4 in next, ____o5 do
     local __v4 = ____o5[__k4]
     if not number63(__k4) then
-      local __e11
+      local __e24
       if quasisplice63(__v4, depth) then
-        __e11 = quasiexpand(__v4[2])
+        __e24 = quasiexpand(__v4[2])
       else
-        __e11 = quasiexpand(__v4, depth)
+        __e24 = quasiexpand(__v4, depth)
       end
-      local __v5 = __e11
+      local __v5 = __e24
       last(__xs)[__k4] = __v5
     end
   end
-  local ____x42 = form
+  local ____x43 = form
   local ____i8 = 0
-  while ____i8 < _35(____x42) do
-    local __x43 = ____x42[____i8 + 1]
-    if quasisplice63(__x43, depth) then
-      local __x44 = quasiexpand(__x43[2])
-      add(__xs, __x44)
+  while ____i8 < _35(____x43) do
+    local __x44 = ____x43[____i8 + 1]
+    if quasisplice63(__x44, depth) then
+      local __x45 = quasiexpand(__x44[2])
+      add(__xs, __x45)
       add(__xs, {"list"})
     else
-      add(last(__xs), quasiexpand(__x43, depth))
+      add(last(__xs), quasiexpand(__x44, depth))
     end
     ____i8 = ____i8 + 1
   end
@@ -336,8 +336,8 @@ function quasiexpand(form, depth)
     end
   end
 end
-function expandIf(__x48)
-  local ____id5 = __x48
+function expandIf(__x49)
+  local ____id5 = __x49
   local __a = ____id5[1]
   local __b1 = ____id5[2]
   local __c = cut(____id5, 2)
@@ -371,67 +371,67 @@ function accessor63(x)
 end
 function compileId(id)
   local __id6 = camelCase(id)
-  local __e12
+  local __e25
   if numberCode63(code(__id6, 0)) then
-    __e12 = "_"
+    __e25 = "_"
   else
-    __e12 = ""
+    __e25 = ""
   end
-  local __id11 = __e12
+  local __id11 = __e25
   local __i10 = 0
   while __i10 < _35(__id6) do
     local __c1 = char(__id6, __i10)
     local __n7 = code(__c1)
-    local __e13
+    local __e26
     if __c1 == "-" and not( __id6 == "-") then
-      __e13 = "_"
+      __e26 = "_"
     else
-      local __e14
+      local __e27
       if validCode63(__n7) then
-        __e14 = __c1
+        __e27 = __c1
       else
-        local __e15
+        local __e28
         if __i10 == 0 then
-          __e15 = "_" .. __n7
+          __e28 = "_" .. __n7
         else
-          __e15 = __n7
+          __e28 = __n7
         end
-        __e14 = __e15
+        __e27 = __e28
       end
-      __e13 = __e14
+      __e26 = __e27
     end
-    local __c11 = __e13
+    local __c11 = __e26
     __id11 = __id11 .. __c11
     __i10 = __i10 + 1
   end
   return __id11
 end
 function validId63(x)
-  local __id31 = some63(x) and x == compileId(x)
-  local __e17
-  if __id31 then
-    local __e18
+  local __id33 = some63(x) and x == compileId(x)
+  local __e30
+  if __id33 then
+    local __e31
     if target == "lua" then
-      __e18 = not reserved63(x)
+      __e31 = not reserved63(x)
     else
-      __e18 = true
+      __e31 = true
     end
-    __e17 = __e18
+    __e30 = __e31
   else
-    __e17 = __id31
+    __e30 = __id33
   end
-  return __e17
+  return __e30
 end
 local __names = {}
 function unique(x)
-  local __x52 = compileId(x)
-  if __names[__x52] then
-    local __i11 = __names[__x52]
-    __names[__x52] = __names[__x52] + 1
-    return unique(__x52 .. __i11)
+  local __x53 = compileId(x)
+  if __names[__x53] then
+    local __i11 = __names[__x53]
+    __names[__x53] = __names[__x53] + 1
+    return unique(__x53 .. __i11)
   else
-    __names[__x52] = 1
-    return "__" .. __x52
+    __names[__x53] = 1
+    return "__" .. __x53
   end
 end
 function key(k)
@@ -452,52 +452,52 @@ function mapo(f, t)
   local __k5 = nil
   for __k5 in next, ____o7 do
     local __v6 = ____o7[__k5]
-    local __x53 = f(__v6)
-    if is63(__x53) then
+    local __x54 = f(__v6)
+    if is63(__x54) then
       add(__o6, literal(__k5))
-      add(__o6, __x53)
+      add(__o6, __x54)
     end
   end
   return __o6
 end
-local ____x55 = {}
 local ____x56 = {}
-____x56.js = "!"
-____x56.lua = "not"
-____x55["not"] = ____x56
 local ____x57 = {}
-____x57["*"] = true
-____x57["/"] = true
-____x57["%"] = true
+____x57.js = "!"
+____x57.lua = "not"
+____x56["not"] = ____x57
 local ____x58 = {}
+____x58["*"] = true
+____x58["/"] = true
+____x58["%"] = true
 local ____x59 = {}
-____x59.js = "+"
-____x59.lua = ".."
-____x58.cat = ____x59
 local ____x60 = {}
-____x60["+"] = true
-____x60["-"] = true
+____x60.js = "+"
+____x60.lua = ".."
+____x59.cat = ____x60
 local ____x61 = {}
-____x61["<"] = true
-____x61[">"] = true
-____x61["<="] = true
-____x61[">="] = true
+____x61["+"] = true
+____x61["-"] = true
 local ____x62 = {}
+____x62["<"] = true
+____x62[">"] = true
+____x62["<="] = true
+____x62[">="] = true
 local ____x63 = {}
-____x63.js = "==="
-____x63.lua = "=="
-____x62["="] = ____x63
 local ____x64 = {}
+____x64.js = "==="
+____x64.lua = "=="
+____x63["="] = ____x64
 local ____x65 = {}
-____x65.js = "&&"
-____x65.lua = "and"
-____x64["and"] = ____x65
 local ____x66 = {}
+____x66.js = "&&"
+____x66.lua = "and"
+____x65["and"] = ____x66
 local ____x67 = {}
-____x67.js = "||"
-____x67.lua = "or"
-____x66["or"] = ____x67
-local infix = {____x55, ____x57, ____x58, ____x60, ____x61, ____x62, ____x64, ____x66}
+local ____x68 = {}
+____x68.js = "||"
+____x68.lua = "or"
+____x67["or"] = ____x68
+local infix = {____x56, ____x58, ____x59, ____x61, ____x62, ____x63, ____x65, ____x67}
 local function unary63(form)
   return two63(form) and in63(hd(form), {"not", "-"})
 end
@@ -521,12 +521,12 @@ local function precedence(form)
 end
 local function getop(op)
   return find(function (level)
-    local __x69 = level[op]
-    if __x69 == true then
+    local __x70 = level[op]
+    if __x70 == true then
       return op
     else
-      if is63(__x69) then
-        return __x69[target]
+      if is63(__x70) then
+        return __x70[target]
       end
     end
   end, infix)
@@ -555,20 +555,20 @@ function compileArgs(args, call63)
   else
     if obj63(__a1) and accessor63(hd(__a1)) then
       local ____id7 = __a1
-      local __x70 = ____id7[1]
+      local __x71 = ____id7[1]
       local __ys = cut(____id7, 1)
-      local __s1 = compileNext(compile(__x70), __ys, true)
+      local __s1 = compileNext(compile(__x71), __ys, true)
       return compileNext(__s1, tl(args), call63)
     else
       local __s2 = ""
       local __c2 = ""
       local __i15 = 0
       while __i15 < _35(args) do
-        local __x71 = args[__i15 + 1]
-        if accessor63(__x71) or obj63(__x71) and accessor63(hd(__x71)) then
+        local __x72 = args[__i15 + 1]
+        if accessor63(__x72) or obj63(__x72) and accessor63(hd(__x72)) then
           return compileNext("(" .. __s2 .. ")", cut(args, __i15), call63)
         else
-          __s2 = __s2 .. __c2 .. compile(__x71)
+          __s2 = __s2 .. __c2 .. compile(__x72)
         end
         __c2 = ", "
         __i15 = __i15 + 1
@@ -582,19 +582,19 @@ local function escapeNewlines(s)
   local __i16 = 0
   while __i16 < _35(s) do
     local __c3 = char(s, __i16)
-    local __e19
+    local __e32
     if __c3 == "\n" then
-      __e19 = "\\n"
+      __e32 = "\\n"
     else
-      local __e20
+      local __e33
       if __c3 == "\r" then
-        __e20 = "\\r"
+        __e33 = "\\r"
       else
-        __e20 = __c3
+        __e33 = __c3
       end
-      __e19 = __e20
+      __e32 = __e33
     end
-    __s11 = __s11 .. __e19
+    __s11 = __s11 .. __e32
     __i16 = __i16 + 1
   end
   return __s11
@@ -676,9 +676,9 @@ local function terminator(stmt63)
 end
 local function compileSpecial(form, stmt63)
   local ____id8 = form
-  local __x72 = ____id8[1]
+  local __x73 = ____id8[1]
   local __args2 = cut(____id8, 1)
-  local ____id9 = getenv(__x72)
+  local ____id9 = getenv(__x73)
   local __special = ____id9.special
   local __stmt = ____id9.stmt
   local __selfTr63 = ____id9.tr
@@ -699,18 +699,18 @@ local function compileCall(form)
   end
 end
 local function opDelims(parent, child, ...)
-  local ____r59 = unstash({...})
-  local __parent = destash33(parent, ____r59)
-  local __child = destash33(child, ____r59)
-  local ____id10 = ____r59
+  local ____r60 = unstash({...})
+  local __parent = destash33(parent, ____r60)
+  local __child = destash33(child, ____r60)
+  local ____id10 = ____r60
   local __right = ____id10.right
-  local __e21
+  local __e34
   if __right then
-    __e21 = _6261
+    __e34 = _6261
   else
-    __e21 = _62
+    __e34 = _62
   end
-  if __e21(precedence(__child), precedence(__parent)) then
+  if __e34(precedence(__child), precedence(__parent)) then
     return {"(", ")"}
   else
     return {"", ""}
@@ -738,46 +738,46 @@ local function compileInfix(form)
   end
 end
 function compileFunction(args, body, ...)
-  local ____r61 = unstash({...})
-  local __args4 = destash33(args, ____r61)
-  local __body3 = destash33(body, ____r61)
-  local ____id15 = ____r61
+  local ____r62 = unstash({...})
+  local __args4 = destash33(args, ____r62)
+  local __body3 = destash33(body, ____r62)
+  local ____id15 = ____r62
   local __name3 = ____id15.name
   local __prefix = ____id15.prefix
-  local __e22
+  local __e35
   if __name3 then
-    __e22 = compile(__name3)
+    __e35 = compile(__name3)
   else
-    __e22 = ""
+    __e35 = ""
   end
-  local __id16 = __e22
-  local __e23
+  local __id16 = __e35
+  local __e36
   if target == "lua" and __args4.rest then
-    __e23 = join(__args4, {"|...|"})
+    __e36 = join(__args4, {"|...|"})
   else
-    __e23 = __args4
+    __e36 = __args4
   end
-  local __args12 = __e23
+  local __args12 = __e36
   local __args5 = compileArgs(__args12)
   indentLevel = indentLevel + 1
-  local ____x78 = compile(__body3, {_stash = true, stmt = true})
+  local ____x79 = compile(__body3, {_stash = true, stmt = true})
   indentLevel = indentLevel - 1
-  local __body4 = ____x78
+  local __body4 = ____x79
   local __ind = indentation()
-  local __e24
+  local __e37
   if __prefix then
-    __e24 = __prefix .. " "
+    __e37 = __prefix .. " "
   else
-    __e24 = ""
+    __e37 = ""
   end
-  local __p = __e24
-  local __e25
+  local __p = __e37
+  local __e38
   if target == "js" then
-    __e25 = ""
+    __e38 = ""
   else
-    __e25 = "end"
+    __e38 = "end"
   end
-  local __tr1 = __e25
+  local __tr1 = __e38
   if __name3 then
     __tr1 = __tr1 .. "\n"
   end
@@ -791,9 +791,9 @@ local function canReturn63(form)
   return is63(form) and (atom63(form) or not( hd(form) == "return") and not statement63(hd(form)))
 end
 function compile(form, ...)
-  local ____r63 = unstash({...})
-  local __form = destash33(form, ____r63)
-  local ____id17 = ____r63
+  local ____r64 = unstash({...})
+  local __form = destash33(form, ____r64)
+  local ____id17 = ____r64
   local __stmt1 = ____id17.stmt
   if nil63(__form) then
     return ""
@@ -802,26 +802,26 @@ function compile(form, ...)
       return compileSpecial(__form, __stmt1)
     else
       local __tr2 = terminator(__stmt1)
-      local __e26
+      local __e39
       if __stmt1 then
-        __e26 = indentation()
+        __e39 = indentation()
       else
-        __e26 = ""
+        __e39 = ""
       end
-      local __ind1 = __e26
-      local __e27
+      local __ind1 = __e39
+      local __e40
       if atom63(__form) then
-        __e27 = compileAtom(__form)
+        __e40 = compileAtom(__form)
       else
-        local __e28
+        local __e41
         if infix63(hd(__form)) then
-          __e28 = compileInfix(__form)
+          __e41 = compileInfix(__form)
         else
-          __e28 = compileCall(__form)
+          __e41 = compileCall(__form)
         end
-        __e27 = __e28
+        __e40 = __e41
       end
-      local __form1 = __e27
+      local __form1 = __e40
       return __ind1 .. __form1 .. __tr2
     end
   end
@@ -829,25 +829,25 @@ end
 local function lowerStatement(form, tail63)
   local __hoist = {}
   local __e = lower(form, __hoist, true, tail63)
-  local __e29
+  local __e42
   if some63(__hoist) and is63(__e) then
-    __e29 = join({"do"}, __hoist, {__e})
+    __e42 = join({"do"}, __hoist, {__e})
   else
-    local __e30
+    local __e43
     if is63(__e) then
-      __e30 = __e
+      __e43 = __e
     else
-      local __e31
+      local __e44
       if _35(__hoist) > 1 then
-        __e31 = join({"do"}, __hoist)
+        __e44 = join({"do"}, __hoist)
       else
-        __e31 = hd(__hoist)
+        __e44 = hd(__hoist)
       end
-      __e30 = __e31
+      __e43 = __e44
     end
-    __e29 = __e30
+    __e42 = __e43
   end
-  return either(__e29, {"do"})
+  return either(__e42, {"do"})
 end
 local function lowerBody(body, tail63)
   return lowerStatement(join({"do"}, body), tail63)
@@ -859,11 +859,11 @@ local function standalone63(form)
   return not atom63(form) and not infix63(hd(form)) and not literal63(form) and not( "get" == hd(form)) or idLiteral63(form)
 end
 local function lowerDo(args, hoist, stmt63, tail63)
-  local ____x85 = almost(args)
+  local ____x86 = almost(args)
   local ____i17 = 0
-  while ____i17 < _35(____x85) do
-    local __x86 = ____x85[____i17 + 1]
-    local ____y = lower(__x86, hoist, stmt63)
+  while ____i17 < _35(____x86) do
+    local __x87 = ____x86[____i17 + 1]
+    local ____y = lower(__x87, hoist, stmt63)
     if yes(____y) then
       local __e1 = ____y
       if standalone63(__e1) then
@@ -894,19 +894,19 @@ local function lowerIf(args, hoist, stmt63, tail63)
   local __then = ____id19[2]
   local __else = ____id19[3]
   if stmt63 then
-    local __e33
+    local __e46
     if is63(__else) then
-      __e33 = {lowerBody({__else}, tail63)}
+      __e46 = {lowerBody({__else}, tail63)}
     end
-    return add(hoist, join({"%if", lower(__cond, hoist), lowerBody({__then}, tail63)}, __e33))
+    return add(hoist, join({"%if", lower(__cond, hoist), lowerBody({__then}, tail63)}, __e46))
   else
     local __e3 = unique("e")
     add(hoist, {"%local", __e3})
-    local __e32
+    local __e45
     if is63(__else) then
-      __e32 = {lower({"%set", __e3, __else})}
+      __e45 = {lower({"%set", __e3, __else})}
     end
-    add(hoist, join({"%if", lower(__cond, hoist), lower({"%set", __e3, __then})}, __e32))
+    add(hoist, join({"%if", lower(__cond, hoist), lower({"%set", __e3, __then})}, __e45))
     return __e3
   end
 end
@@ -918,13 +918,13 @@ local function lowerShort(x, args, hoist)
   local __b11 = lower(__b4, __hoist1)
   if some63(__hoist1) then
     local __id21 = unique("id")
-    local __e34
+    local __e47
     if x == "and" then
-      __e34 = {"%if", __id21, __b4, __id21}
+      __e47 = {"%if", __id21, __b4, __id21}
     else
-      __e34 = {"%if", __id21, __id21, __b4}
+      __e47 = {"%if", __id21, __id21, __b4}
     end
-    return lower({"do", {"%local", __id21, __a4}, __e34}, hoist)
+    return lower({"do", {"%local", __id21, __a4}, __e47}, hoist)
   else
     return {x, lower(__a4, hoist), __b11}
   end
@@ -938,13 +938,13 @@ local function lowerWhile(args, hoist)
   local __body5 = cut(____id22, 1)
   local __pre = {}
   local __c5 = lower(__c4, __pre)
-  local __e35
+  local __e48
   if none63(__pre) then
-    __e35 = {"while", __c5, lowerBody(__body5)}
+    __e48 = {"while", __c5, lowerBody(__body5)}
   else
-    __e35 = {"while", true, join({"do"}, __pre, {{"%if", {"not", __c5}, {"break"}}, lowerBody(__body5)})}
+    __e48 = {"while", true, join({"do"}, __pre, {{"%if", {"not", __c5}, {"break"}}, lowerBody(__body5)})}
   end
-  return add(hoist, __e35)
+  return add(hoist, __e48)
 end
 local function lowerFor(args, hoist)
   local ____id23 = args
@@ -981,10 +981,10 @@ local function lowerPairwise(form)
   if pairwise63(form) then
     local __e4 = {}
     local ____id26 = form
-    local __x115 = ____id26[1]
+    local __x116 = ____id26[1]
     local __args7 = cut(____id26, 1)
     reduce(function (a, b)
-      add(__e4, {__x115, a, b})
+      add(__e4, {__x116, a, b})
       return a
     end, __args7)
     return join({"and"}, reverse(__e4))
@@ -998,10 +998,10 @@ end
 local function lowerInfix(form, hoist)
   local __form3 = lowerPairwise(form)
   local ____id27 = __form3
-  local __x118 = ____id27[1]
+  local __x119 = ____id27[1]
   local __args8 = cut(____id27, 1)
   return lower(reduce(function (a, b)
-    return {__x118, b, a}
+    return {__x119, b, a}
   end, reverse(__args8)), hoist)
 end
 local function lowerSpecial(form, hoist)
@@ -1024,39 +1024,39 @@ function lower(form, hoist, stmt63, tail63)
           return lowerInfix(form, hoist)
         else
           local ____id28 = form
-          local __x121 = ____id28[1]
+          local __x122 = ____id28[1]
           local __args9 = cut(____id28, 1)
-          if __x121 == "do" then
+          if __x122 == "do" then
             return lowerDo(__args9, hoist, stmt63, tail63)
           else
-            if __x121 == "%call" then
+            if __x122 == "%call" then
               return lower(__args9, hoist, stmt63, tail63)
             else
-              if __x121 == "%set" then
+              if __x122 == "%set" then
                 return lowerSet(__args9, hoist, stmt63, tail63)
               else
-                if __x121 == "%if" then
+                if __x122 == "%if" then
                   return lowerIf(__args9, hoist, stmt63, tail63)
                 else
-                  if __x121 == "%try" then
+                  if __x122 == "%try" then
                     return lowerTry(__args9, hoist, tail63)
                   else
-                    if __x121 == "while" then
+                    if __x122 == "while" then
                       return lowerWhile(__args9, hoist)
                     else
-                      if __x121 == "%for" then
+                      if __x122 == "%for" then
                         return lowerFor(__args9, hoist)
                       else
-                        if __x121 == "%function" then
+                        if __x122 == "%function" then
                           return lowerFunction(__args9)
                         else
-                          if __x121 == "%local-function" or __x121 == "%global-function" then
-                            return lowerDefinition(__x121, __args9, hoist)
+                          if __x122 == "%local-function" or __x122 == "%global-function" then
+                            return lowerDefinition(__x122, __args9, hoist)
                           else
-                            if in63(__x121, {"and", "or"}) then
-                              return lowerShort(__x121, __args9, hoist)
+                            if in63(__x122, {"and", "or"}) then
+                              return lowerShort(__x122, __args9, hoist)
                             else
-                              if statement63(__x121) then
+                              if statement63(__x122) then
                                 return lowerSpecial(form, hoist)
                               else
                                 return lowerCall(form, hoist)
@@ -1101,98 +1101,98 @@ function immediateCall63(x)
   return obj63(x) and obj63(hd(x)) and hd(hd(x)) == "%function"
 end
 setenv("do", {_stash = true, special = function (...)
-  local __forms = unstash({...})
-  local __s4 = ""
-  local ____x125 = __forms
-  local ____i18 = 0
-  while ____i18 < _35(____x125) do
-    local __x126 = ____x125[____i18 + 1]
-    if target == "lua" and immediateCall63(__x126) and "\n" == char(__s4, edge(__s4)) then
-      __s4 = clip(__s4, 0, edge(__s4)) .. ";\n"
+  local __forms1 = unstash({...})
+  local __s5 = ""
+  local ____x128 = __forms1
+  local ____i19 = 0
+  while ____i19 < _35(____x128) do
+    local __x129 = ____x128[____i19 + 1]
+    if target == "lua" and immediateCall63(__x129) and "\n" == char(__s5, edge(__s5)) then
+      __s5 = clip(__s5, 0, edge(__s5)) .. ";\n"
     end
-    __s4 = __s4 .. compile(__x126, {_stash = true, stmt = true})
-    if not atom63(__x126) then
-      if hd(__x126) == "return" or hd(__x126) == "break" then
+    __s5 = __s5 .. compile(__x129, {_stash = true, stmt = true})
+    if not atom63(__x129) then
+      if hd(__x129) == "return" or hd(__x129) == "break" then
         break
       end
     end
-    ____i18 = ____i18 + 1
+    ____i19 = ____i19 + 1
   end
-  return __s4
+  return __s5
 end, stmt = true, tr = true})
 setenv("%if", {_stash = true, special = function (cond, cons, alt)
-  local __cond1 = compile(cond)
+  local __cond2 = compile(cond)
   indentLevel = indentLevel + 1
-  local ____x127 = compile(cons, {_stash = true, stmt = true})
+  local ____x132 = compile(cons, {_stash = true, stmt = true})
   indentLevel = indentLevel - 1
-  local __cons = ____x127
-  local __e36
+  local __cons1 = ____x132
+  local __e49
   if alt then
     indentLevel = indentLevel + 1
-    local ____x128 = compile(alt, {_stash = true, stmt = true})
+    local ____x133 = compile(alt, {_stash = true, stmt = true})
     indentLevel = indentLevel - 1
-    __e36 = ____x128
+    __e49 = ____x133
   end
-  local __alt = __e36
-  local __ind2 = indentation()
-  local __s5 = ""
+  local __alt1 = __e49
+  local __ind3 = indentation()
+  local __s7 = ""
   if target == "js" then
-    __s5 = __s5 .. __ind2 .. "if (" .. __cond1 .. ") {\n" .. __cons .. __ind2 .. "}"
+    __s7 = __s7 .. __ind3 .. "if (" .. __cond2 .. ") {\n" .. __cons1 .. __ind3 .. "}"
   else
-    __s5 = __s5 .. __ind2 .. "if " .. __cond1 .. " then\n" .. __cons
+    __s7 = __s7 .. __ind3 .. "if " .. __cond2 .. " then\n" .. __cons1
   end
-  if __alt and target == "js" then
-    __s5 = __s5 .. " else {\n" .. __alt .. __ind2 .. "}"
+  if __alt1 and target == "js" then
+    __s7 = __s7 .. " else {\n" .. __alt1 .. __ind3 .. "}"
   else
-    if __alt then
-      __s5 = __s5 .. __ind2 .. "else\n" .. __alt
+    if __alt1 then
+      __s7 = __s7 .. __ind3 .. "else\n" .. __alt1
     end
   end
   if target == "lua" then
-    return __s5 .. __ind2 .. "end\n"
+    return __s7 .. __ind3 .. "end\n"
   else
-    return __s5 .. "\n"
+    return __s7 .. "\n"
   end
 end, stmt = true, tr = true})
 setenv("while", {_stash = true, special = function (cond, form)
-  local __cond2 = compile(cond)
+  local __cond4 = compile(cond)
   indentLevel = indentLevel + 1
-  local ____x129 = compile(form, {_stash = true, stmt = true})
+  local ____x135 = compile(form, {_stash = true, stmt = true})
   indentLevel = indentLevel - 1
-  local __body9 = ____x129
-  local __ind3 = indentation()
+  local __body10 = ____x135
+  local __ind5 = indentation()
   if target == "js" then
-    return __ind3 .. "while (" .. __cond2 .. ") {\n" .. __body9 .. __ind3 .. "}\n"
+    return __ind5 .. "while (" .. __cond4 .. ") {\n" .. __body10 .. __ind5 .. "}\n"
   else
-    return __ind3 .. "while " .. __cond2 .. " do\n" .. __body9 .. __ind3 .. "end\n"
+    return __ind5 .. "while " .. __cond4 .. " do\n" .. __body10 .. __ind5 .. "end\n"
   end
 end, stmt = true, tr = true})
 setenv("%for", {_stash = true, special = function (t, k, form)
-  local __t1 = compile(t)
-  local __ind4 = indentation()
+  local __t2 = compile(t)
+  local __ind7 = indentation()
   indentLevel = indentLevel + 1
-  local ____x130 = compile(form, {_stash = true, stmt = true})
+  local ____x137 = compile(form, {_stash = true, stmt = true})
   indentLevel = indentLevel - 1
-  local __body10 = ____x130
+  local __body12 = ____x137
   if target == "lua" then
-    return __ind4 .. "for " .. k .. " in next, " .. __t1 .. " do\n" .. __body10 .. __ind4 .. "end\n"
+    return __ind7 .. "for " .. k .. " in next, " .. __t2 .. " do\n" .. __body12 .. __ind7 .. "end\n"
   else
-    return __ind4 .. "for (" .. k .. " in " .. __t1 .. ") {\n" .. __body10 .. __ind4 .. "}\n"
+    return __ind7 .. "for (" .. k .. " in " .. __t2 .. ") {\n" .. __body12 .. __ind7 .. "}\n"
   end
 end, stmt = true, tr = true})
 setenv("%try", {_stash = true, special = function (form)
-  local __e6 = unique("e")
-  local __ind5 = indentation()
+  local __e8 = unique("e")
+  local __ind9 = indentation()
   indentLevel = indentLevel + 1
-  local ____x131 = compile(form, {_stash = true, stmt = true})
+  local ____x142 = compile(form, {_stash = true, stmt = true})
   indentLevel = indentLevel - 1
-  local __body11 = ____x131
-  local __hf = {"return", {"%array", false, __e6}}
+  local __body14 = ____x142
+  local __hf1 = {"return", {"%array", false, __e8}}
   indentLevel = indentLevel + 1
-  local ____x134 = compile(__hf, {_stash = true, stmt = true})
+  local ____x145 = compile(__hf1, {_stash = true, stmt = true})
   indentLevel = indentLevel - 1
-  local __h = ____x134
-  return __ind5 .. "try {\n" .. __body11 .. __ind5 .. "}\n" .. __ind5 .. "catch (" .. __e6 .. ") {\n" .. __h .. __ind5 .. "}\n"
+  local __h1 = ____x145
+  return __ind9 .. "try {\n" .. __body14 .. __ind9 .. "}\n" .. __ind9 .. "catch (" .. __e8 .. ") {\n" .. __h1 .. __ind9 .. "}\n"
 end, stmt = true, tr = true})
 setenv("%delete", {_stash = true, special = function (place)
   return indentation() .. "delete " .. compile(place)
@@ -1205,29 +1205,29 @@ setenv("%function", {_stash = true, special = function (args, body)
 end})
 setenv("%global-function", {_stash = true, special = function (name, args, body)
   if target == "lua" then
-    local __x135 = compileFunction(args, body, {_stash = true, name = name})
-    return indentation() .. __x135
+    local __x149 = compileFunction(args, body, {_stash = true, name = name})
+    return indentation() .. __x149
   else
     return compile({"%set", name, {"%function", args, body}}, {_stash = true, stmt = true})
   end
 end, stmt = true, tr = true})
 setenv("%local-function", {_stash = true, special = function (name, args, body)
   if target == "lua" then
-    local __x138 = compileFunction(args, body, {_stash = true, name = name, prefix = "local"})
-    return indentation() .. __x138
+    local __x155 = compileFunction(args, body, {_stash = true, name = name, prefix = "local"})
+    return indentation() .. __x155
   else
     return compile({"%local", name, {"%function", args, body}}, {_stash = true, stmt = true})
   end
 end, stmt = true, tr = true})
 setenv("return", {_stash = true, special = function (x)
-  local __e37
+  local __e50
   if nil63(x) then
-    __e37 = "return"
+    __e50 = "return"
   else
-    __e37 = "return " .. compile(x)
+    __e50 = "return " .. compile(x)
   end
-  local __x141 = __e37
-  return indentation() .. __x141
+  local __x159 = __e50
+  return indentation() .. __x159
 end, stmt = true})
 setenv("new", {_stash = true, special = function (x)
   return "new " .. compile(x)
@@ -1236,117 +1236,117 @@ setenv("typeof", {_stash = true, special = function (x)
   return "typeof(" .. compile(x) .. ")"
 end})
 setenv("error", {_stash = true, special = function (x)
-  local __e38
+  local __e51
   if target == "js" then
-    __e38 = "throw " .. compile({"new", {"Error", x}})
+    __e51 = "throw " .. compile({"new", {"Error", x}})
   else
-    __e38 = "error(" .. compile(x) .. ")"
+    __e51 = "error(" .. compile(x) .. ")"
   end
-  local __e7 = __e38
-  return indentation() .. __e7
+  local __e12 = __e51
+  return indentation() .. __e12
 end, stmt = true})
 setenv("%local", {_stash = true, special = function (name, value)
-  local __id29 = compile(name)
-  local __value1 = compile(value)
-  local __e39
+  local __id30 = compile(name)
+  local __value11 = compile(value)
+  local __e52
   if is63(value) then
-    __e39 = " = " .. __value1
+    __e52 = " = " .. __value11
   else
-    __e39 = ""
+    __e52 = ""
   end
-  local __rh1 = __e39
-  local __e40
+  local __rh2 = __e52
+  local __e53
   if target == "js" then
-    __e40 = "var "
+    __e53 = "var "
   else
-    __e40 = "local "
+    __e53 = "local "
   end
-  local __keyword = __e40
-  local __ind6 = indentation()
-  return __ind6 .. __keyword .. __id29 .. __rh1
+  local __keyword1 = __e53
+  local __ind11 = indentation()
+  return __ind11 .. __keyword1 .. __id30 .. __rh2
 end, stmt = true})
 setenv("%set", {_stash = true, special = function (lh, rh)
-  local __lh1 = compile(lh)
-  local __e41
+  local __lh2 = compile(lh)
+  local __e54
   if nil63(rh) then
-    __e41 = "nil"
+    __e54 = "nil"
   else
-    __e41 = rh
+    __e54 = rh
   end
-  local __rh2 = compile(__e41)
-  return indentation() .. __lh1 .. " = " .. __rh2
+  local __rh4 = compile(__e54)
+  return indentation() .. __lh2 .. " = " .. __rh4
 end, stmt = true})
 setenv("get", {_stash = true, special = function (t, k)
-  local __t11 = compile(t)
-  local __k11 = compile(k)
-  if target == "lua" and char(__t11, 0) == "{" or infixOperator63(t) then
-    __t11 = "(" .. __t11 .. ")"
+  local __t12 = compile(t)
+  local __k12 = compile(k)
+  if target == "lua" and char(__t12, 0) == "{" or infixOperator63(t) then
+    __t12 = "(" .. __t12 .. ")"
   end
   if stringLiteral63(k) and validId63(inner(k)) then
-    return __t11 .. "." .. inner(k)
+    return __t12 .. "." .. inner(k)
   else
-    return __t11 .. "[" .. __k11 .. "]"
+    return __t12 .. "[" .. __k12 .. "]"
   end
 end})
 setenv("%array", {_stash = true, special = function (...)
-  local __forms1 = unstash({...})
-  local __e42
+  local __forms3 = unstash({...})
+  local __e55
   if target == "lua" then
-    __e42 = "{"
+    __e55 = "{"
   else
-    __e42 = "["
+    __e55 = "["
   end
-  local __open = __e42
-  local __e43
+  local __open1 = __e55
+  local __e56
   if target == "lua" then
-    __e43 = "}"
+    __e56 = "}"
   else
-    __e43 = "]"
+    __e56 = "]"
   end
-  local __close = __e43
-  local __s6 = ""
-  local __c6 = ""
-  local ____o9 = __forms1
-  local __k8 = nil
-  for __k8 in next, ____o9 do
-    local __v8 = ____o9[__k8]
-    if number63(__k8) then
-      __s6 = __s6 .. __c6 .. compile(__v8)
-      __c6 = ", "
-    end
-  end
-  return __open .. __s6 .. __close
-end})
-setenv("%object", {_stash = true, special = function (...)
-  local __forms2 = unstash({...})
-  local __s7 = "{"
+  local __close1 = __e56
+  local __s9 = ""
   local __c7 = ""
-  local __e44
-  if target == "lua" then
-    __e44 = " = "
-  else
-    __e44 = ": "
-  end
-  local __sep = __e44
-  local ____o10 = pair(__forms2)
-  local __k9 = nil
-  for __k9 in next, ____o10 do
-    local __v9 = ____o10[__k9]
-    if number63(__k9) then
-      local ____id30 = __v9
-      local __k10 = ____id30[1]
-      local __v10 = ____id30[2]
-      if not string63(__k10) then
-        error("Illegal key: " .. str(__k10))
-      end
-      __s7 = __s7 .. __c7 .. key(__k10) .. __sep .. compile(__v10)
+  local ____o10 = __forms3
+  local __k10 = nil
+  for __k10 in next, ____o10 do
+    local __v9 = ____o10[__k10]
+    if number63(__k10) then
+      __s9 = __s9 .. __c7 .. compile(__v9)
       __c7 = ", "
     end
   end
-  return __s7 .. "}"
+  return __open1 .. __s9 .. __close1
+end})
+setenv("%object", {_stash = true, special = function (...)
+  local __forms5 = unstash({...})
+  local __s111 = "{"
+  local __c9 = ""
+  local __e57
+  if target == "lua" then
+    __e57 = " = "
+  else
+    __e57 = ": "
+  end
+  local __sep1 = __e57
+  local ____o12 = pair(__forms5)
+  local __k14 = nil
+  for __k14 in next, ____o12 do
+    local __v12 = ____o12[__k14]
+    if number63(__k14) then
+      local ____id32 = __v12
+      local __k15 = ____id32[1]
+      local __v13 = ____id32[2]
+      if not string63(__k15) then
+        error("Illegal key: " .. str(__k15))
+      end
+      __s111 = __s111 .. __c9 .. key(__k15) .. __sep1 .. compile(__v13)
+      __c9 = ", "
+    end
+  end
+  return __s111 .. "}"
 end})
 setenv("%literal", {_stash = true, special = function (...)
-  local __args10 = unstash({...})
-  return apply(cat, map(compile, __args10))
+  local __args111 = unstash({...})
+  return apply(cat, map(compile, __args111))
 end})
 return {run = run, ["eval"] = _eval, expand = expand, compile = compile}

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -1,43 +1,42 @@
-local reader = require("reader")
 local function getenv(k, p)
   if string63(k) then
     local __i = edge(environment)
     while __i >= 0 do
       local __b = environment[__i + 1][k]
       if is63(__b) then
-        local __e21
+        local __e8
         if p then
-          __e21 = __b[p]
+          __e8 = __b[p]
         else
-          __e21 = __b
+          __e8 = __b
         end
-        return __e21
+        return __e8
       else
         __i = __i - 1
       end
     end
   end
 end
-local function macro_function(k)
+local function macroFunction(k)
   return getenv(k, "macro")
 end
 local function macro63(k)
-  return is63(macro_function(k))
+  return is63(macroFunction(k))
 end
 local function special63(k)
   return is63(getenv(k, "special"))
 end
-local function special_form63(form)
+local function specialForm63(form)
   return not atom63(form) and special63(hd(form))
 end
 local function statement63(k)
   return special63(k) and getenv(k, "stmt")
 end
-local function symbol_expansion(k)
+local function symbolExpansion(k)
   return getenv(k, "symbol")
 end
 local function symbol63(k)
-  return is63(symbol_expansion(k))
+  return is63(symbolExpansion(k))
 end
 local function variable63(k)
   return is63(getenv(k, "variable"))
@@ -57,7 +56,7 @@ function quoted(form)
   end
 end
 local function literal(s)
-  if string_literal63(s) then
+  if stringLiteral63(s) then
     return s
   else
     return quoted(s)
@@ -100,21 +99,21 @@ function bind(lh, rh)
     local __k1 = nil
     for __k1 in next, ____o1 do
       local __v1 = ____o1[__k1]
-      local __e22
+      local __e9
       if __k1 == "rest" then
-        __e22 = {"cut", __id, _35(lh)}
+        __e9 = {"cut", __id, _35(lh)}
       else
-        __e22 = {"get", __id, {"quote", bias(__k1)}}
+        __e9 = {"get", __id, {"quote", bias(__k1)}}
       end
-      local __x5 = __e22
+      local __x5 = __e9
       if is63(__k1) then
-        local __e23
+        local __e10
         if __v1 == true then
-          __e23 = __k1
+          __e10 = __k1
         else
-          __e23 = __v1
+          __e10 = __v1
         end
-        local __k2 = __e23
+        local __k2 = __e10
         __bs = join(__bs, bind(__k2, __x5))
       end
     end
@@ -122,7 +121,7 @@ function bind(lh, rh)
   end
 end
 setenv("arguments%", {_stash = true, macro = function (from)
-  return {{"get", {"get", {"get", "Array", {"quote", "prototype"}}, {"quote", "slice"}}, {"quote", "call"}}, "arguments", from}
+  return {"Array", ".prototype", ".slice", ".call", "arguments", from}
 end})
 function bind42(args, body)
   local __args1 = {}
@@ -138,7 +137,7 @@ function bind42(args, body)
     return {__args1, join({"let", {args, rest()}}, body)}
   else
     local __bs1 = {}
-    local __r19 = unique("r")
+    local __r18 = unique("r")
     local ____o2 = args
     local __k3 = nil
     for __k3 in next, ____o2 do
@@ -147,22 +146,22 @@ function bind42(args, body)
         if atom63(__v2) then
           add(__args1, __v2)
         else
-          local __x30 = unique("x")
-          add(__args1, __x30)
-          __bs1 = join(__bs1, {__v2, __x30})
+          local __x17 = unique("x")
+          add(__args1, __x17)
+          __bs1 = join(__bs1, {__v2, __x17})
         end
       end
     end
     if keys63(args) then
-      __bs1 = join(__bs1, {__r19, rest()})
+      __bs1 = join(__bs1, {__r18, rest()})
       local __n3 = _35(__args1)
       local __i4 = 0
       while __i4 < __n3 do
         local __v3 = __args1[__i4 + 1]
-        __bs1 = join(__bs1, {__v3, {"destash!", __v3, __r19}})
+        __bs1 = join(__bs1, {__v3, {"destash!", __v3, __r18}})
         __i4 = __i4 + 1
       end
-      __bs1 = join(__bs1, {keys(args), __r19})
+      __bs1 = join(__bs1, {keys(args), __r18})
     end
     return {__args1, join({"let", __bs1}, body)}
   end
@@ -173,39 +172,39 @@ end
 local function quasiquoting63(depth)
   return quoting63(depth) and depth > 0
 end
-local function can_unquote63(depth)
+local function canUnquote63(depth)
   return quoting63(depth) and depth == 1
 end
 local function quasisplice63(x, depth)
-  return can_unquote63(depth) and not atom63(x) and hd(x) == "unquote-splicing"
+  return canUnquote63(depth) and not atom63(x) and hd(x) == "unquote-splicing"
 end
-local function expand_local(__x38)
-  local ____id1 = __x38
-  local __x39 = ____id1[1]
+local function expandLocal(__x25)
+  local ____id1 = __x25
+  local __x26 = ____id1[1]
   local __name = ____id1[2]
   local __value = ____id1[3]
   setenv(__name, {_stash = true, variable = true})
   return {"%local", __name, macroexpand(__value)}
 end
-local function expand_function(__x41)
-  local ____id2 = __x41
-  local __x42 = ____id2[1]
+local function expandFunction(__x28)
+  local ____id2 = __x28
+  local __x29 = ____id2[1]
   local __args = ____id2[2]
   local __body = cut(____id2, 2)
   add(environment, {})
   local ____o3 = __args
   local ____i5 = nil
   for ____i5 in next, ____o3 do
-    local ____x43 = ____o3[____i5]
-    setenv(____x43, {_stash = true, variable = true})
+    local ____x30 = ____o3[____i5]
+    setenv(____x30, {_stash = true, variable = true})
   end
-  local ____x44 = join({"%function", __args}, macroexpand(__body))
+  local ____x31 = join({"%function", __args}, macroexpand(__body))
   drop(environment)
-  return ____x44
+  return ____x31
 end
-local function expand_definition(__x46)
-  local ____id3 = __x46
-  local __x47 = ____id3[1]
+local function expandDefinition(__x33)
+  local ____id3 = __x33
+  local __x34 = ____id3[1]
   local __name1 = ____id3[2]
   local __args11 = ____id3[3]
   local __body1 = cut(____id3, 3)
@@ -213,44 +212,44 @@ local function expand_definition(__x46)
   local ____o4 = __args11
   local ____i6 = nil
   for ____i6 in next, ____o4 do
-    local ____x48 = ____o4[____i6]
-    setenv(____x48, {_stash = true, variable = true})
+    local ____x35 = ____o4[____i6]
+    setenv(____x35, {_stash = true, variable = true})
   end
-  local ____x49 = join({__x47, __name1, __args11}, macroexpand(__body1))
+  local ____x36 = join({__x34, __name1, __args11}, macroexpand(__body1))
   drop(environment)
-  return ____x49
+  return ____x36
 end
-local function expand_macro(form)
+local function expandMacro(form)
   return macroexpand(expand1(form))
 end
-function expand1(__x51)
-  local ____id4 = __x51
+function expand1(__x38)
+  local ____id4 = __x38
   local __name2 = ____id4[1]
   local __body2 = cut(____id4, 1)
-  return apply(macro_function(__name2), __body2)
+  return apply(macroFunction(__name2), __body2)
 end
 function macroexpand(form)
   if symbol63(form) then
-    return macroexpand(symbol_expansion(form))
+    return macroexpand(symbolExpansion(form))
   else
     if atom63(form) then
       return form
     else
-      local __x52 = hd(form)
-      if __x52 == "%local" then
-        return expand_local(form)
+      local __x39 = hd(form)
+      if __x39 == "%local" then
+        return expandLocal(form)
       else
-        if __x52 == "%function" then
-          return expand_function(form)
+        if __x39 == "%function" then
+          return expandFunction(form)
         else
-          if __x52 == "%global-function" then
-            return expand_definition(form)
+          if __x39 == "%global-function" then
+            return expandDefinition(form)
           else
-            if __x52 == "%local-function" then
-              return expand_definition(form)
+            if __x39 == "%local-function" then
+              return expandDefinition(form)
             else
-              if macro63(__x52) then
-                return expand_macro(form)
+              if macro63(__x39) then
+                return expandMacro(form)
               else
                 return map(macroexpand, form)
               end
@@ -261,33 +260,33 @@ function macroexpand(form)
     end
   end
 end
-local function quasiquote_list(form, depth)
+local function quasiquoteList(form, depth)
   local __xs = {{"list"}}
   local ____o5 = form
   local __k4 = nil
   for __k4 in next, ____o5 do
     local __v4 = ____o5[__k4]
     if not number63(__k4) then
-      local __e24
+      local __e11
       if quasisplice63(__v4, depth) then
-        __e24 = quasiexpand(__v4[2])
+        __e11 = quasiexpand(__v4[2])
       else
-        __e24 = quasiexpand(__v4, depth)
+        __e11 = quasiexpand(__v4, depth)
       end
-      local __v5 = __e24
+      local __v5 = __e11
       last(__xs)[__k4] = __v5
     end
   end
-  local ____x55 = form
+  local ____x42 = form
   local ____i8 = 0
-  while ____i8 < _35(____x55) do
-    local __x56 = ____x55[____i8 + 1]
-    if quasisplice63(__x56, depth) then
-      local __x57 = quasiexpand(__x56[2])
-      add(__xs, __x57)
+  while ____i8 < _35(____x42) do
+    local __x43 = ____x42[____i8 + 1]
+    if quasisplice63(__x43, depth) then
+      local __x44 = quasiexpand(__x43[2])
+      add(__xs, __x44)
       add(__xs, {"list"})
     else
-      add(last(__xs), quasiexpand(__x56, depth))
+      add(last(__xs), quasiexpand(__x43, depth))
     end
     ____i8 = ____i8 + 1
   end
@@ -305,16 +304,16 @@ function quasiexpand(form, depth)
     if atom63(form) then
       return {"quote", form}
     else
-      if can_unquote63(depth) and hd(form) == "unquote" then
+      if canUnquote63(depth) and hd(form) == "unquote" then
         return quasiexpand(form[2])
       else
         if hd(form) == "unquote" or hd(form) == "unquote-splicing" then
-          return quasiquote_list(form, depth - 1)
+          return quasiquoteList(form, depth - 1)
         else
           if hd(form) == "quasiquote" then
-            return quasiquote_list(form, depth + 1)
+            return quasiquoteList(form, depth + 1)
           else
-            return quasiquote_list(form, depth)
+            return quasiquoteList(form, depth)
           end
         end
       end
@@ -337,24 +336,24 @@ function quasiexpand(form, depth)
     end
   end
 end
-function expand_if(__x61)
-  local ____id5 = __x61
+function expandIf(__x48)
+  local ____id5 = __x48
   local __a = ____id5[1]
   local __b1 = ____id5[2]
   local __c = cut(____id5, 2)
   if is63(__b1) then
-    return {join({"%if", __a, __b1}, expand_if(__c))}
+    return {join({"%if", __a, __b1}, expandIf(__c))}
   else
     if is63(__a) then
       return {__a}
     end
   end
 end
-indent_level = 0
+indentLevel = 0
 function indentation()
   local __s = ""
   local __i9 = 0
-  while __i9 < indent_level do
+  while __i9 < indentLevel do
     __s = __s .. "  "
     __i9 = __i9 + 1
   end
@@ -364,74 +363,80 @@ local reserved = {["="] = true, ["=="] = true, ["+"] = true, ["-"] = true, ["%"]
 function reserved63(x)
   return has63(reserved, x)
 end
-local function valid_code63(n)
-  return number_code63(n) or n > 64 and n < 91 or n > 96 and n < 123 or n == 95
+local function validCode63(n)
+  return numberCode63(n) or n > 64 and n < 91 or n > 96 and n < 123 or n == 95
 end
 function accessor63(x)
   return string63(x) and _35(x) > 1 and code(x, 0) == 46 and not( code(x, 1) == 46) or obj63(x) and hd(x) == "%brackets"
 end
-local function id(id, raw63)
-  local __e25
-  if number_code63(code(id, 0)) then
-    __e25 = "_"
+function compileId(id)
+  local __id6 = camelCase(id)
+  local __e12
+  if numberCode63(code(__id6, 0)) then
+    __e12 = "_"
   else
-    __e25 = ""
+    __e12 = ""
   end
-  local __id11 = __e25
+  local __id11 = __e12
   local __i10 = 0
-  while __i10 < _35(id) do
-    local __c1 = char(id, __i10)
+  while __i10 < _35(__id6) do
+    local __c1 = char(__id6, __i10)
     local __n7 = code(__c1)
-    local __e26
-    if __c1 == "-" and not( id == "-") then
-      __e26 = "_"
+    local __e13
+    if __c1 == "-" and not( __id6 == "-") then
+      __e13 = "_"
     else
-      local __e27
-      if valid_code63(__n7) then
-        __e27 = __c1
+      local __e14
+      if validCode63(__n7) then
+        __e14 = __c1
       else
-        local __e28
+        local __e15
         if __i10 == 0 then
-          __e28 = "_" .. __n7
+          __e15 = "_" .. __n7
         else
-          __e28 = __n7
+          __e15 = __n7
         end
-        __e27 = __e28
+        __e14 = __e15
       end
-      __e26 = __e27
+      __e13 = __e14
     end
-    local __c11 = __e26
+    local __c11 = __e13
     __id11 = __id11 .. __c11
     __i10 = __i10 + 1
   end
-  if raw63 then
-    return __id11
-  else
-    if reserved63(__id11) then
-      return "_" .. __id11
-    else
-      return __id11
-    end
-  end
+  return __id11
 end
-function valid_id63(x)
-  return some63(x) and x == id(x)
+function validId63(x)
+  local __id31 = some63(x) and x == compileId(x)
+  local __e17
+  if __id31 then
+    local __e18
+    if target == "lua" then
+      __e18 = not reserved63(x)
+    else
+      __e18 = true
+    end
+    __e17 = __e18
+  else
+    __e17 = __id31
+  end
+  return __e17
 end
 local __names = {}
 function unique(x)
-  local __x65 = id(x)
-  if __names[__x65] then
-    local __i11 = __names[__x65]
-    __names[__x65] = __names[__x65] + 1
-    return unique(__x65 .. __i11)
+  local __x52 = compileId(x)
+  if __names[__x52] then
+    local __i11 = __names[__x52]
+    __names[__x52] = __names[__x52] + 1
+    return unique(__x52 .. __i11)
   else
-    __names[__x65] = 1
-    return "__" .. __x65
+    __names[__x52] = 1
+    return "__" .. __x52
   end
 end
 function key(k)
   local __i12 = inner(k)
-  if valid_id63(__i12) then
+  if validId63(__i12) then
     return __i12
   else
     if target == "js" then
@@ -447,52 +452,52 @@ function mapo(f, t)
   local __k5 = nil
   for __k5 in next, ____o7 do
     local __v6 = ____o7[__k5]
-    local __x66 = f(__v6)
-    if is63(__x66) then
+    local __x53 = f(__v6)
+    if is63(__x53) then
       add(__o6, literal(__k5))
-      add(__o6, __x66)
+      add(__o6, __x53)
     end
   end
   return __o6
 end
-local ____x68 = {}
-local ____x69 = {}
-____x69.js = "!"
-____x69.lua = "not"
-____x68["not"] = ____x69
-local ____x70 = {}
-____x70["*"] = true
-____x70["/"] = true
-____x70["%"] = true
-local ____x71 = {}
-local ____x72 = {}
-____x72.js = "+"
-____x72.lua = ".."
-____x71.cat = ____x72
-local ____x73 = {}
-____x73["+"] = true
-____x73["-"] = true
-local ____x74 = {}
-____x74["<"] = true
-____x74[">"] = true
-____x74["<="] = true
-____x74[">="] = true
-local ____x75 = {}
-local ____x76 = {}
-____x76.js = "==="
-____x76.lua = "=="
-____x75["="] = ____x76
-local ____x77 = {}
-local ____x78 = {}
-____x78.js = "&&"
-____x78.lua = "and"
-____x77["and"] = ____x78
-local ____x79 = {}
-local ____x80 = {}
-____x80.js = "||"
-____x80.lua = "or"
-____x79["or"] = ____x80
-local infix = {____x68, ____x70, ____x71, ____x73, ____x74, ____x75, ____x77, ____x79}
+local ____x55 = {}
+local ____x56 = {}
+____x56.js = "!"
+____x56.lua = "not"
+____x55["not"] = ____x56
+local ____x57 = {}
+____x57["*"] = true
+____x57["/"] = true
+____x57["%"] = true
+local ____x58 = {}
+local ____x59 = {}
+____x59.js = "+"
+____x59.lua = ".."
+____x58.cat = ____x59
+local ____x60 = {}
+____x60["+"] = true
+____x60["-"] = true
+local ____x61 = {}
+____x61["<"] = true
+____x61[">"] = true
+____x61["<="] = true
+____x61[">="] = true
+local ____x62 = {}
+local ____x63 = {}
+____x63.js = "==="
+____x63.lua = "=="
+____x62["="] = ____x63
+local ____x64 = {}
+local ____x65 = {}
+____x65.js = "&&"
+____x65.lua = "and"
+____x64["and"] = ____x65
+local ____x66 = {}
+local ____x67 = {}
+____x67.js = "||"
+____x67.lua = "or"
+____x66["or"] = ____x67
+local infix = {____x55, ____x57, ____x58, ____x60, ____x61, ____x62, ____x64, ____x66}
 local function unary63(form)
   return two63(form) and in63(hd(form), {"not", "-"})
 end
@@ -516,12 +521,12 @@ local function precedence(form)
 end
 local function getop(op)
   return find(function (level)
-    local __x82 = level[op]
-    if __x82 == true then
+    local __x69 = level[op]
+    if __x69 == true then
       return op
     else
-      if is63(__x82) then
-        return __x82[target]
+      if is63(__x69) then
+        return __x69[target]
       end
     end
   end, infix)
@@ -529,10 +534,10 @@ end
 local function infix63(x)
   return is63(getop(x))
 end
-function infix_operator63(x)
+function infixOperator63(x)
   return obj63(x) and infix63(hd(x))
 end
-function compile_next(x, args, call63)
+function compileNext(x, args, call63)
   if none63(args) then
     if call63 then
       return x .. "()"
@@ -540,30 +545,30 @@ function compile_next(x, args, call63)
       return x
     end
   else
-    return x .. compile_args(args, call63)
+    return x .. compileArgs(args, call63)
   end
 end
-function compile_args(args, call63)
+function compileArgs(args, call63)
   local __a1 = hd(args)
   if accessor63(__a1) then
-    return compile_next(compile(__a1), tl(args), call63)
+    return compileNext(compile(__a1), tl(args), call63)
   else
     if obj63(__a1) and accessor63(hd(__a1)) then
-      local ____id6 = __a1
-      local __x83 = ____id6[1]
-      local __ys = cut(____id6, 1)
-      local __s1 = compile_next(compile(__x83), __ys, true)
-      return compile_next(__s1, tl(args), call63)
+      local ____id7 = __a1
+      local __x70 = ____id7[1]
+      local __ys = cut(____id7, 1)
+      local __s1 = compileNext(compile(__x70), __ys, true)
+      return compileNext(__s1, tl(args), call63)
     else
       local __s2 = ""
       local __c2 = ""
       local __i15 = 0
       while __i15 < _35(args) do
-        local __x84 = args[__i15 + 1]
-        if accessor63(__x84) or obj63(__x84) and accessor63(hd(__x84)) then
-          return compile_next("(" .. __s2 .. ")", cut(args, __i15), call63)
+        local __x71 = args[__i15 + 1]
+        if accessor63(__x71) or obj63(__x71) and accessor63(hd(__x71)) then
+          return compileNext("(" .. __s2 .. ")", cut(args, __i15), call63)
         else
-          __s2 = __s2 .. __c2 .. compile(__x84)
+          __s2 = __s2 .. __c2 .. compile(__x71)
         end
         __c2 = ", "
         __i15 = __i15 + 1
@@ -572,37 +577,37 @@ function compile_args(args, call63)
     end
   end
 end
-local function escape_newlines(s)
+local function escapeNewlines(s)
   local __s11 = ""
   local __i16 = 0
   while __i16 < _35(s) do
     local __c3 = char(s, __i16)
-    local __e29
+    local __e19
     if __c3 == "\n" then
-      __e29 = "\\n"
+      __e19 = "\\n"
     else
-      local __e30
+      local __e20
       if __c3 == "\r" then
-        __e30 = "\\r"
+        __e20 = "\\r"
       else
-        __e30 = __c3
+        __e20 = __c3
       end
-      __e29 = __e30
+      __e19 = __e20
     end
-    __s11 = __s11 .. __e29
+    __s11 = __s11 .. __e19
     __i16 = __i16 + 1
   end
   return __s11
 end
 function accessor(x)
-  local __prop = id(clip(x, 1), true)
-  if valid_id63(__prop) then
+  local __prop = compileId(clip(x, 1))
+  if validId63(__prop) then
     return "." .. __prop
   else
     return "[" .. escape(__prop) .. "]"
   end
 end
-local function compile_atom(x)
+local function compileAtom(x)
   if accessor63(x) then
     return accessor(x)
   else
@@ -612,14 +617,19 @@ local function compile_atom(x)
       if x == "nil" then
         return "undefined"
       else
-        if id_literal63(x) then
+        if idLiteral63(x) then
           return inner(x)
         else
-          if string_literal63(x) then
-            return escape_newlines(x)
+          if stringLiteral63(x) then
+            return escapeNewlines(x)
           else
             if string63(x) then
-              return id(x)
+              local __s3 = compileId(x)
+              if reserved63(__s3) then
+                return "_" .. __s3
+              else
+                return __s3
+              end
             else
               if boolean63(x) then
                 if x then
@@ -664,196 +674,196 @@ local function terminator(stmt63)
     end
   end
 end
-local function compile_special(form, stmt63)
-  local ____id6 = form
-  local __x85 = ____id6[1]
-  local __args2 = cut(____id6, 1)
-  local ____id7 = getenv(__x85)
-  local __special = ____id7.special
-  local __stmt = ____id7.stmt
-  local __self_tr63 = ____id7.tr
-  local __tr = terminator(stmt63 and not __self_tr63)
+local function compileSpecial(form, stmt63)
+  local ____id8 = form
+  local __x72 = ____id8[1]
+  local __args2 = cut(____id8, 1)
+  local ____id9 = getenv(__x72)
+  local __special = ____id9.special
+  local __stmt = ____id9.stmt
+  local __selfTr63 = ____id9.tr
+  local __tr = terminator(stmt63 and not __selfTr63)
   return apply(__special, __args2) .. __tr
 end
-local function parenthesize_call63(x)
+local function parenthesizeCall63(x)
   return not atom63(x) and hd(x) == "%function" or precedence(x) > 0
 end
-local function compile_call(form)
+local function compileCall(form)
   local __f = hd(form)
   local __f1 = compile(__f)
-  local __args3 = compile_args(stash42(tl(form)))
-  if parenthesize_call63(__f) then
+  local __args3 = compileArgs(stash42(tl(form)))
+  if parenthesizeCall63(__f) then
     return "(" .. __f1 .. ")" .. __args3
   else
     return __f1 .. __args3
   end
 end
-local function op_delims(parent, child, ...)
-  local ____r57 = unstash({...})
-  local __parent = destash33(parent, ____r57)
-  local __child = destash33(child, ____r57)
-  local ____id8 = ____r57
-  local __right = ____id8.right
-  local __e31
+local function opDelims(parent, child, ...)
+  local ____r59 = unstash({...})
+  local __parent = destash33(parent, ____r59)
+  local __child = destash33(child, ____r59)
+  local ____id10 = ____r59
+  local __right = ____id10.right
+  local __e21
   if __right then
-    __e31 = _6261
+    __e21 = _6261
   else
-    __e31 = _62
+    __e21 = _62
   end
-  if __e31(precedence(__child), precedence(__parent)) then
+  if __e21(precedence(__child), precedence(__parent)) then
     return {"(", ")"}
   else
     return {"", ""}
   end
 end
-local function compile_infix(form)
-  local ____id9 = form
-  local __op = ____id9[1]
-  local ____id10 = cut(____id9, 1)
-  local __a1 = ____id10[1]
-  local __b2 = ____id10[2]
-  local ____id111 = op_delims(form, __a1)
-  local __ao = ____id111[1]
-  local __ac = ____id111[2]
-  local ____id12 = op_delims(form, __b2, {_stash = true, right = true})
-  local __bo = ____id12[1]
-  local __bc = ____id12[2]
-  local __a2 = compile(__a1)
+local function compileInfix(form)
+  local ____id111 = form
+  local __op = ____id111[1]
+  local ____id12 = cut(____id111, 1)
+  local __a2 = ____id12[1]
+  local __b2 = ____id12[2]
+  local ____id13 = opDelims(form, __a2)
+  local __ao = ____id13[1]
+  local __ac = ____id13[2]
+  local ____id14 = opDelims(form, __b2, {_stash = true, right = true})
+  local __bo = ____id14[1]
+  local __bc = ____id14[2]
+  local __a3 = compile(__a2)
   local __b3 = compile(__b2)
   local __op1 = getop(__op)
   if unary63(form) then
-    return __op1 .. __ao .. " " .. __a2 .. __ac
+    return __op1 .. __ao .. " " .. __a3 .. __ac
   else
-    return __ao .. __a2 .. __ac .. " " .. __op1 .. " " .. __bo .. __b3 .. __bc
+    return __ao .. __a3 .. __ac .. " " .. __op1 .. " " .. __bo .. __b3 .. __bc
   end
 end
-function compile_function(args, body, ...)
-  local ____r59 = unstash({...})
-  local __args4 = destash33(args, ____r59)
-  local __body3 = destash33(body, ____r59)
-  local ____id13 = ____r59
-  local __name3 = ____id13.name
-  local __prefix = ____id13.prefix
-  local __e32
+function compileFunction(args, body, ...)
+  local ____r61 = unstash({...})
+  local __args4 = destash33(args, ____r61)
+  local __body3 = destash33(body, ____r61)
+  local ____id15 = ____r61
+  local __name3 = ____id15.name
+  local __prefix = ____id15.prefix
+  local __e22
   if __name3 then
-    __e32 = compile(__name3)
+    __e22 = compile(__name3)
   else
-    __e32 = ""
+    __e22 = ""
   end
-  local __id14 = __e32
-  local __e33
+  local __id16 = __e22
+  local __e23
   if target == "lua" and __args4.rest then
-    __e33 = join(__args4, {"|...|"})
+    __e23 = join(__args4, {"|...|"})
   else
-    __e33 = __args4
+    __e23 = __args4
   end
-  local __args12 = __e33
-  local __args5 = compile_args(__args12)
-  indent_level = indent_level + 1
-  local ____x91 = compile(__body3, {_stash = true, stmt = true})
-  indent_level = indent_level - 1
-  local __body4 = ____x91
+  local __args12 = __e23
+  local __args5 = compileArgs(__args12)
+  indentLevel = indentLevel + 1
+  local ____x78 = compile(__body3, {_stash = true, stmt = true})
+  indentLevel = indentLevel - 1
+  local __body4 = ____x78
   local __ind = indentation()
-  local __e34
+  local __e24
   if __prefix then
-    __e34 = __prefix .. " "
+    __e24 = __prefix .. " "
   else
-    __e34 = ""
+    __e24 = ""
   end
-  local __p = __e34
-  local __e35
+  local __p = __e24
+  local __e25
   if target == "js" then
-    __e35 = ""
+    __e25 = ""
   else
-    __e35 = "end"
+    __e25 = "end"
   end
-  local __tr1 = __e35
+  local __tr1 = __e25
   if __name3 then
     __tr1 = __tr1 .. "\n"
   end
   if target == "js" then
-    return "function " .. __id14 .. __args5 .. " {\n" .. __body4 .. __ind .. "}" .. __tr1
+    return "function " .. __id16 .. __args5 .. " {\n" .. __body4 .. __ind .. "}" .. __tr1
   else
-    return __p .. "function " .. __id14 .. __args5 .. "\n" .. __body4 .. __ind .. __tr1
+    return __p .. "function " .. __id16 .. __args5 .. "\n" .. __body4 .. __ind .. __tr1
   end
 end
-local function can_return63(form)
+local function canReturn63(form)
   return is63(form) and (atom63(form) or not( hd(form) == "return") and not statement63(hd(form)))
 end
 function compile(form, ...)
-  local ____r61 = unstash({...})
-  local __form = destash33(form, ____r61)
-  local ____id15 = ____r61
-  local __stmt1 = ____id15.stmt
+  local ____r63 = unstash({...})
+  local __form = destash33(form, ____r63)
+  local ____id17 = ____r63
+  local __stmt1 = ____id17.stmt
   if nil63(__form) then
     return ""
   else
-    if special_form63(__form) then
-      return compile_special(__form, __stmt1)
+    if specialForm63(__form) then
+      return compileSpecial(__form, __stmt1)
     else
       local __tr2 = terminator(__stmt1)
-      local __e36
+      local __e26
       if __stmt1 then
-        __e36 = indentation()
+        __e26 = indentation()
       else
-        __e36 = ""
+        __e26 = ""
       end
-      local __ind1 = __e36
-      local __e37
+      local __ind1 = __e26
+      local __e27
       if atom63(__form) then
-        __e37 = compile_atom(__form)
+        __e27 = compileAtom(__form)
       else
-        local __e38
+        local __e28
         if infix63(hd(__form)) then
-          __e38 = compile_infix(__form)
+          __e28 = compileInfix(__form)
         else
-          __e38 = compile_call(__form)
+          __e28 = compileCall(__form)
         end
-        __e37 = __e38
+        __e27 = __e28
       end
-      local __form1 = __e37
+      local __form1 = __e27
       return __ind1 .. __form1 .. __tr2
     end
   end
 end
-local function lower_statement(form, tail63)
+local function lowerStatement(form, tail63)
   local __hoist = {}
   local __e = lower(form, __hoist, true, tail63)
-  local __e39
+  local __e29
   if some63(__hoist) and is63(__e) then
-    __e39 = join({"do"}, __hoist, {__e})
+    __e29 = join({"do"}, __hoist, {__e})
   else
-    local __e40
+    local __e30
     if is63(__e) then
-      __e40 = __e
+      __e30 = __e
     else
-      local __e41
+      local __e31
       if _35(__hoist) > 1 then
-        __e41 = join({"do"}, __hoist)
+        __e31 = join({"do"}, __hoist)
       else
-        __e41 = hd(__hoist)
+        __e31 = hd(__hoist)
       end
-      __e40 = __e41
+      __e30 = __e31
     end
-    __e39 = __e40
+    __e29 = __e30
   end
-  return either(__e39, {"do"})
+  return either(__e29, {"do"})
 end
-local function lower_body(body, tail63)
-  return lower_statement(join({"do"}, body), tail63)
+local function lowerBody(body, tail63)
+  return lowerStatement(join({"do"}, body), tail63)
 end
 local function literal63(form)
   return atom63(form) or hd(form) == "%array" or hd(form) == "%object"
 end
 local function standalone63(form)
-  return not atom63(form) and not infix63(hd(form)) and not literal63(form) and not( "get" == hd(form)) or id_literal63(form)
+  return not atom63(form) and not infix63(hd(form)) and not literal63(form) and not( "get" == hd(form)) or idLiteral63(form)
 end
-local function lower_do(args, hoist, stmt63, tail63)
-  local ____x98 = almost(args)
+local function lowerDo(args, hoist, stmt63, tail63)
+  local ____x85 = almost(args)
   local ____i17 = 0
-  while ____i17 < _35(____x98) do
-    local __x99 = ____x98[____i17 + 1]
-    local ____y = lower(__x99, hoist, stmt63)
+  while ____i17 < _35(____x85) do
+    local __x86 = ____x85[____i17 + 1]
+    local ____y = lower(__x86, hoist, stmt63)
     if yes(____y) then
       local __e1 = ____y
       if standalone63(__e1) then
@@ -863,100 +873,100 @@ local function lower_do(args, hoist, stmt63, tail63)
     ____i17 = ____i17 + 1
   end
   local __e2 = lower(last(args), hoist, stmt63, tail63)
-  if tail63 and can_return63(__e2) then
+  if tail63 and canReturn63(__e2) then
     return {"return", __e2}
   else
     return __e2
   end
 end
-local function lower_set(args, hoist, stmt63, tail63)
-  local ____id16 = args
-  local __lh = ____id16[1]
-  local __rh = ____id16[2]
+local function lowerSet(args, hoist, stmt63, tail63)
+  local ____id18 = args
+  local __lh = ____id18[1]
+  local __rh = ____id18[2]
   add(hoist, {"%set", lower(__lh, hoist), lower(__rh, hoist)})
   if not( stmt63 and not tail63) then
     return __lh
   end
 end
-local function lower_if(args, hoist, stmt63, tail63)
-  local ____id17 = args
-  local __cond = ____id17[1]
-  local ___then = ____id17[2]
-  local ___else = ____id17[3]
+local function lowerIf(args, hoist, stmt63, tail63)
+  local ____id19 = args
+  local __cond = ____id19[1]
+  local __then = ____id19[2]
+  local __else = ____id19[3]
   if stmt63 then
-    local __e43
-    if is63(___else) then
-      __e43 = {lower_body({___else}, tail63)}
+    local __e33
+    if is63(__else) then
+      __e33 = {lowerBody({__else}, tail63)}
     end
-    return add(hoist, join({"%if", lower(__cond, hoist), lower_body({___then}, tail63)}, __e43))
+    return add(hoist, join({"%if", lower(__cond, hoist), lowerBody({__then}, tail63)}, __e33))
   else
     local __e3 = unique("e")
     add(hoist, {"%local", __e3})
-    local __e42
-    if is63(___else) then
-      __e42 = {lower({"%set", __e3, ___else})}
+    local __e32
+    if is63(__else) then
+      __e32 = {lower({"%set", __e3, __else})}
     end
-    add(hoist, join({"%if", lower(__cond, hoist), lower({"%set", __e3, ___then})}, __e42))
+    add(hoist, join({"%if", lower(__cond, hoist), lower({"%set", __e3, __then})}, __e32))
     return __e3
   end
 end
-local function lower_short(x, args, hoist)
-  local ____id18 = args
-  local __a3 = ____id18[1]
-  local __b4 = ____id18[2]
+local function lowerShort(x, args, hoist)
+  local ____id20 = args
+  local __a4 = ____id20[1]
+  local __b4 = ____id20[2]
   local __hoist1 = {}
   local __b11 = lower(__b4, __hoist1)
   if some63(__hoist1) then
-    local __id19 = unique("id")
-    local __e44
+    local __id21 = unique("id")
+    local __e34
     if x == "and" then
-      __e44 = {"%if", __id19, __b4, __id19}
+      __e34 = {"%if", __id21, __b4, __id21}
     else
-      __e44 = {"%if", __id19, __id19, __b4}
+      __e34 = {"%if", __id21, __id21, __b4}
     end
-    return lower({"do", {"%local", __id19, __a3}, __e44}, hoist)
+    return lower({"do", {"%local", __id21, __a4}, __e34}, hoist)
   else
-    return {x, lower(__a3, hoist), __b11}
+    return {x, lower(__a4, hoist), __b11}
   end
 end
-local function lower_try(args, hoist, tail63)
-  return add(hoist, {"%try", lower_body(args, tail63)})
+local function lowerTry(args, hoist, tail63)
+  return add(hoist, {"%try", lowerBody(args, tail63)})
 end
-local function lower_while(args, hoist)
-  local ____id20 = args
-  local __c4 = ____id20[1]
-  local __body5 = cut(____id20, 1)
+local function lowerWhile(args, hoist)
+  local ____id22 = args
+  local __c4 = ____id22[1]
+  local __body5 = cut(____id22, 1)
   local __pre = {}
   local __c5 = lower(__c4, __pre)
-  local __e45
+  local __e35
   if none63(__pre) then
-    __e45 = {"while", __c5, lower_body(__body5)}
+    __e35 = {"while", __c5, lowerBody(__body5)}
   else
-    __e45 = {"while", true, join({"do"}, __pre, {{"%if", {"not", __c5}, {"break"}}, lower_body(__body5)})}
+    __e35 = {"while", true, join({"do"}, __pre, {{"%if", {"not", __c5}, {"break"}}, lowerBody(__body5)})}
   end
-  return add(hoist, __e45)
+  return add(hoist, __e35)
 end
-local function lower_for(args, hoist)
-  local ____id21 = args
-  local __t = ____id21[1]
-  local __k7 = ____id21[2]
-  local __body6 = cut(____id21, 2)
-  return add(hoist, {"%for", lower(__t, hoist), __k7, lower_body(__body6)})
-end
-local function lower_function(args)
-  local ____id22 = args
-  local __a4 = ____id22[1]
-  local __body7 = cut(____id22, 1)
-  return {"%function", __a4, lower_body(__body7, true)}
-end
-local function lower_definition(kind, args, hoist)
+local function lowerFor(args, hoist)
   local ____id23 = args
-  local __name4 = ____id23[1]
-  local __args6 = ____id23[2]
-  local __body8 = cut(____id23, 2)
-  return add(hoist, {kind, __name4, __args6, lower_body(__body8, true)})
+  local __t = ____id23[1]
+  local __k7 = ____id23[2]
+  local __body6 = cut(____id23, 2)
+  return add(hoist, {"%for", lower(__t, hoist), __k7, lowerBody(__body6)})
 end
-local function lower_call(form, hoist)
+local function lowerFunction(args)
+  local ____id24 = args
+  local __a5 = ____id24[1]
+  local __body7 = cut(____id24, 1)
+  return {"%function", __a5, lowerBody(__body7, true)}
+end
+local function lowerDefinition(kind, args, hoist)
+  local ____id25 = args
+  local __name4 = ____id25[1]
+  local __args6 = ____id25[2]
+  local __body8 = cut(____id25, 2)
+  return add(hoist, {kind, __name4, __args6, lowerBody(__body8, true)})
+end
+local function lowerCall(form, hoist)
   local __form2 = map(function (x)
     return lower(x, hoist)
   end, form)
@@ -967,14 +977,14 @@ end
 local function pairwise63(form)
   return in63(hd(form), {"<", "<=", "=", ">=", ">"})
 end
-local function lower_pairwise(form)
+local function lowerPairwise(form)
   if pairwise63(form) then
     local __e4 = {}
-    local ____id24 = form
-    local __x128 = ____id24[1]
-    local __args7 = cut(____id24, 1)
+    local ____id26 = form
+    local __x115 = ____id26[1]
+    local __args7 = cut(____id26, 1)
     reduce(function (a, b)
-      add(__e4, {__x128, a, b})
+      add(__e4, {__x115, a, b})
       return a
     end, __args7)
     return join({"and"}, reverse(__e4))
@@ -982,20 +992,20 @@ local function lower_pairwise(form)
     return form
   end
 end
-local function lower_infix63(form)
+local function lowerInfix63(form)
   return infix63(hd(form)) and _35(form) > 3
 end
-local function lower_infix(form, hoist)
-  local __form3 = lower_pairwise(form)
-  local ____id25 = __form3
-  local __x131 = ____id25[1]
-  local __args8 = cut(____id25, 1)
+local function lowerInfix(form, hoist)
+  local __form3 = lowerPairwise(form)
+  local ____id27 = __form3
+  local __x118 = ____id27[1]
+  local __args8 = cut(____id27, 1)
   return lower(reduce(function (a, b)
-    return {__x131, b, a}
+    return {__x118, b, a}
   end, reverse(__args8)), hoist)
 end
-local function lower_special(form, hoist)
-  local __e5 = lower_call(form, hoist)
+local function lowerSpecial(form, hoist)
+  local __e5 = lowerCall(form, hoist)
   if __e5 then
     return add(hoist, __e5)
   end
@@ -1008,48 +1018,48 @@ function lower(form, hoist, stmt63, tail63)
       return {"%array"}
     else
       if nil63(hoist) then
-        return lower_statement(form)
+        return lowerStatement(form)
       else
-        if lower_infix63(form) then
-          return lower_infix(form, hoist)
+        if lowerInfix63(form) then
+          return lowerInfix(form, hoist)
         else
-          local ____id26 = form
-          local __x134 = ____id26[1]
-          local __args9 = cut(____id26, 1)
-          if __x134 == "do" then
-            return lower_do(__args9, hoist, stmt63, tail63)
+          local ____id28 = form
+          local __x121 = ____id28[1]
+          local __args9 = cut(____id28, 1)
+          if __x121 == "do" then
+            return lowerDo(__args9, hoist, stmt63, tail63)
           else
-            if __x134 == "%call" then
+            if __x121 == "%call" then
               return lower(__args9, hoist, stmt63, tail63)
             else
-              if __x134 == "%set" then
-                return lower_set(__args9, hoist, stmt63, tail63)
+              if __x121 == "%set" then
+                return lowerSet(__args9, hoist, stmt63, tail63)
               else
-                if __x134 == "%if" then
-                  return lower_if(__args9, hoist, stmt63, tail63)
+                if __x121 == "%if" then
+                  return lowerIf(__args9, hoist, stmt63, tail63)
                 else
-                  if __x134 == "%try" then
-                    return lower_try(__args9, hoist, tail63)
+                  if __x121 == "%try" then
+                    return lowerTry(__args9, hoist, tail63)
                   else
-                    if __x134 == "while" then
-                      return lower_while(__args9, hoist)
+                    if __x121 == "while" then
+                      return lowerWhile(__args9, hoist)
                     else
-                      if __x134 == "%for" then
-                        return lower_for(__args9, hoist)
+                      if __x121 == "%for" then
+                        return lowerFor(__args9, hoist)
                       else
-                        if __x134 == "%function" then
-                          return lower_function(__args9)
+                        if __x121 == "%function" then
+                          return lowerFunction(__args9)
                         else
-                          if __x134 == "%local-function" or __x134 == "%global-function" then
-                            return lower_definition(__x134, __args9, hoist)
+                          if __x121 == "%local-function" or __x121 == "%global-function" then
+                            return lowerDefinition(__x121, __args9, hoist)
                           else
-                            if in63(__x134, {"and", "or"}) then
-                              return lower_short(__x134, __args9, hoist)
+                            if in63(__x121, {"and", "or"}) then
+                              return lowerShort(__x121, __args9, hoist)
                             else
-                              if statement63(__x134) then
-                                return lower_special(form, hoist)
+                              if statement63(__x121) then
+                                return lowerSpecial(form, hoist)
                               else
-                                return lower_call(form, hoist)
+                                return lowerCall(form, hoist)
                               end
                             end
                           end
@@ -1087,102 +1097,102 @@ function _eval(form)
   run(__code)
   return _37result
 end
-function immediate_call63(x)
+function immediateCall63(x)
   return obj63(x) and obj63(hd(x)) and hd(hd(x)) == "%function"
 end
 setenv("do", {_stash = true, special = function (...)
-  local __forms1 = unstash({...})
-  local __s3 = ""
-  local ____x140 = __forms1
-  local ____i19 = 0
-  while ____i19 < _35(____x140) do
-    local __x141 = ____x140[____i19 + 1]
-    if target == "lua" and immediate_call63(__x141) and "\n" == char(__s3, edge(__s3)) then
-      __s3 = clip(__s3, 0, edge(__s3)) .. ";\n"
+  local __forms = unstash({...})
+  local __s4 = ""
+  local ____x125 = __forms
+  local ____i18 = 0
+  while ____i18 < _35(____x125) do
+    local __x126 = ____x125[____i18 + 1]
+    if target == "lua" and immediateCall63(__x126) and "\n" == char(__s4, edge(__s4)) then
+      __s4 = clip(__s4, 0, edge(__s4)) .. ";\n"
     end
-    __s3 = __s3 .. compile(__x141, {_stash = true, stmt = true})
-    if not atom63(__x141) then
-      if hd(__x141) == "return" or hd(__x141) == "break" then
+    __s4 = __s4 .. compile(__x126, {_stash = true, stmt = true})
+    if not atom63(__x126) then
+      if hd(__x126) == "return" or hd(__x126) == "break" then
         break
       end
     end
-    ____i19 = ____i19 + 1
+    ____i18 = ____i18 + 1
   end
-  return __s3
+  return __s4
 end, stmt = true, tr = true})
 setenv("%if", {_stash = true, special = function (cond, cons, alt)
-  local __cond2 = compile(cond)
-  indent_level = indent_level + 1
-  local ____x144 = compile(cons, {_stash = true, stmt = true})
-  indent_level = indent_level - 1
-  local __cons1 = ____x144
-  local __e46
+  local __cond1 = compile(cond)
+  indentLevel = indentLevel + 1
+  local ____x127 = compile(cons, {_stash = true, stmt = true})
+  indentLevel = indentLevel - 1
+  local __cons = ____x127
+  local __e36
   if alt then
-    indent_level = indent_level + 1
-    local ____x145 = compile(alt, {_stash = true, stmt = true})
-    indent_level = indent_level - 1
-    __e46 = ____x145
+    indentLevel = indentLevel + 1
+    local ____x128 = compile(alt, {_stash = true, stmt = true})
+    indentLevel = indentLevel - 1
+    __e36 = ____x128
   end
-  local __alt1 = __e46
-  local __ind3 = indentation()
+  local __alt = __e36
+  local __ind2 = indentation()
   local __s5 = ""
   if target == "js" then
-    __s5 = __s5 .. __ind3 .. "if (" .. __cond2 .. ") {\n" .. __cons1 .. __ind3 .. "}"
+    __s5 = __s5 .. __ind2 .. "if (" .. __cond1 .. ") {\n" .. __cons .. __ind2 .. "}"
   else
-    __s5 = __s5 .. __ind3 .. "if " .. __cond2 .. " then\n" .. __cons1
+    __s5 = __s5 .. __ind2 .. "if " .. __cond1 .. " then\n" .. __cons
   end
-  if __alt1 and target == "js" then
-    __s5 = __s5 .. " else {\n" .. __alt1 .. __ind3 .. "}"
+  if __alt and target == "js" then
+    __s5 = __s5 .. " else {\n" .. __alt .. __ind2 .. "}"
   else
-    if __alt1 then
-      __s5 = __s5 .. __ind3 .. "else\n" .. __alt1
+    if __alt then
+      __s5 = __s5 .. __ind2 .. "else\n" .. __alt
     end
   end
   if target == "lua" then
-    return __s5 .. __ind3 .. "end\n"
+    return __s5 .. __ind2 .. "end\n"
   else
     return __s5 .. "\n"
   end
 end, stmt = true, tr = true})
 setenv("while", {_stash = true, special = function (cond, form)
-  local __cond4 = compile(cond)
-  indent_level = indent_level + 1
-  local ____x147 = compile(form, {_stash = true, stmt = true})
-  indent_level = indent_level - 1
-  local __body10 = ____x147
-  local __ind5 = indentation()
+  local __cond2 = compile(cond)
+  indentLevel = indentLevel + 1
+  local ____x129 = compile(form, {_stash = true, stmt = true})
+  indentLevel = indentLevel - 1
+  local __body9 = ____x129
+  local __ind3 = indentation()
   if target == "js" then
-    return __ind5 .. "while (" .. __cond4 .. ") {\n" .. __body10 .. __ind5 .. "}\n"
+    return __ind3 .. "while (" .. __cond2 .. ") {\n" .. __body9 .. __ind3 .. "}\n"
   else
-    return __ind5 .. "while " .. __cond4 .. " do\n" .. __body10 .. __ind5 .. "end\n"
+    return __ind3 .. "while " .. __cond2 .. " do\n" .. __body9 .. __ind3 .. "end\n"
   end
 end, stmt = true, tr = true})
 setenv("%for", {_stash = true, special = function (t, k, form)
-  local __t2 = compile(t)
-  local __ind7 = indentation()
-  indent_level = indent_level + 1
-  local ____x149 = compile(form, {_stash = true, stmt = true})
-  indent_level = indent_level - 1
-  local __body12 = ____x149
+  local __t1 = compile(t)
+  local __ind4 = indentation()
+  indentLevel = indentLevel + 1
+  local ____x130 = compile(form, {_stash = true, stmt = true})
+  indentLevel = indentLevel - 1
+  local __body10 = ____x130
   if target == "lua" then
-    return __ind7 .. "for " .. k .. " in next, " .. __t2 .. " do\n" .. __body12 .. __ind7 .. "end\n"
+    return __ind4 .. "for " .. k .. " in next, " .. __t1 .. " do\n" .. __body10 .. __ind4 .. "end\n"
   else
-    return __ind7 .. "for (" .. k .. " in " .. __t2 .. ") {\n" .. __body12 .. __ind7 .. "}\n"
+    return __ind4 .. "for (" .. k .. " in " .. __t1 .. ") {\n" .. __body10 .. __ind4 .. "}\n"
   end
 end, stmt = true, tr = true})
 setenv("%try", {_stash = true, special = function (form)
-  local __e8 = unique("e")
-  local __ind9 = indentation()
-  indent_level = indent_level + 1
-  local ____x154 = compile(form, {_stash = true, stmt = true})
-  indent_level = indent_level - 1
-  local __body14 = ____x154
-  local __hf1 = {"return", {"%array", false, __e8}}
-  indent_level = indent_level + 1
-  local ____x157 = compile(__hf1, {_stash = true, stmt = true})
-  indent_level = indent_level - 1
-  local __h1 = ____x157
-  return __ind9 .. "try {\n" .. __body14 .. __ind9 .. "}\n" .. __ind9 .. "catch (" .. __e8 .. ") {\n" .. __h1 .. __ind9 .. "}\n"
+  local __e6 = unique("e")
+  local __ind5 = indentation()
+  indentLevel = indentLevel + 1
+  local ____x131 = compile(form, {_stash = true, stmt = true})
+  indentLevel = indentLevel - 1
+  local __body11 = ____x131
+  local __hf = {"return", {"%array", false, __e6}}
+  indentLevel = indentLevel + 1
+  local ____x134 = compile(__hf, {_stash = true, stmt = true})
+  indentLevel = indentLevel - 1
+  local __h = ____x134
+  return __ind5 .. "try {\n" .. __body11 .. __ind5 .. "}\n" .. __ind5 .. "catch (" .. __e6 .. ") {\n" .. __h .. __ind5 .. "}\n"
 end, stmt = true, tr = true})
 setenv("%delete", {_stash = true, special = function (place)
   return indentation() .. "delete " .. compile(place)
@@ -1191,33 +1201,33 @@ setenv("break", {_stash = true, special = function ()
   return indentation() .. "break"
 end, stmt = true})
 setenv("%function", {_stash = true, special = function (args, body)
-  return compile_function(args, body)
+  return compileFunction(args, body)
 end})
 setenv("%global-function", {_stash = true, special = function (name, args, body)
   if target == "lua" then
-    local __x161 = compile_function(args, body, {_stash = true, name = name})
-    return indentation() .. __x161
+    local __x135 = compileFunction(args, body, {_stash = true, name = name})
+    return indentation() .. __x135
   else
     return compile({"%set", name, {"%function", args, body}}, {_stash = true, stmt = true})
   end
 end, stmt = true, tr = true})
 setenv("%local-function", {_stash = true, special = function (name, args, body)
   if target == "lua" then
-    local __x167 = compile_function(args, body, {_stash = true, name = name, prefix = "local"})
-    return indentation() .. __x167
+    local __x138 = compileFunction(args, body, {_stash = true, name = name, prefix = "local"})
+    return indentation() .. __x138
   else
     return compile({"%local", name, {"%function", args, body}}, {_stash = true, stmt = true})
   end
 end, stmt = true, tr = true})
 setenv("return", {_stash = true, special = function (x)
-  local __e47
+  local __e37
   if nil63(x) then
-    __e47 = "return"
+    __e37 = "return"
   else
-    __e47 = "return " .. compile(x)
+    __e37 = "return " .. compile(x)
   end
-  local __x171 = __e47
-  return indentation() .. __x171
+  local __x141 = __e37
+  return indentation() .. __x141
 end, stmt = true})
 setenv("new", {_stash = true, special = function (x)
   return "new " .. compile(x)
@@ -1226,117 +1236,117 @@ setenv("typeof", {_stash = true, special = function (x)
   return "typeof(" .. compile(x) .. ")"
 end})
 setenv("error", {_stash = true, special = function (x)
-  local __e48
+  local __e38
   if target == "js" then
-    __e48 = "throw " .. compile({"new", {"Error", x}})
+    __e38 = "throw " .. compile({"new", {"Error", x}})
   else
-    __e48 = "error(" .. compile(x) .. ")"
+    __e38 = "error(" .. compile(x) .. ")"
   end
-  local __e12 = __e48
-  return indentation() .. __e12
+  local __e7 = __e38
+  return indentation() .. __e7
 end, stmt = true})
 setenv("%local", {_stash = true, special = function (name, value)
-  local __id28 = compile(name)
-  local __value11 = compile(value)
-  local __e49
+  local __id29 = compile(name)
+  local __value1 = compile(value)
+  local __e39
   if is63(value) then
-    __e49 = " = " .. __value11
+    __e39 = " = " .. __value1
   else
-    __e49 = ""
+    __e39 = ""
   end
-  local __rh2 = __e49
-  local __e50
+  local __rh1 = __e39
+  local __e40
   if target == "js" then
-    __e50 = "var "
+    __e40 = "var "
   else
-    __e50 = "local "
+    __e40 = "local "
   end
-  local __keyword1 = __e50
-  local __ind11 = indentation()
-  return __ind11 .. __keyword1 .. __id28 .. __rh2
+  local __keyword = __e40
+  local __ind6 = indentation()
+  return __ind6 .. __keyword .. __id29 .. __rh1
 end, stmt = true})
 setenv("%set", {_stash = true, special = function (lh, rh)
-  local __lh2 = compile(lh)
-  local __e51
+  local __lh1 = compile(lh)
+  local __e41
   if nil63(rh) then
-    __e51 = "nil"
+    __e41 = "nil"
   else
-    __e51 = rh
+    __e41 = rh
   end
-  local __rh4 = compile(__e51)
-  return indentation() .. __lh2 .. " = " .. __rh4
+  local __rh2 = compile(__e41)
+  return indentation() .. __lh1 .. " = " .. __rh2
 end, stmt = true})
 setenv("get", {_stash = true, special = function (t, k)
-  local __t12 = compile(t)
-  local __k12 = compile(k)
-  if target == "lua" and char(__t12, 0) == "{" or infix_operator63(t) then
-    __t12 = "(" .. __t12 .. ")"
+  local __t11 = compile(t)
+  local __k11 = compile(k)
+  if target == "lua" and char(__t11, 0) == "{" or infixOperator63(t) then
+    __t11 = "(" .. __t11 .. ")"
   end
-  if string_literal63(k) and valid_id63(inner(k)) then
-    return __t12 .. "." .. inner(k)
+  if stringLiteral63(k) and validId63(inner(k)) then
+    return __t11 .. "." .. inner(k)
   else
-    return __t12 .. "[" .. __k12 .. "]"
+    return __t11 .. "[" .. __k11 .. "]"
   end
 end})
 setenv("%array", {_stash = true, special = function (...)
-  local __forms3 = unstash({...})
-  local __e52
+  local __forms1 = unstash({...})
+  local __e42
   if target == "lua" then
-    __e52 = "{"
+    __e42 = "{"
   else
-    __e52 = "["
+    __e42 = "["
   end
-  local __open1 = __e52
-  local __e53
+  local __open = __e42
+  local __e43
   if target == "lua" then
-    __e53 = "}"
+    __e43 = "}"
   else
-    __e53 = "]"
+    __e43 = "]"
   end
-  local __close1 = __e53
-  local __s7 = ""
+  local __close = __e43
+  local __s6 = ""
+  local __c6 = ""
+  local ____o9 = __forms1
+  local __k8 = nil
+  for __k8 in next, ____o9 do
+    local __v8 = ____o9[__k8]
+    if number63(__k8) then
+      __s6 = __s6 .. __c6 .. compile(__v8)
+      __c6 = ", "
+    end
+  end
+  return __open .. __s6 .. __close
+end})
+setenv("%object", {_stash = true, special = function (...)
+  local __forms2 = unstash({...})
+  local __s7 = "{"
   local __c7 = ""
-  local ____o10 = __forms3
-  local __k10 = nil
-  for __k10 in next, ____o10 do
-    local __v9 = ____o10[__k10]
-    if number63(__k10) then
-      __s7 = __s7 .. __c7 .. compile(__v9)
+  local __e44
+  if target == "lua" then
+    __e44 = " = "
+  else
+    __e44 = ": "
+  end
+  local __sep = __e44
+  local ____o10 = pair(__forms2)
+  local __k9 = nil
+  for __k9 in next, ____o10 do
+    local __v9 = ____o10[__k9]
+    if number63(__k9) then
+      local ____id30 = __v9
+      local __k10 = ____id30[1]
+      local __v10 = ____id30[2]
+      if not string63(__k10) then
+        error("Illegal key: " .. str(__k10))
+      end
+      __s7 = __s7 .. __c7 .. key(__k10) .. __sep .. compile(__v10)
       __c7 = ", "
     end
   end
-  return __open1 .. __s7 .. __close1
-end})
-setenv("%object", {_stash = true, special = function (...)
-  local __forms5 = unstash({...})
-  local __s9 = "{"
-  local __c9 = ""
-  local __e54
-  if target == "lua" then
-    __e54 = " = "
-  else
-    __e54 = ": "
-  end
-  local __sep1 = __e54
-  local ____o12 = pair(__forms5)
-  local __k14 = nil
-  for __k14 in next, ____o12 do
-    local __v12 = ____o12[__k14]
-    if number63(__k14) then
-      local ____id30 = __v12
-      local __k15 = ____id30[1]
-      local __v13 = ____id30[2]
-      if not string63(__k15) then
-        error("Illegal key: " .. str(__k15))
-      end
-      __s9 = __s9 .. __c9 .. key(__k15) .. __sep1 .. compile(__v13)
-      __c9 = ", "
-    end
-  end
-  return __s9 .. "}"
+  return __s7 .. "}"
 end})
 setenv("%literal", {_stash = true, special = function (...)
-  local __args111 = unstash({...})
-  return apply(cat, map(compile, __args111))
+  local __args10 = unstash({...})
+  return apply(cat, map(compile, __args10))
 end})
 return {run = run, ["eval"] = _eval, expand = expand, compile = compile}

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -147,10 +147,31 @@ char = function (s, n) {
 code = function (s, n) {
   return s.charCodeAt(n);
 };
-string_literal63 = function (x) {
+fromCode = function (n) {
+  return String.fromCharCode(n);
+};
+lowercase63 = function (n) {
+  return n > 96 && n < 123;
+};
+camelCase = function (str) {
+  var __s = "";
+  var __n3 = _35(str);
+  var __i3 = 0;
+  while (__i3 < __n3) {
+    var __c = code(str, __i3);
+    if (__c === 45 && lowercase63(code(str, __i3 - 1) || 0) && lowercase63(code(str, __i3 + 1) || 0)) {
+      __i3 = __i3 + 1;
+      __c = code(str, __i3) - 32;
+    }
+    __s = __s + fromCode(__c);
+    __i3 = __i3 + 1;
+  }
+  return __s;
+};
+stringLiteral63 = function (x) {
   return string63(x) && char(x, 0) === "\"";
 };
-id_literal63 = function (x) {
+idLiteral63 = function (x) {
   return string63(x) && char(x, 0) === "|";
 };
 add = function (l, x) {
@@ -168,10 +189,10 @@ almost = function (l) {
 };
 reverse = function (l) {
   var __l1 = keys(l);
-  var __i3 = edge(l);
-  while (__i3 >= 0) {
-    add(__l1, l[__i3]);
-    __i3 = __i3 - 1;
+  var __i4 = edge(l);
+  while (__i4 >= 0) {
+    add(__l1, l[__i4]);
+    __i4 = __i4 - 1;
   }
   return __l1;
 };
@@ -188,13 +209,13 @@ reduce = function (f, x) {
 };
 join = function () {
   var __ls = unstash(Array.prototype.slice.call(arguments, 0));
-  var __r37 = [];
+  var __r40 = [];
   var ____x1 = __ls;
-  var ____i4 = 0;
-  while (____i4 < _35(____x1)) {
-    var __l11 = ____x1[____i4];
+  var ____i5 = 0;
+  while (____i5 < _35(____x1)) {
+    var __l11 = ____x1[____i5];
     if (__l11) {
-      var __n3 = _35(__r37);
+      var __n4 = _35(__r40);
       var ____o2 = __l11;
       var __k4 = undefined;
       for (__k4 in ____o2) {
@@ -207,27 +228,27 @@ join = function () {
         }
         var __k5 = __e4;
         if (number63(__k5)) {
-          __k5 = __k5 + __n3;
+          __k5 = __k5 + __n4;
         }
-        __r37[__k5] = __v2;
+        __r40[__k5] = __v2;
       }
     }
-    ____i4 = ____i4 + 1;
+    ____i5 = ____i5 + 1;
   }
-  return __r37;
+  return __r40;
 };
 find = function (f, t) {
   var ____o3 = t;
-  var ____i6 = undefined;
-  for (____i6 in ____o3) {
-    var __x2 = ____o3[____i6];
+  var ____i7 = undefined;
+  for (____i7 in ____o3) {
+    var __x2 = ____o3[____i7];
     var __e5;
-    if (numeric63(____i6)) {
-      __e5 = parseInt(____i6);
+    if (numeric63(____i7)) {
+      __e5 = parseInt(____i7);
     } else {
-      __e5 = ____i6;
+      __e5 = ____i7;
     }
-    var ____i61 = __e5;
+    var ____i71 = __e5;
     var __y = f(__x2);
     if (__y) {
       return __y;
@@ -236,14 +257,14 @@ find = function (f, t) {
 };
 first = function (f, l) {
   var ____x3 = l;
-  var ____i7 = 0;
-  while (____i7 < _35(____x3)) {
-    var __x4 = ____x3[____i7];
+  var ____i8 = 0;
+  while (____i8 < _35(____x3)) {
+    var __x4 = ____x3[____i8];
     var __y1 = f(__x4);
     if (__y1) {
       return __y1;
     }
-    ____i7 = ____i7 + 1;
+    ____i8 = ____i8 + 1;
   }
 };
 in63 = function (x, t) {
@@ -253,11 +274,11 @@ in63 = function (x, t) {
 };
 pair = function (l) {
   var __l12 = [];
-  var __i8 = 0;
-  while (__i8 < _35(l)) {
-    add(__l12, [l[__i8], l[__i8 + 1]]);
-    __i8 = __i8 + 1;
-    __i8 = __i8 + 1;
+  var __i9 = 0;
+  while (__i9 < _35(l)) {
+    add(__l12, [l[__i9], l[__i9 + 1]]);
+    __i9 = __i9 + 1;
+    __i9 = __i9 + 1;
   }
   return __l12;
 };
@@ -277,14 +298,14 @@ sort = function (l, f) {
 map = function (f, x) {
   var __t1 = [];
   var ____x6 = x;
-  var ____i9 = 0;
-  while (____i9 < _35(____x6)) {
-    var __v3 = ____x6[____i9];
+  var ____i10 = 0;
+  while (____i10 < _35(____x6)) {
+    var __v3 = ____x6[____i10];
     var __y2 = f(__v3);
     if (is63(__y2)) {
       add(__t1, __y2);
     }
-    ____i9 = ____i9 + 1;
+    ____i10 = ____i10 + 1;
   }
   var ____o4 = x;
   var __k6 = undefined;
@@ -333,16 +354,16 @@ keys63 = function (t) {
 };
 empty63 = function (t) {
   var ____o6 = t;
-  var ____i12 = undefined;
-  for (____i12 in ____o6) {
-    var __x7 = ____o6[____i12];
+  var ____i13 = undefined;
+  for (____i13 in ____o6) {
+    var __x7 = ____o6[____i13];
     var __e9;
-    if (numeric63(____i12)) {
-      __e9 = parseInt(____i12);
+    if (numeric63(____i13)) {
+      __e9 = parseInt(____i13);
     } else {
-      __e9 = ____i12;
+      __e9 = ____i13;
     }
-    var ____i121 = __e9;
+    var ____i131 = __e9;
     return false;
   }
   return true;
@@ -420,9 +441,9 @@ destash33 = function (l, args1) {
   }
 };
 search = function (s, pattern, start) {
-  var __i16 = s.indexOf(pattern, start);
-  if (__i16 >= 0) {
-    return __i16;
+  var __i17 = s.indexOf(pattern, start);
+  if (__i17 >= 0) {
+    return __i17;
   }
 };
 split = function (s, sep) {
@@ -430,14 +451,14 @@ split = function (s, sep) {
     return [];
   } else {
     var __l3 = [];
-    var __n12 = _35(sep);
+    var __n13 = _35(sep);
     while (true) {
-      var __i17 = search(s, sep);
-      if (nil63(__i17)) {
+      var __i18 = search(s, sep);
+      if (nil63(__i18)) {
         break;
       } else {
-        add(__l3, clip(s, 0, __i17));
-        s = clip(s, __i17 + __n12);
+        add(__l3, clip(s, 0, __i18));
+        s = clip(s, __i18 + __n13);
       }
     }
     add(__l3, s);
@@ -481,14 +502,14 @@ _37 = function () {
   }, reverse(__xs5)), 0);
 };
 var pairwise = function (f, xs) {
-  var __i18 = 0;
-  while (__i18 < edge(xs)) {
-    var __a = xs[__i18];
-    var __b = xs[__i18 + 1];
+  var __i19 = 0;
+  while (__i19 < edge(xs)) {
+    var __a = xs[__i19];
+    var __b = xs[__i19 + 1];
     if (! f(__a, __b)) {
       return false;
     }
-    __i18 = __i18 + 1;
+    __i19 = __i19 + 1;
   }
   return true;
 };
@@ -523,22 +544,22 @@ _6261 = function () {
   }, __xs10);
 };
 number = function (s) {
-  var __n13 = parseFloat(s);
-  if (! isNaN(__n13)) {
-    return __n13;
+  var __n14 = parseFloat(s);
+  if (! isNaN(__n14)) {
+    return __n14;
   }
 };
-number_code63 = function (n) {
+numberCode63 = function (n) {
   return n > 47 && n < 58;
 };
 numeric63 = function (s) {
-  var __n14 = _35(s);
-  var __i19 = 0;
-  while (__i19 < __n14) {
-    if (! number_code63(code(s, __i19))) {
+  var __n15 = _35(s);
+  var __i20 = 0;
+  while (__i20 < __n15) {
+    if (! numberCode63(code(s, __i20))) {
       return false;
     }
-    __i19 = __i19 + 1;
+    __i20 = __i20 + 1;
   }
   return some63(s);
 };
@@ -547,26 +568,26 @@ var tostring = function (x) {
 };
 escape = function (s) {
   var __s1 = "\"";
-  var __i20 = 0;
-  while (__i20 < _35(s)) {
-    var __c = char(s, __i20);
+  var __i21 = 0;
+  while (__i21 < _35(s)) {
+    var __c1 = char(s, __i21);
     var __e13;
-    if (__c === "\n") {
+    if (__c1 === "\n") {
       __e13 = "\\n";
     } else {
       var __e14;
-      if (__c === "\r") {
+      if (__c1 === "\r") {
         __e14 = "\\r";
       } else {
         var __e15;
-        if (__c === "\"") {
+        if (__c1 === "\"") {
           __e15 = "\\\"";
         } else {
           var __e16;
-          if (__c === "\\") {
+          if (__c1 === "\\") {
             __e16 = "\\\\";
           } else {
-            __e16 = __c;
+            __e16 = __c1;
           }
           __e15 = __e16;
         }
@@ -574,9 +595,9 @@ escape = function (s) {
       }
       __e13 = __e14;
     }
-    var __c1 = __e13;
-    __s1 = __s1 + __c1;
-    __i20 = __i20 + 1;
+    var __c11 = __e13;
+    __s1 = __s1 + __c11;
+    __i21 = __i21 + 1;
   }
   return __s1 + "\"";
 };
@@ -615,7 +636,7 @@ str = function (x, stack) {
                     if (false) {
                       return escape(tostring(x));
                     } else {
-                      var __s = "(";
+                      var __s11 = "(";
                       var __sp = "";
                       var __xs11 = [];
                       var __ks = [];
@@ -641,20 +662,20 @@ str = function (x, stack) {
                       }
                       drop(__l4);
                       var ____o11 = join(__xs11, __ks);
-                      var ____i22 = undefined;
-                      for (____i22 in ____o11) {
-                        var __v10 = ____o11[____i22];
+                      var ____i23 = undefined;
+                      for (____i23 in ____o11) {
+                        var __v10 = ____o11[____i23];
                         var __e18;
-                        if (numeric63(____i22)) {
-                          __e18 = parseInt(____i22);
+                        if (numeric63(____i23)) {
+                          __e18 = parseInt(____i23);
                         } else {
-                          __e18 = ____i22;
+                          __e18 = ____i23;
                         }
-                        var ____i221 = __e18;
-                        __s = __s + __sp + __v10;
+                        var ____i231 = __e18;
+                        __s11 = __s11 + __sp + __v10;
                         __sp = " ";
                       }
-                      return __s + ")";
+                      return __s11 + ")";
                     }
                   }
                 }
@@ -671,16 +692,16 @@ apply = function (f, args) {
   return f.apply(f, __args);
 };
 call = function (f) {
-  var ____r74 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __f = destash33(f, ____r74);
-  var ____id = ____r74;
+  var ____r77 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __f = destash33(f, ____r77);
+  var ____id = ____r77;
   var __args11 = cut(____id, 0);
   return apply(__f, __args11);
 };
 setenv = function (k) {
-  var ____r75 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __k18 = destash33(k, ____r75);
-  var ____id1 = ____r75;
+  var ____r78 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __k18 = destash33(k, ____r78);
+  var ____id1 = ____r78;
   var __keys = cut(____id1, 0);
   if (string63(__k18)) {
     var __e19;
@@ -739,13 +760,13 @@ setenv("quasiquote", {_stash: true, macro: function (form) {
   return quasiexpand(form, 1);
 }});
 setenv("set", {_stash: true, macro: function () {
-  var __args1 = unstash(Array.prototype.slice.call(arguments, 0));
-  return join(["do"], map(function (__x4) {
-    var ____id1 = __x4;
-    var __lh1 = ____id1[0];
-    var __rh1 = ____id1[1];
-    return ["%set", __lh1, __rh1];
-  }, pair(__args1)));
+  var __args = unstash(Array.prototype.slice.call(arguments, 0));
+  return join(["do"], map(function (__x1) {
+    var ____id = __x1;
+    var __lh = ____id[0];
+    var __rh = ____id[1];
+    return ["%set", __lh, __rh];
+  }, pair(__args)));
 }});
 setenv("at", {_stash: true, macro: function (l, i) {
   if (target === "lua" && number63(i)) {
@@ -765,432 +786,437 @@ setenv("wipe", {_stash: true, macro: function (place) {
   }
 }});
 setenv("list", {_stash: true, macro: function () {
-  var __body1 = unstash(Array.prototype.slice.call(arguments, 0));
-  var __x22 = unique("x");
-  var __l1 = [];
-  var __forms1 = [];
-  var ____o1 = __body1;
-  var __k2 = undefined;
-  for (__k2 in ____o1) {
-    var __v1 = ____o1[__k2];
-    var __e8;
-    if (numeric63(__k2)) {
-      __e8 = parseInt(__k2);
+  var __body = unstash(Array.prototype.slice.call(arguments, 0));
+  var __x7 = unique("x");
+  var __l = [];
+  var __forms = [];
+  var ____o = __body;
+  var __k = undefined;
+  for (__k in ____o) {
+    var __v = ____o[__k];
+    var __e;
+    if (numeric63(__k)) {
+      __e = parseInt(__k);
     } else {
-      __e8 = __k2;
+      __e = __k;
     }
-    var __k3 = __e8;
-    if (number63(__k3)) {
-      __l1[__k3] = __v1;
+    var __k1 = __e;
+    if (number63(__k1)) {
+      __l[__k1] = __v;
     } else {
-      add(__forms1, ["set", ["get", __x22, ["quote", __k3]], __v1]);
+      add(__forms, ["set", ["get", __x7, ["quote", __k1]], __v]);
     }
   }
-  if (some63(__forms1)) {
-    return join(["let", __x22, join(["%array"], __l1)], __forms1, [__x22]);
+  if (some63(__forms)) {
+    return join(["let", __x7, join(["%array"], __l)], __forms, [__x7]);
   } else {
-    return join(["%array"], __l1);
+    return join(["%array"], __l);
   }
 }});
 setenv("if", {_stash: true, macro: function () {
-  var __branches1 = unstash(Array.prototype.slice.call(arguments, 0));
-  return hd(expand_if(__branches1));
+  var __branches = unstash(Array.prototype.slice.call(arguments, 0));
+  return hd(expandIf(__branches));
 }});
 setenv("case", {_stash: true, macro: function (expr) {
-  var ____r13 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __expr1 = destash33(expr, ____r13);
-  var ____id4 = ____r13;
-  var __clauses1 = cut(____id4, 0);
-  var __x41 = unique("x");
-  var __eq1 = function (_) {
-    return ["=", ["quote", _], __x41];
+  var ____r5 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __expr = destash33(expr, ____r5);
+  var ____id1 = ____r5;
+  var __clauses = cut(____id1, 0);
+  var __x15 = unique("x");
+  var __eq = function (_) {
+    return ["=", ["quote", _], __x15];
   };
-  var __cl1 = function (__x44) {
-    var ____id5 = __x44;
-    var __a1 = ____id5[0];
-    var __b1 = ____id5[1];
-    if (nil63(__b1)) {
-      return [__a1];
+  var __cl = function (__x18) {
+    var ____id2 = __x18;
+    var __a = ____id2[0];
+    var __b = ____id2[1];
+    if (nil63(__b)) {
+      return [__a];
     } else {
-      if (string63(__a1) || number63(__a1)) {
-        return [__eq1(__a1), __b1];
+      if (string63(__a) || number63(__a)) {
+        return [__eq(__a), __b];
       } else {
-        if (one63(__a1)) {
-          return [__eq1(hd(__a1)), __b1];
+        if (one63(__a)) {
+          return [__eq(hd(__a)), __b];
         } else {
-          if (_35(__a1) > 1) {
-            return [join(["or"], map(__eq1, __a1)), __b1];
+          if (_35(__a) > 1) {
+            return [join(["or"], map(__eq, __a)), __b];
           }
         }
       }
     }
   };
-  return ["let", __x41, __expr1, join(["if"], apply(join, map(__cl1, pair(__clauses1))))];
+  return ["let", __x15, __expr, join(["if"], apply(join, map(__cl, pair(__clauses))))];
 }});
 setenv("when", {_stash: true, macro: function (cond) {
-  var ____r17 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __cond1 = destash33(cond, ____r17);
-  var ____id7 = ____r17;
-  var __body3 = cut(____id7, 0);
-  return ["if", __cond1, join(["do"], __body3)];
+  var ____r8 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __cond = destash33(cond, ____r8);
+  var ____id3 = ____r8;
+  var __body1 = cut(____id3, 0);
+  return ["if", __cond, join(["do"], __body1)];
 }});
 setenv("unless", {_stash: true, macro: function (cond) {
-  var ____r19 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __cond3 = destash33(cond, ____r19);
-  var ____id9 = ____r19;
-  var __body5 = cut(____id9, 0);
-  return ["if", ["not", __cond3], join(["do"], __body5)];
+  var ____r9 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __cond1 = destash33(cond, ____r9);
+  var ____id4 = ____r9;
+  var __body2 = cut(____id4, 0);
+  return ["if", ["not", __cond1], join(["do"], __body2)];
 }});
 setenv("obj", {_stash: true, macro: function () {
-  var __body7 = unstash(Array.prototype.slice.call(arguments, 0));
+  var __body3 = unstash(Array.prototype.slice.call(arguments, 0));
   return join(["%object"], mapo(function (x) {
     return x;
-  }, __body7));
+  }, __body3));
 }});
 setenv("let", {_stash: true, macro: function (bs) {
-  var ____r23 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __bs11 = destash33(bs, ____r23);
-  var ____id14 = ____r23;
-  var __body9 = cut(____id14, 0);
-  if (atom63(__bs11)) {
-    return join(["let", [__bs11, hd(__body9)]], tl(__body9));
+  var ____r11 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __bs = destash33(bs, ____r11);
+  var ____id5 = ____r11;
+  var __body4 = cut(____id5, 0);
+  if (atom63(__bs)) {
+    return join(["let", [__bs, hd(__body4)]], tl(__body4));
   } else {
-    if (none63(__bs11)) {
-      return join(["do"], __body9);
+    if (none63(__bs)) {
+      return join(["do"], __body4);
     } else {
-      var ____id15 = __bs11;
-      var __lh3 = ____id15[0];
-      var __rh3 = ____id15[1];
-      var __bs21 = cut(____id15, 2);
-      var ____id16 = bind(__lh3, __rh3);
-      var __id17 = ____id16[0];
-      var __val1 = ____id16[1];
-      var __bs12 = cut(____id16, 2);
-      var __renames1 = [];
-      if (! id_literal63(__id17)) {
-        var __id121 = unique(__id17);
-        __renames1 = [__id17, __id121];
-        __id17 = __id121;
+      var ____id6 = __bs;
+      var __lh1 = ____id6[0];
+      var __rh1 = ____id6[1];
+      var __bs2 = cut(____id6, 2);
+      var ____id7 = bind(__lh1, __rh1);
+      var __id8 = ____id7[0];
+      var __val = ____id7[1];
+      var __bs1 = cut(____id7, 2);
+      var __renames = [];
+      if (! idLiteral63(__id8)) {
+        var __id11 = unique(__id8);
+        __renames = [__id8, __id11];
+        __id8 = __id11;
       }
-      return ["do", ["%local", __id17, __val1], ["let-symbol", __renames1, join(["let", join(__bs12, __bs21)], __body9)]];
+      return ["do", ["%local", __id8, __val], ["let-symbol", __renames, join(["let", join(__bs1, __bs2)], __body4)]];
     }
   }
 }});
 setenv("with", {_stash: true, macro: function (x, v) {
-  var ____r25 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __x84 = destash33(x, ____r25);
-  var __v3 = destash33(v, ____r25);
-  var ____id19 = ____r25;
-  var __body11 = cut(____id19, 0);
-  return join(["let", [__x84, __v3]], __body11, [__x84]);
+  var ____r12 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __x40 = destash33(x, ____r12);
+  var __v1 = destash33(v, ____r12);
+  var ____id9 = ____r12;
+  var __body5 = cut(____id9, 0);
+  return join(["let", [__x40, __v1]], __body5, [__x40]);
 }});
 setenv("let-when", {_stash: true, macro: function (x, v) {
-  var ____r27 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __x94 = destash33(x, ____r27);
-  var __v5 = destash33(v, ____r27);
-  var ____id21 = ____r27;
-  var __body13 = cut(____id21, 0);
-  var __y1 = unique("y");
-  return ["let", __y1, __v5, ["when", ["yes", __y1], join(["let", [__x94, __y1]], __body13)]];
+  var ____r13 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __x44 = destash33(x, ____r13);
+  var __v2 = destash33(v, ____r13);
+  var ____id10 = ____r13;
+  var __body6 = cut(____id10, 0);
+  var __y = unique("y");
+  return ["let", __y, __v2, ["when", ["yes", __y], join(["let", [__x44, __y]], __body6)]];
 }});
 setenv("define-macro", {_stash: true, macro: function (name, args) {
-  var ____r29 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __name1 = destash33(name, ____r29);
-  var __args3 = destash33(args, ____r29);
-  var ____id23 = ____r29;
-  var __body15 = cut(____id23, 0);
-  var ____x103 = ["setenv", ["quote", __name1]];
-  ____x103.macro = join(["fn", __args3], __body15);
-  var __form1 = ____x103;
-  _eval(__form1);
-  return __form1;
+  var ____r14 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __name = destash33(name, ____r14);
+  var __args1 = destash33(args, ____r14);
+  var ____id111 = ____r14;
+  var __body7 = cut(____id111, 0);
+  var ____x50 = ["setenv", ["quote", __name]];
+  ____x50.macro = join(["fn", __args1], __body7);
+  var __form = ____x50;
+  return __form;
 }});
 setenv("define-special", {_stash: true, macro: function (name, args) {
-  var ____r31 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __name3 = destash33(name, ____r31);
-  var __args5 = destash33(args, ____r31);
-  var ____id25 = ____r31;
-  var __body17 = cut(____id25, 0);
-  var ____x109 = ["setenv", ["quote", __name3]];
-  ____x109.special = join(["fn", __args5], __body17);
-  var __form3 = join(____x109, keys(__body17));
-  _eval(__form3);
-  return __form3;
+  var ____r15 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __name1 = destash33(name, ____r15);
+  var __args2 = destash33(args, ____r15);
+  var ____id12 = ____r15;
+  var __body8 = cut(____id12, 0);
+  var ____x53 = ["setenv", ["quote", __name1]];
+  ____x53.special = join(["fn", __args2], __body8);
+  var __form1 = join(____x53, keys(__body8));
+  return __form1;
 }});
 setenv("define-symbol", {_stash: true, macro: function (name, expansion) {
   setenv(name, {_stash: true, symbol: expansion});
-  var ____x115 = ["setenv", ["quote", name]];
-  ____x115.symbol = ["quote", expansion];
-  return ____x115;
+  var ____x56 = ["setenv", ["quote", name]];
+  ____x56.symbol = ["quote", expansion];
+  return ____x56;
 }});
-setenv("define-reader", {_stash: true, macro: function (__x123) {
-  var ____id28 = __x123;
-  var __char1 = ____id28[0];
-  var __s1 = ____id28[1];
-  var ____r35 = unstash(Array.prototype.slice.call(arguments, 1));
-  var ____x123 = destash33(__x123, ____r35);
-  var ____id29 = ____r35;
-  var __body19 = cut(____id29, 0);
-  return ["set", ["get", "read-table", __char1], join(["fn", [__s1]], __body19)];
+setenv("define-reader", {_stash: true, macro: function (__x59) {
+  var ____id13 = __x59;
+  var __char = ____id13[0];
+  var __s = ____id13[1];
+  var ____r17 = unstash(Array.prototype.slice.call(arguments, 1));
+  var ____x59 = destash33(__x59, ____r17);
+  var ____id14 = ____r17;
+  var __body9 = cut(____id14, 0);
+  return ["set", ["get", "read-table", __char], join(["fn", [__s]], __body9)];
 }});
 setenv("define", {_stash: true, macro: function (name, x) {
-  var ____r37 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __name5 = destash33(name, ____r37);
-  var __x131 = destash33(x, ____r37);
-  var ____id31 = ____r37;
-  var __body21 = cut(____id31, 0);
-  setenv(__name5, {_stash: true, variable: true});
-  if (some63(__body21)) {
-    return join(["%local-function", __name5], bind42(__x131, __body21));
+  var ____r18 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __name2 = destash33(name, ____r18);
+  var __x64 = destash33(x, ____r18);
+  var ____id15 = ____r18;
+  var __body10 = cut(____id15, 0);
+  setenv(__name2, {_stash: true, variable: true});
+  if (some63(__body10)) {
+    return join(["%local-function", __name2], bind42(__x64, __body10));
   } else {
-    return ["%local", __name5, __x131];
+    return ["%local", __name2, __x64];
   }
 }});
 setenv("define-global", {_stash: true, macro: function (name, x) {
-  var ____r39 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __name7 = destash33(name, ____r39);
-  var __x137 = destash33(x, ____r39);
-  var ____id33 = ____r39;
-  var __body23 = cut(____id33, 0);
-  setenv(__name7, {_stash: true, toplevel: true, variable: true});
-  if (some63(__body23)) {
-    return join(["%global-function", __name7], bind42(__x137, __body23));
+  var ____r19 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __name3 = destash33(name, ____r19);
+  var __x67 = destash33(x, ____r19);
+  var ____id16 = ____r19;
+  var __body11 = cut(____id16, 0);
+  setenv(__name3, {_stash: true, toplevel: true, variable: true});
+  if (some63(__body11)) {
+    return join(["%global-function", __name3], bind42(__x67, __body11));
   } else {
-    return ["set", __name7, __x137];
+    return ["set", __name3, __x67];
   }
 }});
 setenv("with-frame", {_stash: true, macro: function () {
-  var __body25 = unstash(Array.prototype.slice.call(arguments, 0));
-  var __x147 = unique("x");
-  return ["do", ["add", "environment", ["obj"]], ["with", __x147, join(["do"], __body25), ["drop", "environment"]]];
+  var __body12 = unstash(Array.prototype.slice.call(arguments, 0));
+  var __x70 = unique("x");
+  return ["do", ["add", "environment", ["obj"]], ["with", __x70, join(["do"], __body12), ["drop", "environment"]]];
 }});
-setenv("with-bindings", {_stash: true, macro: function (__x159) {
-  var ____id36 = __x159;
-  var __names1 = ____id36[0];
-  var ____r41 = unstash(Array.prototype.slice.call(arguments, 1));
-  var ____x159 = destash33(__x159, ____r41);
-  var ____id37 = ____r41;
-  var __body27 = cut(____id37, 0);
-  var __x160 = unique("x");
-  var ____x163 = ["setenv", __x160];
-  ____x163.variable = true;
-  return join(["with-frame", ["each", __x160, __names1, ____x163]], __body27);
+setenv("with-bindings", {_stash: true, macro: function (__x77) {
+  var ____id17 = __x77;
+  var __names = ____id17[0];
+  var ____r20 = unstash(Array.prototype.slice.call(arguments, 1));
+  var ____x77 = destash33(__x77, ____r20);
+  var ____id18 = ____r20;
+  var __body13 = cut(____id18, 0);
+  var __x78 = unique("x");
+  var ____x81 = ["setenv", __x78];
+  ____x81.variable = true;
+  return join(["with-frame", ["each", __x78, __names, ____x81]], __body13);
 }});
 setenv("let-macro", {_stash: true, macro: function (definitions) {
-  var ____r44 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __definitions1 = destash33(definitions, ____r44);
-  var ____id39 = ____r44;
-  var __body29 = cut(____id39, 0);
+  var ____r21 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __definitions = destash33(definitions, ____r21);
+  var ____id19 = ____r21;
+  var __body14 = cut(____id19, 0);
   add(environment, {});
   map(function (m) {
-    return macroexpand(join(["define-macro"], m));
-  }, __definitions1);
-  var ____x167 = join(["do"], macroexpand(__body29));
+    return _eval(join(["define-macro"], m));
+  }, __definitions);
+  var ____x82 = join(["do"], macroexpand(__body14));
   drop(environment);
-  return ____x167;
+  return ____x82;
 }});
 setenv("let-symbol", {_stash: true, macro: function (expansions) {
-  var ____r48 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __expansions1 = destash33(expansions, ____r48);
-  var ____id42 = ____r48;
-  var __body31 = cut(____id42, 0);
+  var ____r23 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __expansions = destash33(expansions, ____r23);
+  var ____id20 = ____r23;
+  var __body15 = cut(____id20, 0);
   add(environment, {});
-  map(function (__x175) {
-    var ____id43 = __x175;
-    var __name9 = ____id43[0];
-    var __exp1 = ____id43[1];
-    return macroexpand(["define-symbol", __name9, __exp1]);
-  }, pair(__expansions1));
-  var ____x174 = join(["do"], macroexpand(__body31));
+  map(function (__x86) {
+    var ____id21 = __x86;
+    var __name4 = ____id21[0];
+    var __exp = ____id21[1];
+    return macroexpand(["define-symbol", __name4, __exp]);
+  }, pair(__expansions));
+  var ____x85 = join(["do"], macroexpand(__body15));
   drop(environment);
-  return ____x174;
+  return ____x85;
 }});
 setenv("let-unique", {_stash: true, macro: function (names) {
-  var ____r52 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __names3 = destash33(names, ____r52);
-  var ____id45 = ____r52;
-  var __body33 = cut(____id45, 0);
-  var __bs3 = map(function (n) {
+  var ____r25 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __names1 = destash33(names, ____r25);
+  var ____id22 = ____r25;
+  var __body16 = cut(____id22, 0);
+  var __bs11 = map(function (n) {
     return [n, ["unique", ["quote", n]]];
-  }, __names3);
-  return join(["let", apply(join, __bs3)], __body33);
+  }, __names1);
+  return join(["let", apply(join, __bs11)], __body16);
 }});
 setenv("fn", {_stash: true, macro: function (args) {
-  var ____r55 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __args7 = destash33(args, ____r55);
-  var ____id47 = ____r55;
-  var __body35 = cut(____id47, 0);
-  return join(["%function"], bind42(__args7, __body35));
+  var ____r27 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __args3 = destash33(args, ____r27);
+  var ____id23 = ____r27;
+  var __body17 = cut(____id23, 0);
+  return join(["%function"], bind42(__args3, __body17));
 }});
 setenv("apply", {_stash: true, macro: function (f) {
-  var ____r57 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __f1 = destash33(f, ____r57);
-  var ____id49 = ____r57;
-  var __args9 = cut(____id49, 0);
-  if (_35(__args9) > 1) {
-    return ["%call", "apply", __f1, ["join", join(["list"], almost(__args9)), last(__args9)]];
+  var ____r28 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __f = destash33(f, ____r28);
+  var ____id24 = ____r28;
+  var __args4 = cut(____id24, 0);
+  if (_35(__args4) > 1) {
+    return ["%call", "apply", __f, ["join", join(["list"], almost(__args4)), last(__args4)]];
   } else {
-    return join(["%call", "apply", __f1], __args9);
+    return join(["%call", "apply", __f], __args4);
   }
 }});
 setenv("guard", {_stash: true, macro: function (expr) {
   if (target === "js") {
     return [["fn", join(), ["%try", ["list", true, expr]]]];
   } else {
-    var ____x229 = ["obj"];
-    ____x229.stack = [["get", "debug", ["quote", "traceback"]]];
-    ____x229.message = ["if", ["string?", "m"], ["clip", "m", ["+", ["search", "m", "\": \""], 2]], ["nil?", "m"], "\"\"", ["str", "m"]];
-    return ["list", ["xpcall", ["fn", join(), expr], ["fn", ["m"], ["if", ["obj?", "m"], "m", ____x229]]]];
+    var ____x109 = ["obj"];
+    ____x109.stack = ["debug", [".traceback"]];
+    ____x109.message = ["if", ["string?", "m"], ["clip", "m", ["+", ["search", "m", "\": \""], 2]], ["nil?", "m"], "\"\"", ["str", "m"]];
+    return ["list", ["xpcall", ["fn", join(), expr], ["fn", ["m"], ["if", ["obj?", "m"], "m", ____x109]]]];
   }
 }});
 setenv("each", {_stash: true, macro: function (x, t) {
-  var ____r61 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __x254 = destash33(x, ____r61);
-  var __t1 = destash33(t, ____r61);
-  var ____id52 = ____r61;
-  var __body37 = cut(____id52, 0);
-  var __o3 = unique("o");
-  var __n3 = unique("n");
-  var __i3 = unique("i");
-  var __e9;
-  if (atom63(__x254)) {
-    __e9 = [__i3, __x254];
+  var ____r30 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __x119 = destash33(x, ____r30);
+  var __t = destash33(t, ____r30);
+  var ____id25 = ____r30;
+  var __body18 = cut(____id25, 0);
+  var __o1 = unique("o");
+  var __n1 = unique("n");
+  var __i1 = unique("i");
+  var __e1;
+  if (atom63(__x119)) {
+    __e1 = [__i1, __x119];
   } else {
-    var __e10;
-    if (_35(__x254) > 1) {
-      __e10 = __x254;
+    var __e2;
+    if (_35(__x119) > 1) {
+      __e2 = __x119;
     } else {
-      __e10 = [__i3, hd(__x254)];
+      __e2 = [__i1, hd(__x119)];
     }
-    __e9 = __e10;
+    __e1 = __e2;
   }
-  var ____id53 = __e9;
-  var __k5 = ____id53[0];
-  var __v7 = ____id53[1];
-  var __e11;
+  var ____id26 = __e1;
+  var __k2 = ____id26[0];
+  var __v3 = ____id26[1];
+  var __e3;
   if (target === "lua") {
-    __e11 = __body37;
+    __e3 = __body18;
   } else {
-    __e11 = [join(["let", __k5, ["if", ["numeric?", __k5], ["parseInt", __k5], __k5]], __body37)];
+    __e3 = [join(["let", __k2, ["if", ["numeric?", __k2], ["parseInt", __k2], __k2]], __body18)];
   }
-  return ["let", [__o3, __t1, __k5, "nil"], ["%for", __o3, __k5, join(["let", [__v7, ["get", __o3, __k5]]], __e11)]];
+  return ["let", [__o1, __t, __k2, "nil"], ["%for", __o1, __k2, join(["let", [__v3, ["get", __o1, __k2]]], __e3)]];
 }});
 setenv("for", {_stash: true, macro: function (i, to) {
-  var ____r63 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __i5 = destash33(i, ____r63);
-  var __to1 = destash33(to, ____r63);
-  var ____id55 = ____r63;
-  var __body39 = cut(____id55, 0);
-  return ["let", __i5, 0, join(["while", ["<", __i5, __to1]], __body39, [["inc", __i5]])];
+  var ____r31 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __i2 = destash33(i, ____r31);
+  var __to = destash33(to, ____r31);
+  var ____id27 = ____r31;
+  var __body19 = cut(____id27, 0);
+  return ["let", __i2, 0, join(["while", ["<", __i2, __to]], __body19, [["inc", __i2]])];
 }});
 setenv("step", {_stash: true, macro: function (v, t) {
-  var ____r65 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __v9 = destash33(v, ____r65);
-  var __t3 = destash33(t, ____r65);
-  var ____id57 = ____r65;
-  var __body41 = cut(____id57, 0);
-  var __x286 = unique("x");
-  var __i7 = unique("i");
-  return ["let", [__x286, __t3], ["for", __i7, ["#", __x286], join(["let", [__v9, ["at", __x286, __i7]]], __body41)]];
+  var ____r32 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __v4 = destash33(v, ____r32);
+  var __t1 = destash33(t, ____r32);
+  var ____id28 = ____r32;
+  var __body20 = cut(____id28, 0);
+  var __x138 = unique("x");
+  var __i3 = unique("i");
+  return ["let", [__x138, __t1], ["for", __i3, ["#", __x138], join(["let", [__v4, ["at", __x138, __i3]]], __body20)]];
 }});
 setenv("set-of", {_stash: true, macro: function () {
-  var __xs1 = unstash(Array.prototype.slice.call(arguments, 0));
-  var __l3 = [];
-  var ____o5 = __xs1;
-  var ____i9 = undefined;
-  for (____i9 in ____o5) {
-    var __x296 = ____o5[____i9];
-    var __e12;
-    if (numeric63(____i9)) {
-      __e12 = parseInt(____i9);
+  var __xs = unstash(Array.prototype.slice.call(arguments, 0));
+  var __l1 = [];
+  var ____o2 = __xs;
+  var ____i4 = undefined;
+  for (____i4 in ____o2) {
+    var __x146 = ____o2[____i4];
+    var __e4;
+    if (numeric63(____i4)) {
+      __e4 = parseInt(____i4);
     } else {
-      __e12 = ____i9;
+      __e4 = ____i4;
     }
-    var ____i91 = __e12;
-    __l3[__x296] = true;
+    var ____i41 = __e4;
+    __l1[__x146] = true;
   }
-  return join(["obj"], __l3);
+  return join(["obj"], __l1);
 }});
 setenv("language", {_stash: true, macro: function () {
   return ["quote", target];
 }});
 setenv("target", {_stash: true, macro: function () {
-  var __clauses3 = unstash(Array.prototype.slice.call(arguments, 0));
-  return __clauses3[target];
+  var __clauses1 = unstash(Array.prototype.slice.call(arguments, 0));
+  return __clauses1[target];
 }});
 setenv("join!", {_stash: true, macro: function (a) {
-  var ____r69 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __a3 = destash33(a, ____r69);
-  var ____id59 = ____r69;
-  var __bs5 = cut(____id59, 0);
-  return ["set", __a3, join(["join", __a3], __bs5)];
+  var ____r34 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __a1 = destash33(a, ____r34);
+  var ____id29 = ____r34;
+  var __bs21 = cut(____id29, 0);
+  return ["set", __a1, join(["join", __a1], __bs21)];
 }});
 setenv("cat!", {_stash: true, macro: function (a) {
-  var ____r71 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __a5 = destash33(a, ____r71);
-  var ____id61 = ____r71;
-  var __bs7 = cut(____id61, 0);
-  return ["set", __a5, join(["cat", __a5], __bs7)];
+  var ____r35 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __a2 = destash33(a, ____r35);
+  var ____id30 = ____r35;
+  var __bs3 = cut(____id30, 0);
+  return ["set", __a2, join(["cat", __a2], __bs3)];
 }});
 setenv("inc", {_stash: true, macro: function (n, by) {
-  var __e13;
+  var __e5;
   if (nil63(by)) {
-    __e13 = 1;
+    __e5 = 1;
   } else {
-    __e13 = by;
+    __e5 = by;
   }
-  return ["set", n, ["+", n, __e13]];
+  return ["set", n, ["+", n, __e5]];
 }});
 setenv("dec", {_stash: true, macro: function (n, by) {
-  var __e14;
+  var __e6;
   if (nil63(by)) {
-    __e14 = 1;
+    __e6 = 1;
   } else {
-    __e14 = by;
+    __e6 = by;
   }
-  return ["set", n, ["-", n, __e14]];
+  return ["set", n, ["-", n, __e6]];
 }});
 setenv("with-indent", {_stash: true, macro: function (form) {
-  var __x321 = unique("x");
-  return ["do", ["inc", "indent-level"], ["with", __x321, form, ["dec", "indent-level"]]];
+  var __x157 = unique("x");
+  return ["do", ["inc", "indent-level"], ["with", __x157, form, ["dec", "indent-level"]]];
 }});
 setenv("export", {_stash: true, macro: function () {
-  var __names5 = unstash(Array.prototype.slice.call(arguments, 0));
+  var __names2 = unstash(Array.prototype.slice.call(arguments, 0));
   if (target === "js") {
     return join(["do"], map(function (k) {
-      return ["set", ["get", "exports", ["quote", k]], k];
-    }, __names5));
+      return ["set", ["exports", "." + k], k];
+    }, __names2));
   } else {
-    var __x337 = {};
-    var ____o7 = __names5;
-    var ____i11 = undefined;
-    for (____i11 in ____o7) {
-      var __k7 = ____o7[____i11];
-      var __e15;
-      if (numeric63(____i11)) {
-        __e15 = parseInt(____i11);
+    var __x165 = {};
+    var ____o3 = __names2;
+    var ____i5 = undefined;
+    for (____i5 in ____o3) {
+      var __k3 = ____o3[____i5];
+      var __e7;
+      if (numeric63(____i5)) {
+        __e7 = parseInt(____i5);
       } else {
-        __e15 = ____i11;
+        __e7 = ____i5;
       }
-      var ____i111 = __e15;
-      __x337[__k7] = __k7;
+      var ____i51 = __e7;
+      var __k4 = compileId(__k3);
+      __x165[__k4] = __k4;
     }
     return ["return", join(["%object"], mapo(function (x) {
       return x;
-    }, __x337))];
+    }, __x165))];
   }
 }});
 setenv("when-compiling", {_stash: true, macro: function () {
-  var __body43 = unstash(Array.prototype.slice.call(arguments, 0));
-  return _eval(join(["do"], __body43));
+  var __body21 = unstash(Array.prototype.slice.call(arguments, 0));
+  return _eval(join(["do"], __body21));
+}});
+setenv("during-compilation", {_stash: true, macro: function () {
+  var __body22 = unstash(Array.prototype.slice.call(arguments, 0));
+  var __form2 = join(["do"], __body22);
+  _eval(__form2);
+  return __form2;
 }});
 var reader = require("reader");
 var compiler = require("compiler");
 var system = require("system");
-var eval_print = function (form) {
+var evalPrint = function (form) {
   var ____id = (function () {
     try {
-      return [true, compiler["eval"](form)];
+      return [true, compiler.eval(form)];
     }
     catch (__e) {
       return [false, __e];
@@ -1207,46 +1233,46 @@ var eval_print = function (form) {
   }
 };
 var rep = function (s) {
-  return eval_print(reader["read-string"](s));
+  return evalPrint(reader.readString(s));
 };
 var repl = function () {
   var __buf = "";
   var rep1 = function (s) {
     __buf = __buf + s;
     var __more = [];
-    var __form = reader["read-string"](__buf, __more);
+    var __form = reader.readString(__buf, __more);
     if (!( __form === __more)) {
-      eval_print(__form);
+      evalPrint(__form);
       __buf = "";
       return system.write("> ");
     }
   };
   system.write("> ");
-  var ___in = process.stdin;
-  ___in.setEncoding("utf8");
-  return ___in.on("data", rep1);
+  var __in = process.stdin;
+  __in.setEncoding("utf8");
+  return __in.on("data", rep1);
 };
-compile_file = function (path) {
-  var __s = reader.stream(system["read-file"](path));
-  var __body = reader["read-all"](__s);
+compileFile = function (path) {
+  var __s = reader.stream(system.readFile(path));
+  var __body = reader.readAll(__s);
   var __form1 = compiler.expand(join(["do"], __body));
   return compiler.compile(__form1, {_stash: true, stmt: true});
 };
 _load = function (path) {
   var __previous = target;
   target = "js";
-  var __code = compile_file(path);
+  var __code = compileFile(path);
   target = __previous;
   return compiler.run(__code);
 };
-var script_file63 = function (path) {
+var scriptFile63 = function (path) {
   return !( "-" === char(path, 0) || ".js" === clip(path, _35(path) - 3) || ".lua" === clip(path, _35(path) - 4));
 };
-var run_file = function (path) {
-  if (script_file63(path)) {
+var runFile = function (path) {
+  if (scriptFile63(path)) {
     return _load(path);
   } else {
-    return compiler.run(system["read-file"](path));
+    return compiler.run(system.readFile(path));
   }
 };
 var usage = function () {
@@ -1262,7 +1288,7 @@ var usage = function () {
 };
 var main = function () {
   var __arg = hd(system.argv);
-  if (__arg && script_file63(__arg)) {
+  if (__arg && scriptFile63(__arg)) {
     return _load(__arg);
   } else {
     if (__arg === "-h" || __arg === "--help") {
@@ -1310,7 +1336,7 @@ var main = function () {
       var ____i1 = 0;
       while (____i1 < _35(____x2)) {
         var __file = ____x2[____i1];
-        run_file(__file);
+        runFile(__file);
         ____i1 = ____i1 + 1;
       }
       if (nil63(__input)) {
@@ -1323,11 +1349,11 @@ var main = function () {
         if (__target1) {
           target = __target1;
         }
-        var __code1 = compile_file(__input);
+        var __code1 = compileFile(__input);
         if (nil63(__output) || __output === "-") {
           return print(__code1);
         } else {
-          return system["write-file"](__output, __code1);
+          return system.writeFile(__output, __code1);
         }
       }
     }

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -760,13 +760,13 @@ setenv("quasiquote", {_stash: true, macro: function (form) {
   return quasiexpand(form, 1);
 }});
 setenv("set", {_stash: true, macro: function () {
-  var __args = unstash(Array.prototype.slice.call(arguments, 0));
-  return join(["do"], map(function (__x1) {
-    var ____id = __x1;
-    var __lh = ____id[0];
-    var __rh = ____id[1];
-    return ["%set", __lh, __rh];
-  }, pair(__args)));
+  var __args1 = unstash(Array.prototype.slice.call(arguments, 0));
+  return join(["do"], map(function (__x4) {
+    var ____id1 = __x4;
+    var __lh1 = ____id1[0];
+    var __rh1 = ____id1[1];
+    return ["%set", __lh1, __rh1];
+  }, pair(__args1)));
 }});
 setenv("at", {_stash: true, macro: function (l, i) {
   if (target === "lua" && number63(i)) {
@@ -786,429 +786,431 @@ setenv("wipe", {_stash: true, macro: function (place) {
   }
 }});
 setenv("list", {_stash: true, macro: function () {
-  var __body = unstash(Array.prototype.slice.call(arguments, 0));
-  var __x7 = unique("x");
-  var __l = [];
-  var __forms = [];
-  var ____o = __body;
-  var __k = undefined;
-  for (__k in ____o) {
-    var __v = ____o[__k];
-    var __e;
-    if (numeric63(__k)) {
-      __e = parseInt(__k);
+  var __body1 = unstash(Array.prototype.slice.call(arguments, 0));
+  var __x22 = unique("x");
+  var __l1 = [];
+  var __forms1 = [];
+  var ____o1 = __body1;
+  var __k2 = undefined;
+  for (__k2 in ____o1) {
+    var __v1 = ____o1[__k2];
+    var __e8;
+    if (numeric63(__k2)) {
+      __e8 = parseInt(__k2);
     } else {
-      __e = __k;
+      __e8 = __k2;
     }
-    var __k1 = __e;
-    if (number63(__k1)) {
-      __l[__k1] = __v;
+    var __k3 = __e8;
+    if (number63(__k3)) {
+      __l1[__k3] = __v1;
     } else {
-      add(__forms, ["set", ["get", __x7, ["quote", __k1]], __v]);
+      add(__forms1, ["set", ["get", __x22, ["quote", __k3]], __v1]);
     }
   }
-  if (some63(__forms)) {
-    return join(["let", __x7, join(["%array"], __l)], __forms, [__x7]);
+  if (some63(__forms1)) {
+    return join(["let", __x22, join(["%array"], __l1)], __forms1, [__x22]);
   } else {
-    return join(["%array"], __l);
+    return join(["%array"], __l1);
   }
 }});
 setenv("if", {_stash: true, macro: function () {
-  var __branches = unstash(Array.prototype.slice.call(arguments, 0));
-  return hd(expandIf(__branches));
+  var __branches1 = unstash(Array.prototype.slice.call(arguments, 0));
+  return hd(expandIf(__branches1));
 }});
 setenv("case", {_stash: true, macro: function (expr) {
-  var ____r5 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __expr = destash33(expr, ____r5);
-  var ____id1 = ____r5;
-  var __clauses = cut(____id1, 0);
-  var __x15 = unique("x");
-  var __eq = function (_) {
-    return ["=", ["quote", _], __x15];
+  var ____r13 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __expr1 = destash33(expr, ____r13);
+  var ____id4 = ____r13;
+  var __clauses1 = cut(____id4, 0);
+  var __x41 = unique("x");
+  var __eq1 = function (_) {
+    return ["=", ["quote", _], __x41];
   };
-  var __cl = function (__x18) {
-    var ____id2 = __x18;
-    var __a = ____id2[0];
-    var __b = ____id2[1];
-    if (nil63(__b)) {
-      return [__a];
+  var __cl1 = function (__x44) {
+    var ____id5 = __x44;
+    var __a1 = ____id5[0];
+    var __b1 = ____id5[1];
+    if (nil63(__b1)) {
+      return [__a1];
     } else {
-      if (string63(__a) || number63(__a)) {
-        return [__eq(__a), __b];
+      if (string63(__a1) || number63(__a1)) {
+        return [__eq1(__a1), __b1];
       } else {
-        if (one63(__a)) {
-          return [__eq(hd(__a)), __b];
+        if (one63(__a1)) {
+          return [__eq1(hd(__a1)), __b1];
         } else {
-          if (_35(__a) > 1) {
-            return [join(["or"], map(__eq, __a)), __b];
+          if (_35(__a1) > 1) {
+            return [join(["or"], map(__eq1, __a1)), __b1];
           }
         }
       }
     }
   };
-  return ["let", __x15, __expr, join(["if"], apply(join, map(__cl, pair(__clauses))))];
+  return ["let", __x41, __expr1, join(["if"], apply(join, map(__cl1, pair(__clauses1))))];
 }});
 setenv("when", {_stash: true, macro: function (cond) {
-  var ____r8 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __cond = destash33(cond, ____r8);
-  var ____id3 = ____r8;
-  var __body1 = cut(____id3, 0);
-  return ["if", __cond, join(["do"], __body1)];
+  var ____r17 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __cond1 = destash33(cond, ____r17);
+  var ____id7 = ____r17;
+  var __body3 = cut(____id7, 0);
+  return ["if", __cond1, join(["do"], __body3)];
 }});
 setenv("unless", {_stash: true, macro: function (cond) {
-  var ____r9 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __cond1 = destash33(cond, ____r9);
-  var ____id4 = ____r9;
-  var __body2 = cut(____id4, 0);
-  return ["if", ["not", __cond1], join(["do"], __body2)];
+  var ____r19 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __cond3 = destash33(cond, ____r19);
+  var ____id9 = ____r19;
+  var __body5 = cut(____id9, 0);
+  return ["if", ["not", __cond3], join(["do"], __body5)];
 }});
 setenv("obj", {_stash: true, macro: function () {
-  var __body3 = unstash(Array.prototype.slice.call(arguments, 0));
+  var __body7 = unstash(Array.prototype.slice.call(arguments, 0));
   return join(["%object"], mapo(function (x) {
     return x;
-  }, __body3));
+  }, __body7));
 }});
 setenv("let", {_stash: true, macro: function (bs) {
-  var ____r11 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __bs = destash33(bs, ____r11);
-  var ____id5 = ____r11;
-  var __body4 = cut(____id5, 0);
-  if (atom63(__bs)) {
-    return join(["let", [__bs, hd(__body4)]], tl(__body4));
+  var ____r23 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __bs11 = destash33(bs, ____r23);
+  var ____id14 = ____r23;
+  var __body9 = cut(____id14, 0);
+  if (atom63(__bs11)) {
+    return join(["let", [__bs11, hd(__body9)]], tl(__body9));
   } else {
-    if (none63(__bs)) {
-      return join(["do"], __body4);
+    if (none63(__bs11)) {
+      return join(["do"], __body9);
     } else {
-      var ____id6 = __bs;
-      var __lh1 = ____id6[0];
-      var __rh1 = ____id6[1];
-      var __bs2 = cut(____id6, 2);
-      var ____id7 = bind(__lh1, __rh1);
-      var __id8 = ____id7[0];
-      var __val = ____id7[1];
-      var __bs1 = cut(____id7, 2);
-      var __renames = [];
-      if (! idLiteral63(__id8)) {
-        var __id11 = unique(__id8);
-        __renames = [__id8, __id11];
-        __id8 = __id11;
+      var ____id15 = __bs11;
+      var __lh3 = ____id15[0];
+      var __rh3 = ____id15[1];
+      var __bs21 = cut(____id15, 2);
+      var ____id16 = bind(__lh3, __rh3);
+      var __id17 = ____id16[0];
+      var __val1 = ____id16[1];
+      var __bs12 = cut(____id16, 2);
+      var __renames1 = [];
+      if (! idLiteral63(__id17)) {
+        var __id121 = unique(__id17);
+        __renames1 = [__id17, __id121];
+        __id17 = __id121;
       }
-      return ["do", ["%local", __id8, __val], ["let-symbol", __renames, join(["let", join(__bs1, __bs2)], __body4)]];
+      return ["do", ["%local", __id17, __val1], ["let-symbol", __renames1, join(["let", join(__bs12, __bs21)], __body9)]];
     }
   }
 }});
 setenv("with", {_stash: true, macro: function (x, v) {
-  var ____r12 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __x40 = destash33(x, ____r12);
-  var __v1 = destash33(v, ____r12);
-  var ____id9 = ____r12;
-  var __body5 = cut(____id9, 0);
-  return join(["let", [__x40, __v1]], __body5, [__x40]);
+  var ____r25 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __x84 = destash33(x, ____r25);
+  var __v3 = destash33(v, ____r25);
+  var ____id19 = ____r25;
+  var __body11 = cut(____id19, 0);
+  return join(["let", [__x84, __v3]], __body11, [__x84]);
 }});
 setenv("let-when", {_stash: true, macro: function (x, v) {
-  var ____r13 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __x44 = destash33(x, ____r13);
-  var __v2 = destash33(v, ____r13);
-  var ____id10 = ____r13;
-  var __body6 = cut(____id10, 0);
-  var __y = unique("y");
-  return ["let", __y, __v2, ["when", ["yes", __y], join(["let", [__x44, __y]], __body6)]];
+  var ____r27 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __x94 = destash33(x, ____r27);
+  var __v5 = destash33(v, ____r27);
+  var ____id21 = ____r27;
+  var __body13 = cut(____id21, 0);
+  var __y1 = unique("y");
+  return ["let", __y1, __v5, ["when", ["yes", __y1], join(["let", [__x94, __y1]], __body13)]];
 }});
 setenv("define-macro", {_stash: true, macro: function (name, args) {
-  var ____r14 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __name = destash33(name, ____r14);
-  var __args1 = destash33(args, ____r14);
-  var ____id111 = ____r14;
-  var __body7 = cut(____id111, 0);
-  var ____x50 = ["setenv", ["quote", __name]];
-  ____x50.macro = join(["fn", __args1], __body7);
-  var __form = ____x50;
-  return __form;
+  var ____r29 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __name1 = destash33(name, ____r29);
+  var __args3 = destash33(args, ____r29);
+  var ____id23 = ____r29;
+  var __body15 = cut(____id23, 0);
+  var ____x103 = ["setenv", ["quote", __name1]];
+  ____x103.macro = join(["fn", __args3], __body15);
+  var __form1 = ____x103;
+  _eval(__form1);
+  return __form1;
 }});
 setenv("define-special", {_stash: true, macro: function (name, args) {
-  var ____r15 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __name1 = destash33(name, ____r15);
-  var __args2 = destash33(args, ____r15);
-  var ____id12 = ____r15;
-  var __body8 = cut(____id12, 0);
-  var ____x53 = ["setenv", ["quote", __name1]];
-  ____x53.special = join(["fn", __args2], __body8);
-  var __form1 = join(____x53, keys(__body8));
-  return __form1;
+  var ____r31 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __name3 = destash33(name, ____r31);
+  var __args5 = destash33(args, ____r31);
+  var ____id25 = ____r31;
+  var __body17 = cut(____id25, 0);
+  var ____x109 = ["setenv", ["quote", __name3]];
+  ____x109.special = join(["fn", __args5], __body17);
+  var __form3 = join(____x109, keys(__body17));
+  _eval(__form3);
+  return __form3;
 }});
 setenv("define-symbol", {_stash: true, macro: function (name, expansion) {
   setenv(name, {_stash: true, symbol: expansion});
-  var ____x56 = ["setenv", ["quote", name]];
-  ____x56.symbol = ["quote", expansion];
-  return ____x56;
+  var ____x115 = ["setenv", ["quote", name]];
+  ____x115.symbol = ["quote", expansion];
+  return ____x115;
 }});
-setenv("define-reader", {_stash: true, macro: function (__x59) {
-  var ____id13 = __x59;
-  var __char = ____id13[0];
-  var __s = ____id13[1];
-  var ____r17 = unstash(Array.prototype.slice.call(arguments, 1));
-  var ____x59 = destash33(__x59, ____r17);
-  var ____id14 = ____r17;
-  var __body9 = cut(____id14, 0);
-  return ["set", ["get", "read-table", __char], join(["fn", [__s]], __body9)];
+setenv("define-reader", {_stash: true, macro: function (__x123) {
+  var ____id28 = __x123;
+  var __char1 = ____id28[0];
+  var __s1 = ____id28[1];
+  var ____r35 = unstash(Array.prototype.slice.call(arguments, 1));
+  var ____x123 = destash33(__x123, ____r35);
+  var ____id29 = ____r35;
+  var __body19 = cut(____id29, 0);
+  return ["set", ["get", "read-table", __char1], join(["fn", [__s1]], __body19)];
 }});
 setenv("define", {_stash: true, macro: function (name, x) {
-  var ____r18 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __name2 = destash33(name, ____r18);
-  var __x64 = destash33(x, ____r18);
-  var ____id15 = ____r18;
-  var __body10 = cut(____id15, 0);
-  setenv(__name2, {_stash: true, variable: true});
-  if (some63(__body10)) {
-    return join(["%local-function", __name2], bind42(__x64, __body10));
+  var ____r37 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __name5 = destash33(name, ____r37);
+  var __x131 = destash33(x, ____r37);
+  var ____id31 = ____r37;
+  var __body21 = cut(____id31, 0);
+  setenv(__name5, {_stash: true, variable: true});
+  if (some63(__body21)) {
+    return join(["%local-function", __name5], bind42(__x131, __body21));
   } else {
-    return ["%local", __name2, __x64];
+    return ["%local", __name5, __x131];
   }
 }});
 setenv("define-global", {_stash: true, macro: function (name, x) {
-  var ____r19 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __name3 = destash33(name, ____r19);
-  var __x67 = destash33(x, ____r19);
-  var ____id16 = ____r19;
-  var __body11 = cut(____id16, 0);
-  setenv(__name3, {_stash: true, toplevel: true, variable: true});
-  if (some63(__body11)) {
-    return join(["%global-function", __name3], bind42(__x67, __body11));
+  var ____r39 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __name7 = destash33(name, ____r39);
+  var __x137 = destash33(x, ____r39);
+  var ____id33 = ____r39;
+  var __body23 = cut(____id33, 0);
+  setenv(__name7, {_stash: true, toplevel: true, variable: true});
+  if (some63(__body23)) {
+    return join(["%global-function", __name7], bind42(__x137, __body23));
   } else {
-    return ["set", __name3, __x67];
+    return ["set", __name7, __x137];
   }
 }});
 setenv("with-frame", {_stash: true, macro: function () {
-  var __body12 = unstash(Array.prototype.slice.call(arguments, 0));
-  var __x70 = unique("x");
-  return ["do", ["add", "environment", ["obj"]], ["with", __x70, join(["do"], __body12), ["drop", "environment"]]];
+  var __body25 = unstash(Array.prototype.slice.call(arguments, 0));
+  var __x147 = unique("x");
+  return ["do", ["add", "environment", ["obj"]], ["with", __x147, join(["do"], __body25), ["drop", "environment"]]];
 }});
-setenv("with-bindings", {_stash: true, macro: function (__x77) {
-  var ____id17 = __x77;
-  var __names = ____id17[0];
-  var ____r20 = unstash(Array.prototype.slice.call(arguments, 1));
-  var ____x77 = destash33(__x77, ____r20);
-  var ____id18 = ____r20;
-  var __body13 = cut(____id18, 0);
-  var __x78 = unique("x");
-  var ____x81 = ["setenv", __x78];
-  ____x81.variable = true;
-  return join(["with-frame", ["each", __x78, __names, ____x81]], __body13);
+setenv("with-bindings", {_stash: true, macro: function (__x159) {
+  var ____id36 = __x159;
+  var __names1 = ____id36[0];
+  var ____r41 = unstash(Array.prototype.slice.call(arguments, 1));
+  var ____x159 = destash33(__x159, ____r41);
+  var ____id37 = ____r41;
+  var __body27 = cut(____id37, 0);
+  var __x160 = unique("x");
+  var ____x163 = ["setenv", __x160];
+  ____x163.variable = true;
+  return join(["with-frame", ["each", __x160, __names1, ____x163]], __body27);
 }});
 setenv("let-macro", {_stash: true, macro: function (definitions) {
-  var ____r21 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __definitions = destash33(definitions, ____r21);
-  var ____id19 = ____r21;
-  var __body14 = cut(____id19, 0);
+  var ____r44 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __definitions1 = destash33(definitions, ____r44);
+  var ____id39 = ____r44;
+  var __body29 = cut(____id39, 0);
   add(environment, {});
   map(function (m) {
-    return _eval(join(["define-macro"], m));
-  }, __definitions);
-  var ____x82 = join(["do"], macroexpand(__body14));
+    return macroexpand(join(["define-macro"], m));
+  }, __definitions1);
+  var ____x167 = join(["do"], macroexpand(__body29));
   drop(environment);
-  return ____x82;
+  return ____x167;
 }});
 setenv("let-symbol", {_stash: true, macro: function (expansions) {
-  var ____r23 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __expansions = destash33(expansions, ____r23);
-  var ____id20 = ____r23;
-  var __body15 = cut(____id20, 0);
+  var ____r48 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __expansions1 = destash33(expansions, ____r48);
+  var ____id42 = ____r48;
+  var __body31 = cut(____id42, 0);
   add(environment, {});
-  map(function (__x86) {
-    var ____id21 = __x86;
-    var __name4 = ____id21[0];
-    var __exp = ____id21[1];
-    return macroexpand(["define-symbol", __name4, __exp]);
-  }, pair(__expansions));
-  var ____x85 = join(["do"], macroexpand(__body15));
+  map(function (__x175) {
+    var ____id43 = __x175;
+    var __name9 = ____id43[0];
+    var __exp1 = ____id43[1];
+    return macroexpand(["define-symbol", __name9, __exp1]);
+  }, pair(__expansions1));
+  var ____x174 = join(["do"], macroexpand(__body31));
   drop(environment);
-  return ____x85;
+  return ____x174;
 }});
 setenv("let-unique", {_stash: true, macro: function (names) {
-  var ____r25 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __names1 = destash33(names, ____r25);
-  var ____id22 = ____r25;
-  var __body16 = cut(____id22, 0);
-  var __bs11 = map(function (n) {
+  var ____r52 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __names3 = destash33(names, ____r52);
+  var ____id45 = ____r52;
+  var __body33 = cut(____id45, 0);
+  var __bs3 = map(function (n) {
     return [n, ["unique", ["quote", n]]];
-  }, __names1);
-  return join(["let", apply(join, __bs11)], __body16);
+  }, __names3);
+  return join(["let", apply(join, __bs3)], __body33);
 }});
 setenv("fn", {_stash: true, macro: function (args) {
-  var ____r27 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __args3 = destash33(args, ____r27);
-  var ____id23 = ____r27;
-  var __body17 = cut(____id23, 0);
-  return join(["%function"], bind42(__args3, __body17));
+  var ____r55 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __args7 = destash33(args, ____r55);
+  var ____id47 = ____r55;
+  var __body35 = cut(____id47, 0);
+  return join(["%function"], bind42(__args7, __body35));
 }});
 setenv("apply", {_stash: true, macro: function (f) {
-  var ____r28 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __f = destash33(f, ____r28);
-  var ____id24 = ____r28;
-  var __args4 = cut(____id24, 0);
-  if (_35(__args4) > 1) {
-    return ["%call", "apply", __f, ["join", join(["list"], almost(__args4)), last(__args4)]];
+  var ____r57 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __f1 = destash33(f, ____r57);
+  var ____id49 = ____r57;
+  var __args9 = cut(____id49, 0);
+  if (_35(__args9) > 1) {
+    return ["%call", "apply", __f1, ["join", join(["list"], almost(__args9)), last(__args9)]];
   } else {
-    return join(["%call", "apply", __f], __args4);
+    return join(["%call", "apply", __f1], __args9);
   }
 }});
 setenv("guard", {_stash: true, macro: function (expr) {
   if (target === "js") {
     return [["fn", join(), ["%try", ["list", true, expr]]]];
   } else {
-    var ____x109 = ["obj"];
-    ____x109.stack = ["debug", [".traceback"]];
-    ____x109.message = ["if", ["string?", "m"], ["clip", "m", ["+", ["search", "m", "\": \""], 2]], ["nil?", "m"], "\"\"", ["str", "m"]];
-    return ["list", ["xpcall", ["fn", join(), expr], ["fn", ["m"], ["if", ["obj?", "m"], "m", ____x109]]]];
+    var ____x228 = ["obj"];
+    ____x228.stack = ["debug", [".traceback"]];
+    ____x228.message = ["if", ["string?", "m"], ["clip", "m", ["+", ["search", "m", "\": \""], 2]], ["nil?", "m"], "\"\"", ["str", "m"]];
+    return ["list", ["xpcall", ["fn", join(), expr], ["fn", ["m"], ["if", ["obj?", "m"], "m", ____x228]]]];
   }
 }});
 setenv("each", {_stash: true, macro: function (x, t) {
-  var ____r30 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __x119 = destash33(x, ____r30);
-  var __t = destash33(t, ____r30);
-  var ____id25 = ____r30;
-  var __body18 = cut(____id25, 0);
-  var __o1 = unique("o");
-  var __n1 = unique("n");
-  var __i1 = unique("i");
-  var __e1;
-  if (atom63(__x119)) {
-    __e1 = [__i1, __x119];
+  var ____r61 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __x252 = destash33(x, ____r61);
+  var __t1 = destash33(t, ____r61);
+  var ____id52 = ____r61;
+  var __body37 = cut(____id52, 0);
+  var __o3 = unique("o");
+  var __n3 = unique("n");
+  var __i3 = unique("i");
+  var __e9;
+  if (atom63(__x252)) {
+    __e9 = [__i3, __x252];
   } else {
-    var __e2;
-    if (_35(__x119) > 1) {
-      __e2 = __x119;
+    var __e10;
+    if (_35(__x252) > 1) {
+      __e10 = __x252;
     } else {
-      __e2 = [__i1, hd(__x119)];
+      __e10 = [__i3, hd(__x252)];
     }
-    __e1 = __e2;
+    __e9 = __e10;
   }
-  var ____id26 = __e1;
-  var __k2 = ____id26[0];
-  var __v3 = ____id26[1];
-  var __e3;
+  var ____id53 = __e9;
+  var __k5 = ____id53[0];
+  var __v7 = ____id53[1];
+  var __e11;
   if (target === "lua") {
-    __e3 = __body18;
+    __e11 = __body37;
   } else {
-    __e3 = [join(["let", __k2, ["if", ["numeric?", __k2], ["parseInt", __k2], __k2]], __body18)];
+    __e11 = [join(["let", __k5, ["if", ["numeric?", __k5], ["parseInt", __k5], __k5]], __body37)];
   }
-  return ["let", [__o1, __t, __k2, "nil"], ["%for", __o1, __k2, join(["let", [__v3, ["get", __o1, __k2]]], __e3)]];
+  return ["let", [__o3, __t1, __k5, "nil"], ["%for", __o3, __k5, join(["let", [__v7, ["get", __o3, __k5]]], __e11)]];
 }});
 setenv("for", {_stash: true, macro: function (i, to) {
-  var ____r31 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __i2 = destash33(i, ____r31);
-  var __to = destash33(to, ____r31);
-  var ____id27 = ____r31;
-  var __body19 = cut(____id27, 0);
-  return ["let", __i2, 0, join(["while", ["<", __i2, __to]], __body19, [["inc", __i2]])];
+  var ____r63 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __i5 = destash33(i, ____r63);
+  var __to1 = destash33(to, ____r63);
+  var ____id55 = ____r63;
+  var __body39 = cut(____id55, 0);
+  return ["let", __i5, 0, join(["while", ["<", __i5, __to1]], __body39, [["inc", __i5]])];
 }});
 setenv("step", {_stash: true, macro: function (v, t) {
-  var ____r32 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __v4 = destash33(v, ____r32);
-  var __t1 = destash33(t, ____r32);
-  var ____id28 = ____r32;
-  var __body20 = cut(____id28, 0);
-  var __x138 = unique("x");
-  var __i3 = unique("i");
-  return ["let", [__x138, __t1], ["for", __i3, ["#", __x138], join(["let", [__v4, ["at", __x138, __i3]]], __body20)]];
+  var ____r65 = unstash(Array.prototype.slice.call(arguments, 2));
+  var __v9 = destash33(v, ____r65);
+  var __t3 = destash33(t, ____r65);
+  var ____id57 = ____r65;
+  var __body41 = cut(____id57, 0);
+  var __x284 = unique("x");
+  var __i7 = unique("i");
+  return ["let", [__x284, __t3], ["for", __i7, ["#", __x284], join(["let", [__v9, ["at", __x284, __i7]]], __body41)]];
 }});
 setenv("set-of", {_stash: true, macro: function () {
-  var __xs = unstash(Array.prototype.slice.call(arguments, 0));
-  var __l1 = [];
-  var ____o2 = __xs;
-  var ____i4 = undefined;
-  for (____i4 in ____o2) {
-    var __x146 = ____o2[____i4];
-    var __e4;
-    if (numeric63(____i4)) {
-      __e4 = parseInt(____i4);
+  var __xs1 = unstash(Array.prototype.slice.call(arguments, 0));
+  var __l3 = [];
+  var ____o5 = __xs1;
+  var ____i9 = undefined;
+  for (____i9 in ____o5) {
+    var __x294 = ____o5[____i9];
+    var __e12;
+    if (numeric63(____i9)) {
+      __e12 = parseInt(____i9);
     } else {
-      __e4 = ____i4;
+      __e12 = ____i9;
     }
-    var ____i41 = __e4;
-    __l1[__x146] = true;
+    var ____i91 = __e12;
+    __l3[__x294] = true;
   }
-  return join(["obj"], __l1);
+  return join(["obj"], __l3);
 }});
 setenv("language", {_stash: true, macro: function () {
   return ["quote", target];
 }});
 setenv("target", {_stash: true, macro: function () {
-  var __clauses1 = unstash(Array.prototype.slice.call(arguments, 0));
-  return __clauses1[target];
+  var __clauses3 = unstash(Array.prototype.slice.call(arguments, 0));
+  return __clauses3[target];
 }});
 setenv("join!", {_stash: true, macro: function (a) {
-  var ____r34 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __a1 = destash33(a, ____r34);
-  var ____id29 = ____r34;
-  var __bs21 = cut(____id29, 0);
-  return ["set", __a1, join(["join", __a1], __bs21)];
+  var ____r69 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __a3 = destash33(a, ____r69);
+  var ____id59 = ____r69;
+  var __bs5 = cut(____id59, 0);
+  return ["set", __a3, join(["join", __a3], __bs5)];
 }});
 setenv("cat!", {_stash: true, macro: function (a) {
-  var ____r35 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __a2 = destash33(a, ____r35);
-  var ____id30 = ____r35;
-  var __bs3 = cut(____id30, 0);
-  return ["set", __a2, join(["cat", __a2], __bs3)];
+  var ____r71 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __a5 = destash33(a, ____r71);
+  var ____id61 = ____r71;
+  var __bs7 = cut(____id61, 0);
+  return ["set", __a5, join(["cat", __a5], __bs7)];
 }});
 setenv("inc", {_stash: true, macro: function (n, by) {
-  var __e5;
+  var __e13;
   if (nil63(by)) {
-    __e5 = 1;
+    __e13 = 1;
   } else {
-    __e5 = by;
+    __e13 = by;
   }
-  return ["set", n, ["+", n, __e5]];
+  return ["set", n, ["+", n, __e13]];
 }});
 setenv("dec", {_stash: true, macro: function (n, by) {
-  var __e6;
+  var __e14;
   if (nil63(by)) {
-    __e6 = 1;
+    __e14 = 1;
   } else {
-    __e6 = by;
+    __e14 = by;
   }
-  return ["set", n, ["-", n, __e6]];
+  return ["set", n, ["-", n, __e14]];
 }});
 setenv("with-indent", {_stash: true, macro: function (form) {
-  var __x157 = unique("x");
-  return ["do", ["inc", "indent-level"], ["with", __x157, form, ["dec", "indent-level"]]];
+  var __x319 = unique("x");
+  return ["do", ["inc", "indent-level"], ["with", __x319, form, ["dec", "indent-level"]]];
 }});
 setenv("export", {_stash: true, macro: function () {
-  var __names2 = unstash(Array.prototype.slice.call(arguments, 0));
+  var __names5 = unstash(Array.prototype.slice.call(arguments, 0));
   if (target === "js") {
     return join(["do"], map(function (k) {
       return ["set", ["exports", "." + k], k];
-    }, __names2));
+    }, __names5));
   } else {
-    var __x165 = {};
-    var ____o3 = __names2;
-    var ____i5 = undefined;
-    for (____i5 in ____o3) {
-      var __k3 = ____o3[____i5];
-      var __e7;
-      if (numeric63(____i5)) {
-        __e7 = parseInt(____i5);
+    var __x333 = {};
+    var ____o7 = __names5;
+    var ____i11 = undefined;
+    for (____i11 in ____o7) {
+      var __k8 = ____o7[____i11];
+      var __e15;
+      if (numeric63(____i11)) {
+        __e15 = parseInt(____i11);
       } else {
-        __e7 = ____i5;
+        __e15 = ____i11;
       }
-      var ____i51 = __e7;
-      var __k4 = compileId(__k3);
-      __x165[__k4] = __k4;
+      var ____i111 = __e15;
+      var __k9 = compileId(__k8);
+      __x333[__k9] = __k9;
     }
     return ["return", join(["%object"], mapo(function (x) {
       return x;
-    }, __x165))];
+    }, __x333))];
   }
 }});
 setenv("when-compiling", {_stash: true, macro: function () {
-  var __body21 = unstash(Array.prototype.slice.call(arguments, 0));
-  return _eval(join(["do"], __body21));
+  var __body43 = unstash(Array.prototype.slice.call(arguments, 0));
+  return _eval(join(["do"], __body43));
 }});
 setenv("during-compilation", {_stash: true, macro: function () {
-  var __body22 = unstash(Array.prototype.slice.call(arguments, 0));
-  var __form2 = join(["do"], __body22);
-  _eval(__form2);
-  return __form2;
+  var __body45 = unstash(Array.prototype.slice.call(arguments, 0));
+  var __form5 = join(["do"], __body45);
+  _eval(__form5);
+  return __form5;
 }});
 var reader = require("reader");
 var compiler = require("compiler");

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -658,13 +658,13 @@ setenv("quasiquote", {_stash = true, macro = function (form)
   return quasiexpand(form, 1)
 end})
 setenv("set", {_stash = true, macro = function (...)
-  local __args = unstash({...})
-  return join({"do"}, map(function (__x2)
-    local ____id = __x2
-    local __lh = ____id[1]
-    local __rh = ____id[2]
-    return {"%set", __lh, __rh}
-  end, pair(__args)))
+  local __args1 = unstash({...})
+  return join({"do"}, map(function (__x5)
+    local ____id1 = __x5
+    local __lh1 = ____id1[1]
+    local __rh1 = ____id1[2]
+    return {"%set", __lh1, __rh1}
+  end, pair(__args1)))
 end})
 setenv("at", {_stash = true, macro = function (l, i)
   if target == "lua" and number63(i) then
@@ -684,408 +684,410 @@ setenv("wipe", {_stash = true, macro = function (place)
   end
 end})
 setenv("list", {_stash = true, macro = function (...)
-  local __body = unstash({...})
-  local __x9 = unique("x")
-  local __l = {}
-  local __forms = {}
-  local ____o = __body
-  local __k = nil
-  for __k in next, ____o do
-    local __v = ____o[__k]
-    if number63(__k) then
-      __l[__k] = __v
+  local __body1 = unstash({...})
+  local __x24 = unique("x")
+  local __l1 = {}
+  local __forms1 = {}
+  local ____o1 = __body1
+  local __k2 = nil
+  for __k2 in next, ____o1 do
+    local __v1 = ____o1[__k2]
+    if number63(__k2) then
+      __l1[__k2] = __v1
     else
-      add(__forms, {"set", {"get", __x9, {"quote", __k}}, __v})
+      add(__forms1, {"set", {"get", __x24, {"quote", __k2}}, __v1})
     end
   end
-  if some63(__forms) then
-    return join({"let", __x9, join({"%array"}, __l)}, __forms, {__x9})
+  if some63(__forms1) then
+    return join({"let", __x24, join({"%array"}, __l1)}, __forms1, {__x24})
   else
-    return join({"%array"}, __l)
+    return join({"%array"}, __l1)
   end
 end})
 setenv("if", {_stash = true, macro = function (...)
-  local __branches = unstash({...})
-  return hd(expandIf(__branches))
+  local __branches1 = unstash({...})
+  return hd(expandIf(__branches1))
 end})
 setenv("case", {_stash = true, macro = function (expr, ...)
-  local ____r5 = unstash({...})
-  local __expr = destash33(expr, ____r5)
-  local ____id1 = ____r5
-  local __clauses = cut(____id1, 0)
-  local __x19 = unique("x")
-  local __eq = function (_)
-    return {"=", {"quote", _}, __x19}
+  local ____r13 = unstash({...})
+  local __expr1 = destash33(expr, ____r13)
+  local ____id4 = ____r13
+  local __clauses1 = cut(____id4, 0)
+  local __x45 = unique("x")
+  local __eq1 = function (_)
+    return {"=", {"quote", _}, __x45}
   end
-  local __cl = function (__x22)
-    local ____id2 = __x22
-    local __a = ____id2[1]
-    local __b = ____id2[2]
-    if nil63(__b) then
-      return {__a}
+  local __cl1 = function (__x48)
+    local ____id5 = __x48
+    local __a1 = ____id5[1]
+    local __b1 = ____id5[2]
+    if nil63(__b1) then
+      return {__a1}
     else
-      if string63(__a) or number63(__a) then
-        return {__eq(__a), __b}
+      if string63(__a1) or number63(__a1) then
+        return {__eq1(__a1), __b1}
       else
-        if one63(__a) then
-          return {__eq(hd(__a)), __b}
+        if one63(__a1) then
+          return {__eq1(hd(__a1)), __b1}
         else
-          if _35(__a) > 1 then
-            return {join({"or"}, map(__eq, __a)), __b}
+          if _35(__a1) > 1 then
+            return {join({"or"}, map(__eq1, __a1)), __b1}
           end
         end
       end
     end
   end
-  return {"let", __x19, __expr, join({"if"}, apply(join, map(__cl, pair(__clauses))))}
+  return {"let", __x45, __expr1, join({"if"}, apply(join, map(__cl1, pair(__clauses1))))}
 end})
 setenv("when", {_stash = true, macro = function (cond, ...)
-  local ____r8 = unstash({...})
-  local __cond = destash33(cond, ____r8)
-  local ____id3 = ____r8
-  local __body1 = cut(____id3, 0)
-  return {"if", __cond, join({"do"}, __body1)}
+  local ____r17 = unstash({...})
+  local __cond1 = destash33(cond, ____r17)
+  local ____id7 = ____r17
+  local __body3 = cut(____id7, 0)
+  return {"if", __cond1, join({"do"}, __body3)}
 end})
 setenv("unless", {_stash = true, macro = function (cond, ...)
-  local ____r9 = unstash({...})
-  local __cond1 = destash33(cond, ____r9)
-  local ____id4 = ____r9
-  local __body2 = cut(____id4, 0)
-  return {"if", {"not", __cond1}, join({"do"}, __body2)}
+  local ____r19 = unstash({...})
+  local __cond3 = destash33(cond, ____r19)
+  local ____id9 = ____r19
+  local __body5 = cut(____id9, 0)
+  return {"if", {"not", __cond3}, join({"do"}, __body5)}
 end})
 setenv("obj", {_stash = true, macro = function (...)
-  local __body3 = unstash({...})
+  local __body7 = unstash({...})
   return join({"%object"}, mapo(function (x)
     return x
-  end, __body3))
+  end, __body7))
 end})
 setenv("let", {_stash = true, macro = function (bs, ...)
-  local ____r11 = unstash({...})
-  local __bs = destash33(bs, ____r11)
-  local ____id5 = ____r11
-  local __body4 = cut(____id5, 0)
-  if atom63(__bs) then
-    return join({"let", {__bs, hd(__body4)}}, tl(__body4))
+  local ____r23 = unstash({...})
+  local __bs11 = destash33(bs, ____r23)
+  local ____id14 = ____r23
+  local __body9 = cut(____id14, 0)
+  if atom63(__bs11) then
+    return join({"let", {__bs11, hd(__body9)}}, tl(__body9))
   else
-    if none63(__bs) then
-      return join({"do"}, __body4)
+    if none63(__bs11) then
+      return join({"do"}, __body9)
     else
-      local ____id6 = __bs
-      local __lh1 = ____id6[1]
-      local __rh1 = ____id6[2]
-      local __bs2 = cut(____id6, 2)
-      local ____id7 = bind(__lh1, __rh1)
-      local __id8 = ____id7[1]
-      local __val = ____id7[2]
-      local __bs1 = cut(____id7, 2)
-      local __renames = {}
-      if not idLiteral63(__id8) then
-        local __id11 = unique(__id8)
-        __renames = {__id8, __id11}
-        __id8 = __id11
+      local ____id15 = __bs11
+      local __lh3 = ____id15[1]
+      local __rh3 = ____id15[2]
+      local __bs21 = cut(____id15, 2)
+      local ____id16 = bind(__lh3, __rh3)
+      local __id17 = ____id16[1]
+      local __val1 = ____id16[2]
+      local __bs12 = cut(____id16, 2)
+      local __renames1 = {}
+      if not idLiteral63(__id17) then
+        local __id121 = unique(__id17)
+        __renames1 = {__id17, __id121}
+        __id17 = __id121
       end
-      return {"do", {"%local", __id8, __val}, {"let-symbol", __renames, join({"let", join(__bs1, __bs2)}, __body4)}}
+      return {"do", {"%local", __id17, __val1}, {"let-symbol", __renames1, join({"let", join(__bs12, __bs21)}, __body9)}}
     end
   end
 end})
 setenv("with", {_stash = true, macro = function (x, v, ...)
-  local ____r12 = unstash({...})
-  local __x49 = destash33(x, ____r12)
-  local __v1 = destash33(v, ____r12)
-  local ____id9 = ____r12
-  local __body5 = cut(____id9, 0)
-  return join({"let", {__x49, __v1}}, __body5, {__x49})
+  local ____r25 = unstash({...})
+  local __x93 = destash33(x, ____r25)
+  local __v3 = destash33(v, ____r25)
+  local ____id19 = ____r25
+  local __body11 = cut(____id19, 0)
+  return join({"let", {__x93, __v3}}, __body11, {__x93})
 end})
 setenv("let-when", {_stash = true, macro = function (x, v, ...)
-  local ____r13 = unstash({...})
-  local __x54 = destash33(x, ____r13)
-  local __v2 = destash33(v, ____r13)
-  local ____id10 = ____r13
-  local __body6 = cut(____id10, 0)
-  local __y = unique("y")
-  return {"let", __y, __v2, {"when", {"yes", __y}, join({"let", {__x54, __y}}, __body6)}}
+  local ____r27 = unstash({...})
+  local __x104 = destash33(x, ____r27)
+  local __v5 = destash33(v, ____r27)
+  local ____id21 = ____r27
+  local __body13 = cut(____id21, 0)
+  local __y1 = unique("y")
+  return {"let", __y1, __v5, {"when", {"yes", __y1}, join({"let", {__x104, __y1}}, __body13)}}
 end})
 setenv("define-macro", {_stash = true, macro = function (name, args, ...)
-  local ____r14 = unstash({...})
-  local __name = destash33(name, ____r14)
-  local __args1 = destash33(args, ____r14)
-  local ____id111 = ____r14
-  local __body7 = cut(____id111, 0)
-  local ____x61 = {"setenv", {"quote", __name}}
-  ____x61.macro = join({"fn", __args1}, __body7)
-  local __form = ____x61
-  return __form
+  local ____r29 = unstash({...})
+  local __name1 = destash33(name, ____r29)
+  local __args3 = destash33(args, ____r29)
+  local ____id23 = ____r29
+  local __body15 = cut(____id23, 0)
+  local ____x114 = {"setenv", {"quote", __name1}}
+  ____x114.macro = join({"fn", __args3}, __body15)
+  local __form1 = ____x114
+  _eval(__form1)
+  return __form1
 end})
 setenv("define-special", {_stash = true, macro = function (name, args, ...)
-  local ____r15 = unstash({...})
-  local __name1 = destash33(name, ____r15)
-  local __args2 = destash33(args, ____r15)
-  local ____id12 = ____r15
-  local __body8 = cut(____id12, 0)
-  local ____x65 = {"setenv", {"quote", __name1}}
-  ____x65.special = join({"fn", __args2}, __body8)
-  local __form1 = join(____x65, keys(__body8))
-  return __form1
+  local ____r31 = unstash({...})
+  local __name3 = destash33(name, ____r31)
+  local __args5 = destash33(args, ____r31)
+  local ____id25 = ____r31
+  local __body17 = cut(____id25, 0)
+  local ____x121 = {"setenv", {"quote", __name3}}
+  ____x121.special = join({"fn", __args5}, __body17)
+  local __form3 = join(____x121, keys(__body17))
+  _eval(__form3)
+  return __form3
 end})
 setenv("define-symbol", {_stash = true, macro = function (name, expansion)
   setenv(name, {_stash = true, symbol = expansion})
-  local ____x68 = {"setenv", {"quote", name}}
-  ____x68.symbol = {"quote", expansion}
-  return ____x68
+  local ____x127 = {"setenv", {"quote", name}}
+  ____x127.symbol = {"quote", expansion}
+  return ____x127
 end})
-setenv("define-reader", {_stash = true, macro = function (__x71, ...)
-  local ____id13 = __x71
-  local __char = ____id13[1]
-  local __s = ____id13[2]
-  local ____r17 = unstash({...})
-  local ____x71 = destash33(__x71, ____r17)
-  local ____id14 = ____r17
-  local __body9 = cut(____id14, 0)
-  return {"set", {"get", "read-table", __char}, join({"fn", {__s}}, __body9)}
+setenv("define-reader", {_stash = true, macro = function (__x135, ...)
+  local ____id28 = __x135
+  local __char1 = ____id28[1]
+  local __s1 = ____id28[2]
+  local ____r35 = unstash({...})
+  local ____x135 = destash33(__x135, ____r35)
+  local ____id29 = ____r35
+  local __body19 = cut(____id29, 0)
+  return {"set", {"get", "read-table", __char1}, join({"fn", {__s1}}, __body19)}
 end})
 setenv("define", {_stash = true, macro = function (name, x, ...)
-  local ____r18 = unstash({...})
-  local __name2 = destash33(name, ____r18)
-  local __x78 = destash33(x, ____r18)
-  local ____id15 = ____r18
-  local __body10 = cut(____id15, 0)
-  setenv(__name2, {_stash = true, variable = true})
-  if some63(__body10) then
-    return join({"%local-function", __name2}, bind42(__x78, __body10))
+  local ____r37 = unstash({...})
+  local __name5 = destash33(name, ____r37)
+  local __x145 = destash33(x, ____r37)
+  local ____id31 = ____r37
+  local __body21 = cut(____id31, 0)
+  setenv(__name5, {_stash = true, variable = true})
+  if some63(__body21) then
+    return join({"%local-function", __name5}, bind42(__x145, __body21))
   else
-    return {"%local", __name2, __x78}
+    return {"%local", __name5, __x145}
   end
 end})
 setenv("define-global", {_stash = true, macro = function (name, x, ...)
-  local ____r19 = unstash({...})
-  local __name3 = destash33(name, ____r19)
-  local __x82 = destash33(x, ____r19)
-  local ____id16 = ____r19
-  local __body11 = cut(____id16, 0)
-  setenv(__name3, {_stash = true, toplevel = true, variable = true})
-  if some63(__body11) then
-    return join({"%global-function", __name3}, bind42(__x82, __body11))
+  local ____r39 = unstash({...})
+  local __name7 = destash33(name, ____r39)
+  local __x152 = destash33(x, ____r39)
+  local ____id33 = ____r39
+  local __body23 = cut(____id33, 0)
+  setenv(__name7, {_stash = true, toplevel = true, variable = true})
+  if some63(__body23) then
+    return join({"%global-function", __name7}, bind42(__x152, __body23))
   else
-    return {"set", __name3, __x82}
+    return {"set", __name7, __x152}
   end
 end})
 setenv("with-frame", {_stash = true, macro = function (...)
-  local __body12 = unstash({...})
-  local __x86 = unique("x")
-  return {"do", {"add", "environment", {"obj"}}, {"with", __x86, join({"do"}, __body12), {"drop", "environment"}}}
+  local __body25 = unstash({...})
+  local __x163 = unique("x")
+  return {"do", {"add", "environment", {"obj"}}, {"with", __x163, join({"do"}, __body25), {"drop", "environment"}}}
 end})
-setenv("with-bindings", {_stash = true, macro = function (__x93, ...)
-  local ____id17 = __x93
-  local __names = ____id17[1]
-  local ____r20 = unstash({...})
-  local ____x93 = destash33(__x93, ____r20)
-  local ____id18 = ____r20
-  local __body13 = cut(____id18, 0)
-  local __x95 = unique("x")
-  local ____x98 = {"setenv", __x95}
-  ____x98.variable = true
-  return join({"with-frame", {"each", __x95, __names, ____x98}}, __body13)
+setenv("with-bindings", {_stash = true, macro = function (__x175, ...)
+  local ____id36 = __x175
+  local __names1 = ____id36[1]
+  local ____r41 = unstash({...})
+  local ____x175 = destash33(__x175, ____r41)
+  local ____id37 = ____r41
+  local __body27 = cut(____id37, 0)
+  local __x177 = unique("x")
+  local ____x180 = {"setenv", __x177}
+  ____x180.variable = true
+  return join({"with-frame", {"each", __x177, __names1, ____x180}}, __body27)
 end})
 setenv("let-macro", {_stash = true, macro = function (definitions, ...)
-  local ____r21 = unstash({...})
-  local __definitions = destash33(definitions, ____r21)
-  local ____id19 = ____r21
-  local __body14 = cut(____id19, 0)
+  local ____r44 = unstash({...})
+  local __definitions1 = destash33(definitions, ____r44)
+  local ____id39 = ____r44
+  local __body29 = cut(____id39, 0)
   add(environment, {})
   map(function (m)
-    return _eval(join({"define-macro"}, m))
-  end, __definitions)
-  local ____x100 = join({"do"}, macroexpand(__body14))
+    return macroexpand(join({"define-macro"}, m))
+  end, __definitions1)
+  local ____x185 = join({"do"}, macroexpand(__body29))
   drop(environment)
-  return ____x100
+  return ____x185
 end})
 setenv("let-symbol", {_stash = true, macro = function (expansions, ...)
-  local ____r23 = unstash({...})
-  local __expansions = destash33(expansions, ____r23)
-  local ____id20 = ____r23
-  local __body15 = cut(____id20, 0)
+  local ____r48 = unstash({...})
+  local __expansions1 = destash33(expansions, ____r48)
+  local ____id42 = ____r48
+  local __body31 = cut(____id42, 0)
   add(environment, {})
-  map(function (__x105)
-    local ____id21 = __x105
-    local __name4 = ____id21[1]
-    local __exp = ____id21[2]
-    return macroexpand({"define-symbol", __name4, __exp})
-  end, pair(__expansions))
-  local ____x104 = join({"do"}, macroexpand(__body15))
+  map(function (__x194)
+    local ____id43 = __x194
+    local __name9 = ____id43[1]
+    local __exp1 = ____id43[2]
+    return macroexpand({"define-symbol", __name9, __exp1})
+  end, pair(__expansions1))
+  local ____x193 = join({"do"}, macroexpand(__body31))
   drop(environment)
-  return ____x104
+  return ____x193
 end})
 setenv("let-unique", {_stash = true, macro = function (names, ...)
-  local ____r25 = unstash({...})
-  local __names1 = destash33(names, ____r25)
-  local ____id22 = ____r25
-  local __body16 = cut(____id22, 0)
-  local __bs11 = map(function (n)
+  local ____r52 = unstash({...})
+  local __names3 = destash33(names, ____r52)
+  local ____id45 = ____r52
+  local __body33 = cut(____id45, 0)
+  local __bs3 = map(function (n)
     return {n, {"unique", {"quote", n}}}
-  end, __names1)
-  return join({"let", apply(join, __bs11)}, __body16)
+  end, __names3)
+  return join({"let", apply(join, __bs3)}, __body33)
 end})
 setenv("fn", {_stash = true, macro = function (args, ...)
-  local ____r27 = unstash({...})
-  local __args3 = destash33(args, ____r27)
-  local ____id23 = ____r27
-  local __body17 = cut(____id23, 0)
-  return join({"%function"}, bind42(__args3, __body17))
+  local ____r55 = unstash({...})
+  local __args7 = destash33(args, ____r55)
+  local ____id47 = ____r55
+  local __body35 = cut(____id47, 0)
+  return join({"%function"}, bind42(__args7, __body35))
 end})
 setenv("apply", {_stash = true, macro = function (f, ...)
-  local ____r28 = unstash({...})
-  local __f = destash33(f, ____r28)
-  local ____id24 = ____r28
-  local __args4 = cut(____id24, 0)
-  if _35(__args4) > 1 then
-    return {"%call", "apply", __f, {"join", join({"list"}, almost(__args4)), last(__args4)}}
+  local ____r57 = unstash({...})
+  local __f1 = destash33(f, ____r57)
+  local ____id49 = ____r57
+  local __args9 = cut(____id49, 0)
+  if _35(__args9) > 1 then
+    return {"%call", "apply", __f1, {"join", join({"list"}, almost(__args9)), last(__args9)}}
   else
-    return join({"%call", "apply", __f}, __args4)
+    return join({"%call", "apply", __f1}, __args9)
   end
 end})
 setenv("guard", {_stash = true, macro = function (expr)
   if target == "js" then
     return {{"fn", join(), {"%try", {"list", true, expr}}}}
   else
-    local ____x131 = {"obj"}
-    ____x131.stack = {"debug", {".traceback"}}
-    ____x131.message = {"if", {"string?", "m"}, {"clip", "m", {"+", {"search", "m", "\": \""}, 2}}, {"nil?", "m"}, "\"\"", {"str", "m"}}
-    return {"list", {"xpcall", {"fn", join(), expr}, {"fn", {"m"}, {"if", {"obj?", "m"}, "m", ____x131}}}}
+    local ____x250 = {"obj"}
+    ____x250.stack = {"debug", {".traceback"}}
+    ____x250.message = {"if", {"string?", "m"}, {"clip", "m", {"+", {"search", "m", "\": \""}, 2}}, {"nil?", "m"}, "\"\"", {"str", "m"}}
+    return {"list", {"xpcall", {"fn", join(), expr}, {"fn", {"m"}, {"if", {"obj?", "m"}, "m", ____x250}}}}
   end
 end})
 setenv("each", {_stash = true, macro = function (x, t, ...)
-  local ____r30 = unstash({...})
-  local __x142 = destash33(x, ____r30)
-  local __t = destash33(t, ____r30)
-  local ____id25 = ____r30
-  local __body18 = cut(____id25, 0)
-  local __o1 = unique("o")
-  local __n1 = unique("n")
-  local __i1 = unique("i")
-  local __e
-  if atom63(__x142) then
-    __e = {__i1, __x142}
+  local ____r61 = unstash({...})
+  local __x275 = destash33(x, ____r61)
+  local __t1 = destash33(t, ____r61)
+  local ____id52 = ____r61
+  local __body37 = cut(____id52, 0)
+  local __o3 = unique("o")
+  local __n3 = unique("n")
+  local __i3 = unique("i")
+  local __e8
+  if atom63(__x275) then
+    __e8 = {__i3, __x275}
   else
-    local __e1
-    if _35(__x142) > 1 then
-      __e1 = __x142
+    local __e9
+    if _35(__x275) > 1 then
+      __e9 = __x275
     else
-      __e1 = {__i1, hd(__x142)}
+      __e9 = {__i3, hd(__x275)}
     end
-    __e = __e1
+    __e8 = __e9
   end
-  local ____id26 = __e
-  local __k1 = ____id26[1]
-  local __v3 = ____id26[2]
-  local __e2
+  local ____id53 = __e8
+  local __k4 = ____id53[1]
+  local __v7 = ____id53[2]
+  local __e10
   if target == "lua" then
-    __e2 = __body18
+    __e10 = __body37
   else
-    __e2 = {join({"let", __k1, {"if", {"numeric?", __k1}, {"parseInt", __k1}, __k1}}, __body18)}
+    __e10 = {join({"let", __k4, {"if", {"numeric?", __k4}, {"parseInt", __k4}, __k4}}, __body37)}
   end
-  return {"let", {__o1, __t, __k1, "nil"}, {"%for", __o1, __k1, join({"let", {__v3, {"get", __o1, __k1}}}, __e2)}}
+  return {"let", {__o3, __t1, __k4, "nil"}, {"%for", __o3, __k4, join({"let", {__v7, {"get", __o3, __k4}}}, __e10)}}
 end})
 setenv("for", {_stash = true, macro = function (i, to, ...)
-  local ____r31 = unstash({...})
-  local __i2 = destash33(i, ____r31)
-  local __to = destash33(to, ____r31)
-  local ____id27 = ____r31
-  local __body19 = cut(____id27, 0)
-  return {"let", __i2, 0, join({"while", {"<", __i2, __to}}, __body19, {{"inc", __i2}})}
+  local ____r63 = unstash({...})
+  local __i5 = destash33(i, ____r63)
+  local __to1 = destash33(to, ____r63)
+  local ____id55 = ____r63
+  local __body39 = cut(____id55, 0)
+  return {"let", __i5, 0, join({"while", {"<", __i5, __to1}}, __body39, {{"inc", __i5}})}
 end})
 setenv("step", {_stash = true, macro = function (v, t, ...)
-  local ____r32 = unstash({...})
-  local __v4 = destash33(v, ____r32)
-  local __t1 = destash33(t, ____r32)
-  local ____id28 = ____r32
-  local __body20 = cut(____id28, 0)
-  local __x163 = unique("x")
-  local __i3 = unique("i")
-  return {"let", {__x163, __t1}, {"for", __i3, {"#", __x163}, join({"let", {__v4, {"at", __x163, __i3}}}, __body20)}}
+  local ____r65 = unstash({...})
+  local __v9 = destash33(v, ____r65)
+  local __t3 = destash33(t, ____r65)
+  local ____id57 = ____r65
+  local __body41 = cut(____id57, 0)
+  local __x309 = unique("x")
+  local __i7 = unique("i")
+  return {"let", {__x309, __t3}, {"for", __i7, {"#", __x309}, join({"let", {__v9, {"at", __x309, __i7}}}, __body41)}}
 end})
 setenv("set-of", {_stash = true, macro = function (...)
-  local __xs = unstash({...})
-  local __l1 = {}
-  local ____o2 = __xs
-  local ____i4 = nil
-  for ____i4 in next, ____o2 do
-    local __x172 = ____o2[____i4]
-    __l1[__x172] = true
+  local __xs1 = unstash({...})
+  local __l3 = {}
+  local ____o5 = __xs1
+  local ____i9 = nil
+  for ____i9 in next, ____o5 do
+    local __x320 = ____o5[____i9]
+    __l3[__x320] = true
   end
-  return join({"obj"}, __l1)
+  return join({"obj"}, __l3)
 end})
 setenv("language", {_stash = true, macro = function ()
   return {"quote", target}
 end})
 setenv("target", {_stash = true, macro = function (...)
-  local __clauses1 = unstash({...})
-  return __clauses1[target]
+  local __clauses3 = unstash({...})
+  return __clauses3[target]
 end})
 setenv("join!", {_stash = true, macro = function (a, ...)
-  local ____r34 = unstash({...})
-  local __a1 = destash33(a, ____r34)
-  local ____id29 = ____r34
-  local __bs21 = cut(____id29, 0)
-  return {"set", __a1, join({"join", __a1}, __bs21)}
+  local ____r69 = unstash({...})
+  local __a3 = destash33(a, ____r69)
+  local ____id59 = ____r69
+  local __bs5 = cut(____id59, 0)
+  return {"set", __a3, join({"join", __a3}, __bs5)}
 end})
 setenv("cat!", {_stash = true, macro = function (a, ...)
-  local ____r35 = unstash({...})
-  local __a2 = destash33(a, ____r35)
-  local ____id30 = ____r35
-  local __bs3 = cut(____id30, 0)
-  return {"set", __a2, join({"cat", __a2}, __bs3)}
+  local ____r71 = unstash({...})
+  local __a5 = destash33(a, ____r71)
+  local ____id61 = ____r71
+  local __bs7 = cut(____id61, 0)
+  return {"set", __a5, join({"cat", __a5}, __bs7)}
 end})
 setenv("inc", {_stash = true, macro = function (n, by)
-  local __e3
+  local __e11
   if nil63(by) then
-    __e3 = 1
+    __e11 = 1
   else
-    __e3 = by
+    __e11 = by
   end
-  return {"set", n, {"+", n, __e3}}
+  return {"set", n, {"+", n, __e11}}
 end})
 setenv("dec", {_stash = true, macro = function (n, by)
-  local __e4
+  local __e12
   if nil63(by) then
-    __e4 = 1
+    __e12 = 1
   else
-    __e4 = by
+    __e12 = by
   end
-  return {"set", n, {"-", n, __e4}}
+  return {"set", n, {"-", n, __e12}}
 end})
 setenv("with-indent", {_stash = true, macro = function (form)
-  local __x186 = unique("x")
-  return {"do", {"inc", "indent-level"}, {"with", __x186, form, {"dec", "indent-level"}}}
+  local __x348 = unique("x")
+  return {"do", {"inc", "indent-level"}, {"with", __x348, form, {"dec", "indent-level"}}}
 end})
 setenv("export", {_stash = true, macro = function (...)
-  local __names2 = unstash({...})
+  local __names5 = unstash({...})
   if target == "js" then
     return join({"do"}, map(function (k)
       return {"set", {"exports", "." .. k}, k}
-    end, __names2))
+    end, __names5))
   else
-    local __x195 = {}
-    local ____o3 = __names2
-    local ____i5 = nil
-    for ____i5 in next, ____o3 do
-      local __k2 = ____o3[____i5]
-      local __k3 = compileId(__k2)
-      __x195[__k3] = __k3
+    local __x363 = {}
+    local ____o7 = __names5
+    local ____i11 = nil
+    for ____i11 in next, ____o7 do
+      local __k7 = ____o7[____i11]
+      local __k8 = compileId(__k7)
+      __x363[__k8] = __k8
     end
     return {"return", join({"%object"}, mapo(function (x)
       return x
-    end, __x195))}
+    end, __x363))}
   end
 end})
 setenv("when-compiling", {_stash = true, macro = function (...)
-  local __body21 = unstash({...})
-  return _eval(join({"do"}, __body21))
+  local __body43 = unstash({...})
+  return _eval(join({"do"}, __body43))
 end})
 setenv("during-compilation", {_stash = true, macro = function (...)
-  local __body22 = unstash({...})
-  local __form2 = join({"do"}, __body22)
-  _eval(__form2)
-  return __form2
+  local __body45 = unstash({...})
+  local __form5 = join({"do"}, __body45)
+  _eval(__form5)
+  return __form5
 end})
 local reader = require("reader")
 local compiler = require("compiler")

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -134,10 +134,31 @@ function code(s, n)
   end
   return string.byte(s, __e2)
 end
-function string_literal63(x)
+function fromCode(n)
+  return string.char(n)
+end
+function lowercase63(n)
+  return n > 96 and n < 123
+end
+function camelCase(str)
+  local __s = ""
+  local __n3 = _35(str)
+  local __i3 = 0
+  while __i3 < __n3 do
+    local __c = code(str, __i3)
+    if __c == 45 and lowercase63(code(str, __i3 - 1) or 0) and lowercase63(code(str, __i3 + 1) or 0) then
+      __i3 = __i3 + 1
+      __c = code(str, __i3) - 32
+    end
+    __s = __s .. fromCode(__c)
+    __i3 = __i3 + 1
+  end
+  return __s
+end
+function stringLiteral63(x)
   return string63(x) and char(x, 0) == "\""
 end
-function id_literal63(x)
+function idLiteral63(x)
   return string63(x) and char(x, 0) == "|"
 end
 function add(l, x)
@@ -154,10 +175,10 @@ function almost(l)
 end
 function reverse(l)
   local __l1 = keys(l)
-  local __i3 = edge(l)
-  while __i3 >= 0 do
-    add(__l1, l[__i3 + 1])
-    __i3 = __i3 - 1
+  local __i4 = edge(l)
+  while __i4 >= 0 do
+    add(__l1, l[__i4 + 1])
+    __i4 = __i4 - 1
   end
   return __l1
 end
@@ -174,32 +195,32 @@ function reduce(f, x)
 end
 function join(...)
   local __ls = unstash({...})
-  local __r36 = {}
+  local __r39 = {}
   local ____x2 = __ls
-  local ____i4 = 0
-  while ____i4 < _35(____x2) do
-    local __l11 = ____x2[____i4 + 1]
+  local ____i5 = 0
+  while ____i5 < _35(____x2) do
+    local __l11 = ____x2[____i5 + 1]
     if __l11 then
-      local __n3 = _35(__r36)
+      local __n4 = _35(__r39)
       local ____o2 = __l11
       local __k2 = nil
       for __k2 in next, ____o2 do
         local __v2 = ____o2[__k2]
         if number63(__k2) then
-          __k2 = __k2 + __n3
+          __k2 = __k2 + __n4
         end
-        __r36[__k2] = __v2
+        __r39[__k2] = __v2
       end
     end
-    ____i4 = ____i4 + 1
+    ____i5 = ____i5 + 1
   end
-  return __r36
+  return __r39
 end
 function find(f, t)
   local ____o3 = t
-  local ____i6 = nil
-  for ____i6 in next, ____o3 do
-    local __x3 = ____o3[____i6]
+  local ____i7 = nil
+  for ____i7 in next, ____o3 do
+    local __x3 = ____o3[____i7]
     local __y = f(__x3)
     if __y then
       return __y
@@ -208,14 +229,14 @@ function find(f, t)
 end
 function first(f, l)
   local ____x4 = l
-  local ____i7 = 0
-  while ____i7 < _35(____x4) do
-    local __x5 = ____x4[____i7 + 1]
+  local ____i8 = 0
+  while ____i8 < _35(____x4) do
+    local __x5 = ____x4[____i8 + 1]
     local __y1 = f(__x5)
     if __y1 then
       return __y1
     end
-    ____i7 = ____i7 + 1
+    ____i8 = ____i8 + 1
   end
 end
 function in63(x, t)
@@ -225,11 +246,11 @@ function in63(x, t)
 end
 function pair(l)
   local __l12 = {}
-  local __i8 = 0
-  while __i8 < _35(l) do
-    add(__l12, {l[__i8 + 1], l[__i8 + 1 + 1]})
-    __i8 = __i8 + 1
-    __i8 = __i8 + 1
+  local __i9 = 0
+  while __i9 < _35(l) do
+    add(__l12, {l[__i9 + 1], l[__i9 + 1 + 1]})
+    __i9 = __i9 + 1
+    __i9 = __i9 + 1
   end
   return __l12
 end
@@ -240,14 +261,14 @@ end
 function map(f, x)
   local __t1 = {}
   local ____x7 = x
-  local ____i9 = 0
-  while ____i9 < _35(____x7) do
-    local __v3 = ____x7[____i9 + 1]
+  local ____i10 = 0
+  while ____i10 < _35(____x7) do
+    local __v3 = ____x7[____i10 + 1]
     local __y2 = f(__v3)
     if is63(__y2) then
       add(__t1, __y2)
     end
-    ____i9 = ____i9 + 1
+    ____i10 = ____i10 + 1
   end
   local ____o4 = x
   local __k3 = nil
@@ -282,9 +303,9 @@ function keys63(t)
 end
 function empty63(t)
   local ____o6 = t
-  local ____i12 = nil
-  for ____i12 in next, ____o6 do
-    local __x8 = ____o6[____i12]
+  local ____i13 = nil
+  for ____i13 in next, ____o6 do
+    local __x8 = ____o6[____i13]
     return false
   end
   return true
@@ -346,22 +367,22 @@ function search(s, pattern, start)
     __e3 = start + 1
   end
   local __start = __e3
-  local __i16 = string.find(s, pattern, __start, true)
-  return __i16 and __i16 - 1
+  local __i17 = string.find(s, pattern, __start, true)
+  return __i17 and __i17 - 1
 end
 function split(s, sep)
   if s == "" or sep == "" then
     return {}
   else
     local __l3 = {}
-    local __n12 = _35(sep)
+    local __n13 = _35(sep)
     while true do
-      local __i17 = search(s, sep)
-      if nil63(__i17) then
+      local __i18 = search(s, sep)
+      if nil63(__i18) then
         break
       else
-        add(__l3, clip(s, 0, __i17))
-        s = clip(s, __i17 + __n12)
+        add(__l3, clip(s, 0, __i18))
+        s = clip(s, __i18 + __n13)
       end
     end
     add(__l3, s)
@@ -405,14 +426,14 @@ function _37(...)
   end, reverse(__xs5)), 0)
 end
 local function pairwise(f, xs)
-  local __i18 = 0
-  while __i18 < edge(xs) do
-    local __a = xs[__i18 + 1]
-    local __b = xs[__i18 + 1 + 1]
+  local __i19 = 0
+  while __i19 < edge(xs) do
+    local __a = xs[__i19 + 1]
+    local __b = xs[__i19 + 1 + 1]
     if not f(__a, __b) then
       return false
     end
-    __i18 = __i18 + 1
+    __i19 = __i19 + 1
   end
   return true
 end
@@ -449,42 +470,42 @@ end
 function number(s)
   return tonumber(s)
 end
-function number_code63(n)
+function numberCode63(n)
   return n > 47 and n < 58
 end
 function numeric63(s)
-  local __n13 = _35(s)
-  local __i19 = 0
-  while __i19 < __n13 do
-    if not number_code63(code(s, __i19)) then
+  local __n14 = _35(s)
+  local __i20 = 0
+  while __i20 < __n14 do
+    if not numberCode63(code(s, __i20)) then
       return false
     end
-    __i19 = __i19 + 1
+    __i20 = __i20 + 1
   end
   return some63(s)
 end
 function escape(s)
   local __s1 = "\""
-  local __i20 = 0
-  while __i20 < _35(s) do
-    local __c = char(s, __i20)
+  local __i21 = 0
+  while __i21 < _35(s) do
+    local __c1 = char(s, __i21)
     local __e4
-    if __c == "\n" then
+    if __c1 == "\n" then
       __e4 = "\\n"
     else
       local __e5
-      if __c == "\r" then
+      if __c1 == "\r" then
         __e5 = "\\r"
       else
         local __e6
-        if __c == "\"" then
+        if __c1 == "\"" then
           __e6 = "\\\""
         else
           local __e7
-          if __c == "\\" then
+          if __c1 == "\\" then
             __e7 = "\\\\"
           else
-            __e7 = __c
+            __e7 = __c1
           end
           __e6 = __e7
         end
@@ -492,9 +513,9 @@ function escape(s)
       end
       __e4 = __e5
     end
-    local __c1 = __e4
-    __s1 = __s1 .. __c1
-    __i20 = __i20 + 1
+    local __c11 = __e4
+    __s1 = __s1 .. __c11
+    __i21 = __i21 + 1
   end
   return __s1 .. "\""
 end
@@ -533,7 +554,7 @@ function str(x, stack)
                     if not( type(x) == "table") then
                       return escape(tostring(x))
                     else
-                      local __s = "("
+                      local __s11 = "("
                       local __sp = ""
                       local __xs11 = {}
                       local __ks = {}
@@ -555,13 +576,13 @@ function str(x, stack)
                       end
                       drop(__l4)
                       local ____o11 = join(__xs11, __ks)
-                      local ____i22 = nil
-                      for ____i22 in next, ____o11 do
-                        local __v10 = ____o11[____i22]
-                        __s = __s .. __sp .. __v10
+                      local ____i23 = nil
+                      for ____i23 in next, ____o11 do
+                        local __v10 = ____o11[____i23]
+                        __s11 = __s11 .. __sp .. __v10
                         __sp = " "
                       end
-                      return __s .. ")"
+                      return __s11 .. ")"
                     end
                   end
                 end
@@ -579,16 +600,16 @@ function apply(f, args)
   return f(values(__args))
 end
 function call(f, ...)
-  local ____r71 = unstash({...})
-  local __f = destash33(f, ____r71)
-  local ____id = ____r71
+  local ____r74 = unstash({...})
+  local __f = destash33(f, ____r74)
+  local ____id = ____r74
   local __args11 = cut(____id, 0)
   return apply(__f, __args11)
 end
 function setenv(k, ...)
-  local ____r72 = unstash({...})
-  local __k9 = destash33(k, ____r72)
-  local ____id1 = ____r72
+  local ____r75 = unstash({...})
+  local __k9 = destash33(k, ____r75)
+  local ____id1 = ____r75
   local __keys = cut(____id1, 0)
   if string63(__k9) then
     local __e8
@@ -637,13 +658,13 @@ setenv("quasiquote", {_stash = true, macro = function (form)
   return quasiexpand(form, 1)
 end})
 setenv("set", {_stash = true, macro = function (...)
-  local __args1 = unstash({...})
-  return join({"do"}, map(function (__x5)
-    local ____id1 = __x5
-    local __lh1 = ____id1[1]
-    local __rh1 = ____id1[2]
-    return {"%set", __lh1, __rh1}
-  end, pair(__args1)))
+  local __args = unstash({...})
+  return join({"do"}, map(function (__x2)
+    local ____id = __x2
+    local __lh = ____id[1]
+    local __rh = ____id[2]
+    return {"%set", __lh, __rh}
+  end, pair(__args)))
 end})
 setenv("at", {_stash = true, macro = function (l, i)
   if target == "lua" and number63(i) then
@@ -663,408 +684,413 @@ setenv("wipe", {_stash = true, macro = function (place)
   end
 end})
 setenv("list", {_stash = true, macro = function (...)
-  local __body1 = unstash({...})
-  local __x24 = unique("x")
-  local __l1 = {}
-  local __forms1 = {}
-  local ____o1 = __body1
-  local __k2 = nil
-  for __k2 in next, ____o1 do
-    local __v1 = ____o1[__k2]
-    if number63(__k2) then
-      __l1[__k2] = __v1
+  local __body = unstash({...})
+  local __x9 = unique("x")
+  local __l = {}
+  local __forms = {}
+  local ____o = __body
+  local __k = nil
+  for __k in next, ____o do
+    local __v = ____o[__k]
+    if number63(__k) then
+      __l[__k] = __v
     else
-      add(__forms1, {"set", {"get", __x24, {"quote", __k2}}, __v1})
+      add(__forms, {"set", {"get", __x9, {"quote", __k}}, __v})
     end
   end
-  if some63(__forms1) then
-    return join({"let", __x24, join({"%array"}, __l1)}, __forms1, {__x24})
+  if some63(__forms) then
+    return join({"let", __x9, join({"%array"}, __l)}, __forms, {__x9})
   else
-    return join({"%array"}, __l1)
+    return join({"%array"}, __l)
   end
 end})
 setenv("if", {_stash = true, macro = function (...)
-  local __branches1 = unstash({...})
-  return hd(expand_if(__branches1))
+  local __branches = unstash({...})
+  return hd(expandIf(__branches))
 end})
 setenv("case", {_stash = true, macro = function (expr, ...)
-  local ____r13 = unstash({...})
-  local __expr1 = destash33(expr, ____r13)
-  local ____id4 = ____r13
-  local __clauses1 = cut(____id4, 0)
-  local __x45 = unique("x")
-  local __eq1 = function (_)
-    return {"=", {"quote", _}, __x45}
+  local ____r5 = unstash({...})
+  local __expr = destash33(expr, ____r5)
+  local ____id1 = ____r5
+  local __clauses = cut(____id1, 0)
+  local __x19 = unique("x")
+  local __eq = function (_)
+    return {"=", {"quote", _}, __x19}
   end
-  local __cl1 = function (__x48)
-    local ____id5 = __x48
-    local __a1 = ____id5[1]
-    local __b1 = ____id5[2]
-    if nil63(__b1) then
-      return {__a1}
+  local __cl = function (__x22)
+    local ____id2 = __x22
+    local __a = ____id2[1]
+    local __b = ____id2[2]
+    if nil63(__b) then
+      return {__a}
     else
-      if string63(__a1) or number63(__a1) then
-        return {__eq1(__a1), __b1}
+      if string63(__a) or number63(__a) then
+        return {__eq(__a), __b}
       else
-        if one63(__a1) then
-          return {__eq1(hd(__a1)), __b1}
+        if one63(__a) then
+          return {__eq(hd(__a)), __b}
         else
-          if _35(__a1) > 1 then
-            return {join({"or"}, map(__eq1, __a1)), __b1}
+          if _35(__a) > 1 then
+            return {join({"or"}, map(__eq, __a)), __b}
           end
         end
       end
     end
   end
-  return {"let", __x45, __expr1, join({"if"}, apply(join, map(__cl1, pair(__clauses1))))}
+  return {"let", __x19, __expr, join({"if"}, apply(join, map(__cl, pair(__clauses))))}
 end})
 setenv("when", {_stash = true, macro = function (cond, ...)
-  local ____r17 = unstash({...})
-  local __cond1 = destash33(cond, ____r17)
-  local ____id7 = ____r17
-  local __body3 = cut(____id7, 0)
-  return {"if", __cond1, join({"do"}, __body3)}
+  local ____r8 = unstash({...})
+  local __cond = destash33(cond, ____r8)
+  local ____id3 = ____r8
+  local __body1 = cut(____id3, 0)
+  return {"if", __cond, join({"do"}, __body1)}
 end})
 setenv("unless", {_stash = true, macro = function (cond, ...)
-  local ____r19 = unstash({...})
-  local __cond3 = destash33(cond, ____r19)
-  local ____id9 = ____r19
-  local __body5 = cut(____id9, 0)
-  return {"if", {"not", __cond3}, join({"do"}, __body5)}
+  local ____r9 = unstash({...})
+  local __cond1 = destash33(cond, ____r9)
+  local ____id4 = ____r9
+  local __body2 = cut(____id4, 0)
+  return {"if", {"not", __cond1}, join({"do"}, __body2)}
 end})
 setenv("obj", {_stash = true, macro = function (...)
-  local __body7 = unstash({...})
+  local __body3 = unstash({...})
   return join({"%object"}, mapo(function (x)
     return x
-  end, __body7))
+  end, __body3))
 end})
 setenv("let", {_stash = true, macro = function (bs, ...)
-  local ____r23 = unstash({...})
-  local __bs11 = destash33(bs, ____r23)
-  local ____id14 = ____r23
-  local __body9 = cut(____id14, 0)
-  if atom63(__bs11) then
-    return join({"let", {__bs11, hd(__body9)}}, tl(__body9))
+  local ____r11 = unstash({...})
+  local __bs = destash33(bs, ____r11)
+  local ____id5 = ____r11
+  local __body4 = cut(____id5, 0)
+  if atom63(__bs) then
+    return join({"let", {__bs, hd(__body4)}}, tl(__body4))
   else
-    if none63(__bs11) then
-      return join({"do"}, __body9)
+    if none63(__bs) then
+      return join({"do"}, __body4)
     else
-      local ____id15 = __bs11
-      local __lh3 = ____id15[1]
-      local __rh3 = ____id15[2]
-      local __bs21 = cut(____id15, 2)
-      local ____id16 = bind(__lh3, __rh3)
-      local __id17 = ____id16[1]
-      local __val1 = ____id16[2]
-      local __bs12 = cut(____id16, 2)
-      local __renames1 = {}
-      if not id_literal63(__id17) then
-        local __id121 = unique(__id17)
-        __renames1 = {__id17, __id121}
-        __id17 = __id121
+      local ____id6 = __bs
+      local __lh1 = ____id6[1]
+      local __rh1 = ____id6[2]
+      local __bs2 = cut(____id6, 2)
+      local ____id7 = bind(__lh1, __rh1)
+      local __id8 = ____id7[1]
+      local __val = ____id7[2]
+      local __bs1 = cut(____id7, 2)
+      local __renames = {}
+      if not idLiteral63(__id8) then
+        local __id11 = unique(__id8)
+        __renames = {__id8, __id11}
+        __id8 = __id11
       end
-      return {"do", {"%local", __id17, __val1}, {"let-symbol", __renames1, join({"let", join(__bs12, __bs21)}, __body9)}}
+      return {"do", {"%local", __id8, __val}, {"let-symbol", __renames, join({"let", join(__bs1, __bs2)}, __body4)}}
     end
   end
 end})
 setenv("with", {_stash = true, macro = function (x, v, ...)
-  local ____r25 = unstash({...})
-  local __x93 = destash33(x, ____r25)
-  local __v3 = destash33(v, ____r25)
-  local ____id19 = ____r25
-  local __body11 = cut(____id19, 0)
-  return join({"let", {__x93, __v3}}, __body11, {__x93})
+  local ____r12 = unstash({...})
+  local __x49 = destash33(x, ____r12)
+  local __v1 = destash33(v, ____r12)
+  local ____id9 = ____r12
+  local __body5 = cut(____id9, 0)
+  return join({"let", {__x49, __v1}}, __body5, {__x49})
 end})
 setenv("let-when", {_stash = true, macro = function (x, v, ...)
-  local ____r27 = unstash({...})
-  local __x104 = destash33(x, ____r27)
-  local __v5 = destash33(v, ____r27)
-  local ____id21 = ____r27
-  local __body13 = cut(____id21, 0)
-  local __y1 = unique("y")
-  return {"let", __y1, __v5, {"when", {"yes", __y1}, join({"let", {__x104, __y1}}, __body13)}}
+  local ____r13 = unstash({...})
+  local __x54 = destash33(x, ____r13)
+  local __v2 = destash33(v, ____r13)
+  local ____id10 = ____r13
+  local __body6 = cut(____id10, 0)
+  local __y = unique("y")
+  return {"let", __y, __v2, {"when", {"yes", __y}, join({"let", {__x54, __y}}, __body6)}}
 end})
 setenv("define-macro", {_stash = true, macro = function (name, args, ...)
-  local ____r29 = unstash({...})
-  local __name1 = destash33(name, ____r29)
-  local __args3 = destash33(args, ____r29)
-  local ____id23 = ____r29
-  local __body15 = cut(____id23, 0)
-  local ____x114 = {"setenv", {"quote", __name1}}
-  ____x114.macro = join({"fn", __args3}, __body15)
-  local __form1 = ____x114
-  _eval(__form1)
-  return __form1
+  local ____r14 = unstash({...})
+  local __name = destash33(name, ____r14)
+  local __args1 = destash33(args, ____r14)
+  local ____id111 = ____r14
+  local __body7 = cut(____id111, 0)
+  local ____x61 = {"setenv", {"quote", __name}}
+  ____x61.macro = join({"fn", __args1}, __body7)
+  local __form = ____x61
+  return __form
 end})
 setenv("define-special", {_stash = true, macro = function (name, args, ...)
-  local ____r31 = unstash({...})
-  local __name3 = destash33(name, ____r31)
-  local __args5 = destash33(args, ____r31)
-  local ____id25 = ____r31
-  local __body17 = cut(____id25, 0)
-  local ____x121 = {"setenv", {"quote", __name3}}
-  ____x121.special = join({"fn", __args5}, __body17)
-  local __form3 = join(____x121, keys(__body17))
-  _eval(__form3)
-  return __form3
+  local ____r15 = unstash({...})
+  local __name1 = destash33(name, ____r15)
+  local __args2 = destash33(args, ____r15)
+  local ____id12 = ____r15
+  local __body8 = cut(____id12, 0)
+  local ____x65 = {"setenv", {"quote", __name1}}
+  ____x65.special = join({"fn", __args2}, __body8)
+  local __form1 = join(____x65, keys(__body8))
+  return __form1
 end})
 setenv("define-symbol", {_stash = true, macro = function (name, expansion)
   setenv(name, {_stash = true, symbol = expansion})
-  local ____x127 = {"setenv", {"quote", name}}
-  ____x127.symbol = {"quote", expansion}
-  return ____x127
+  local ____x68 = {"setenv", {"quote", name}}
+  ____x68.symbol = {"quote", expansion}
+  return ____x68
 end})
-setenv("define-reader", {_stash = true, macro = function (__x135, ...)
-  local ____id28 = __x135
-  local __char1 = ____id28[1]
-  local __s1 = ____id28[2]
-  local ____r35 = unstash({...})
-  local ____x135 = destash33(__x135, ____r35)
-  local ____id29 = ____r35
-  local __body19 = cut(____id29, 0)
-  return {"set", {"get", "read-table", __char1}, join({"fn", {__s1}}, __body19)}
+setenv("define-reader", {_stash = true, macro = function (__x71, ...)
+  local ____id13 = __x71
+  local __char = ____id13[1]
+  local __s = ____id13[2]
+  local ____r17 = unstash({...})
+  local ____x71 = destash33(__x71, ____r17)
+  local ____id14 = ____r17
+  local __body9 = cut(____id14, 0)
+  return {"set", {"get", "read-table", __char}, join({"fn", {__s}}, __body9)}
 end})
 setenv("define", {_stash = true, macro = function (name, x, ...)
-  local ____r37 = unstash({...})
-  local __name5 = destash33(name, ____r37)
-  local __x145 = destash33(x, ____r37)
-  local ____id31 = ____r37
-  local __body21 = cut(____id31, 0)
-  setenv(__name5, {_stash = true, variable = true})
-  if some63(__body21) then
-    return join({"%local-function", __name5}, bind42(__x145, __body21))
+  local ____r18 = unstash({...})
+  local __name2 = destash33(name, ____r18)
+  local __x78 = destash33(x, ____r18)
+  local ____id15 = ____r18
+  local __body10 = cut(____id15, 0)
+  setenv(__name2, {_stash = true, variable = true})
+  if some63(__body10) then
+    return join({"%local-function", __name2}, bind42(__x78, __body10))
   else
-    return {"%local", __name5, __x145}
+    return {"%local", __name2, __x78}
   end
 end})
 setenv("define-global", {_stash = true, macro = function (name, x, ...)
-  local ____r39 = unstash({...})
-  local __name7 = destash33(name, ____r39)
-  local __x152 = destash33(x, ____r39)
-  local ____id33 = ____r39
-  local __body23 = cut(____id33, 0)
-  setenv(__name7, {_stash = true, toplevel = true, variable = true})
-  if some63(__body23) then
-    return join({"%global-function", __name7}, bind42(__x152, __body23))
+  local ____r19 = unstash({...})
+  local __name3 = destash33(name, ____r19)
+  local __x82 = destash33(x, ____r19)
+  local ____id16 = ____r19
+  local __body11 = cut(____id16, 0)
+  setenv(__name3, {_stash = true, toplevel = true, variable = true})
+  if some63(__body11) then
+    return join({"%global-function", __name3}, bind42(__x82, __body11))
   else
-    return {"set", __name7, __x152}
+    return {"set", __name3, __x82}
   end
 end})
 setenv("with-frame", {_stash = true, macro = function (...)
-  local __body25 = unstash({...})
-  local __x163 = unique("x")
-  return {"do", {"add", "environment", {"obj"}}, {"with", __x163, join({"do"}, __body25), {"drop", "environment"}}}
+  local __body12 = unstash({...})
+  local __x86 = unique("x")
+  return {"do", {"add", "environment", {"obj"}}, {"with", __x86, join({"do"}, __body12), {"drop", "environment"}}}
 end})
-setenv("with-bindings", {_stash = true, macro = function (__x175, ...)
-  local ____id36 = __x175
-  local __names1 = ____id36[1]
-  local ____r41 = unstash({...})
-  local ____x175 = destash33(__x175, ____r41)
-  local ____id37 = ____r41
-  local __body27 = cut(____id37, 0)
-  local __x177 = unique("x")
-  local ____x180 = {"setenv", __x177}
-  ____x180.variable = true
-  return join({"with-frame", {"each", __x177, __names1, ____x180}}, __body27)
+setenv("with-bindings", {_stash = true, macro = function (__x93, ...)
+  local ____id17 = __x93
+  local __names = ____id17[1]
+  local ____r20 = unstash({...})
+  local ____x93 = destash33(__x93, ____r20)
+  local ____id18 = ____r20
+  local __body13 = cut(____id18, 0)
+  local __x95 = unique("x")
+  local ____x98 = {"setenv", __x95}
+  ____x98.variable = true
+  return join({"with-frame", {"each", __x95, __names, ____x98}}, __body13)
 end})
 setenv("let-macro", {_stash = true, macro = function (definitions, ...)
-  local ____r44 = unstash({...})
-  local __definitions1 = destash33(definitions, ____r44)
-  local ____id39 = ____r44
-  local __body29 = cut(____id39, 0)
+  local ____r21 = unstash({...})
+  local __definitions = destash33(definitions, ____r21)
+  local ____id19 = ____r21
+  local __body14 = cut(____id19, 0)
   add(environment, {})
   map(function (m)
-    return macroexpand(join({"define-macro"}, m))
-  end, __definitions1)
-  local ____x185 = join({"do"}, macroexpand(__body29))
+    return _eval(join({"define-macro"}, m))
+  end, __definitions)
+  local ____x100 = join({"do"}, macroexpand(__body14))
   drop(environment)
-  return ____x185
+  return ____x100
 end})
 setenv("let-symbol", {_stash = true, macro = function (expansions, ...)
-  local ____r48 = unstash({...})
-  local __expansions1 = destash33(expansions, ____r48)
-  local ____id42 = ____r48
-  local __body31 = cut(____id42, 0)
+  local ____r23 = unstash({...})
+  local __expansions = destash33(expansions, ____r23)
+  local ____id20 = ____r23
+  local __body15 = cut(____id20, 0)
   add(environment, {})
-  map(function (__x194)
-    local ____id43 = __x194
-    local __name9 = ____id43[1]
-    local __exp1 = ____id43[2]
-    return macroexpand({"define-symbol", __name9, __exp1})
-  end, pair(__expansions1))
-  local ____x193 = join({"do"}, macroexpand(__body31))
+  map(function (__x105)
+    local ____id21 = __x105
+    local __name4 = ____id21[1]
+    local __exp = ____id21[2]
+    return macroexpand({"define-symbol", __name4, __exp})
+  end, pair(__expansions))
+  local ____x104 = join({"do"}, macroexpand(__body15))
   drop(environment)
-  return ____x193
+  return ____x104
 end})
 setenv("let-unique", {_stash = true, macro = function (names, ...)
-  local ____r52 = unstash({...})
-  local __names3 = destash33(names, ____r52)
-  local ____id45 = ____r52
-  local __body33 = cut(____id45, 0)
-  local __bs3 = map(function (n)
+  local ____r25 = unstash({...})
+  local __names1 = destash33(names, ____r25)
+  local ____id22 = ____r25
+  local __body16 = cut(____id22, 0)
+  local __bs11 = map(function (n)
     return {n, {"unique", {"quote", n}}}
-  end, __names3)
-  return join({"let", apply(join, __bs3)}, __body33)
+  end, __names1)
+  return join({"let", apply(join, __bs11)}, __body16)
 end})
 setenv("fn", {_stash = true, macro = function (args, ...)
-  local ____r55 = unstash({...})
-  local __args7 = destash33(args, ____r55)
-  local ____id47 = ____r55
-  local __body35 = cut(____id47, 0)
-  return join({"%function"}, bind42(__args7, __body35))
+  local ____r27 = unstash({...})
+  local __args3 = destash33(args, ____r27)
+  local ____id23 = ____r27
+  local __body17 = cut(____id23, 0)
+  return join({"%function"}, bind42(__args3, __body17))
 end})
 setenv("apply", {_stash = true, macro = function (f, ...)
-  local ____r57 = unstash({...})
-  local __f1 = destash33(f, ____r57)
-  local ____id49 = ____r57
-  local __args9 = cut(____id49, 0)
-  if _35(__args9) > 1 then
-    return {"%call", "apply", __f1, {"join", join({"list"}, almost(__args9)), last(__args9)}}
+  local ____r28 = unstash({...})
+  local __f = destash33(f, ____r28)
+  local ____id24 = ____r28
+  local __args4 = cut(____id24, 0)
+  if _35(__args4) > 1 then
+    return {"%call", "apply", __f, {"join", join({"list"}, almost(__args4)), last(__args4)}}
   else
-    return join({"%call", "apply", __f1}, __args9)
+    return join({"%call", "apply", __f}, __args4)
   end
 end})
 setenv("guard", {_stash = true, macro = function (expr)
   if target == "js" then
     return {{"fn", join(), {"%try", {"list", true, expr}}}}
   else
-    local ____x251 = {"obj"}
-    ____x251.stack = {{"get", "debug", {"quote", "traceback"}}}
-    ____x251.message = {"if", {"string?", "m"}, {"clip", "m", {"+", {"search", "m", "\": \""}, 2}}, {"nil?", "m"}, "\"\"", {"str", "m"}}
-    return {"list", {"xpcall", {"fn", join(), expr}, {"fn", {"m"}, {"if", {"obj?", "m"}, "m", ____x251}}}}
+    local ____x131 = {"obj"}
+    ____x131.stack = {"debug", {".traceback"}}
+    ____x131.message = {"if", {"string?", "m"}, {"clip", "m", {"+", {"search", "m", "\": \""}, 2}}, {"nil?", "m"}, "\"\"", {"str", "m"}}
+    return {"list", {"xpcall", {"fn", join(), expr}, {"fn", {"m"}, {"if", {"obj?", "m"}, "m", ____x131}}}}
   end
 end})
 setenv("each", {_stash = true, macro = function (x, t, ...)
-  local ____r61 = unstash({...})
-  local __x277 = destash33(x, ____r61)
-  local __t1 = destash33(t, ____r61)
-  local ____id52 = ____r61
-  local __body37 = cut(____id52, 0)
-  local __o3 = unique("o")
-  local __n3 = unique("n")
-  local __i3 = unique("i")
-  local __e8
-  if atom63(__x277) then
-    __e8 = {__i3, __x277}
+  local ____r30 = unstash({...})
+  local __x142 = destash33(x, ____r30)
+  local __t = destash33(t, ____r30)
+  local ____id25 = ____r30
+  local __body18 = cut(____id25, 0)
+  local __o1 = unique("o")
+  local __n1 = unique("n")
+  local __i1 = unique("i")
+  local __e
+  if atom63(__x142) then
+    __e = {__i1, __x142}
   else
-    local __e9
-    if _35(__x277) > 1 then
-      __e9 = __x277
+    local __e1
+    if _35(__x142) > 1 then
+      __e1 = __x142
     else
-      __e9 = {__i3, hd(__x277)}
+      __e1 = {__i1, hd(__x142)}
     end
-    __e8 = __e9
+    __e = __e1
   end
-  local ____id53 = __e8
-  local __k4 = ____id53[1]
-  local __v7 = ____id53[2]
-  local __e10
+  local ____id26 = __e
+  local __k1 = ____id26[1]
+  local __v3 = ____id26[2]
+  local __e2
   if target == "lua" then
-    __e10 = __body37
+    __e2 = __body18
   else
-    __e10 = {join({"let", __k4, {"if", {"numeric?", __k4}, {"parseInt", __k4}, __k4}}, __body37)}
+    __e2 = {join({"let", __k1, {"if", {"numeric?", __k1}, {"parseInt", __k1}, __k1}}, __body18)}
   end
-  return {"let", {__o3, __t1, __k4, "nil"}, {"%for", __o3, __k4, join({"let", {__v7, {"get", __o3, __k4}}}, __e10)}}
+  return {"let", {__o1, __t, __k1, "nil"}, {"%for", __o1, __k1, join({"let", {__v3, {"get", __o1, __k1}}}, __e2)}}
 end})
 setenv("for", {_stash = true, macro = function (i, to, ...)
-  local ____r63 = unstash({...})
-  local __i5 = destash33(i, ____r63)
-  local __to1 = destash33(to, ____r63)
-  local ____id55 = ____r63
-  local __body39 = cut(____id55, 0)
-  return {"let", __i5, 0, join({"while", {"<", __i5, __to1}}, __body39, {{"inc", __i5}})}
+  local ____r31 = unstash({...})
+  local __i2 = destash33(i, ____r31)
+  local __to = destash33(to, ____r31)
+  local ____id27 = ____r31
+  local __body19 = cut(____id27, 0)
+  return {"let", __i2, 0, join({"while", {"<", __i2, __to}}, __body19, {{"inc", __i2}})}
 end})
 setenv("step", {_stash = true, macro = function (v, t, ...)
-  local ____r65 = unstash({...})
-  local __v9 = destash33(v, ____r65)
-  local __t3 = destash33(t, ____r65)
-  local ____id57 = ____r65
-  local __body41 = cut(____id57, 0)
-  local __x311 = unique("x")
-  local __i7 = unique("i")
-  return {"let", {__x311, __t3}, {"for", __i7, {"#", __x311}, join({"let", {__v9, {"at", __x311, __i7}}}, __body41)}}
+  local ____r32 = unstash({...})
+  local __v4 = destash33(v, ____r32)
+  local __t1 = destash33(t, ____r32)
+  local ____id28 = ____r32
+  local __body20 = cut(____id28, 0)
+  local __x163 = unique("x")
+  local __i3 = unique("i")
+  return {"let", {__x163, __t1}, {"for", __i3, {"#", __x163}, join({"let", {__v4, {"at", __x163, __i3}}}, __body20)}}
 end})
 setenv("set-of", {_stash = true, macro = function (...)
-  local __xs1 = unstash({...})
-  local __l3 = {}
-  local ____o5 = __xs1
-  local ____i9 = nil
-  for ____i9 in next, ____o5 do
-    local __x322 = ____o5[____i9]
-    __l3[__x322] = true
+  local __xs = unstash({...})
+  local __l1 = {}
+  local ____o2 = __xs
+  local ____i4 = nil
+  for ____i4 in next, ____o2 do
+    local __x172 = ____o2[____i4]
+    __l1[__x172] = true
   end
-  return join({"obj"}, __l3)
+  return join({"obj"}, __l1)
 end})
 setenv("language", {_stash = true, macro = function ()
   return {"quote", target}
 end})
 setenv("target", {_stash = true, macro = function (...)
-  local __clauses3 = unstash({...})
-  return __clauses3[target]
+  local __clauses1 = unstash({...})
+  return __clauses1[target]
 end})
 setenv("join!", {_stash = true, macro = function (a, ...)
-  local ____r69 = unstash({...})
-  local __a3 = destash33(a, ____r69)
-  local ____id59 = ____r69
-  local __bs5 = cut(____id59, 0)
-  return {"set", __a3, join({"join", __a3}, __bs5)}
+  local ____r34 = unstash({...})
+  local __a1 = destash33(a, ____r34)
+  local ____id29 = ____r34
+  local __bs21 = cut(____id29, 0)
+  return {"set", __a1, join({"join", __a1}, __bs21)}
 end})
 setenv("cat!", {_stash = true, macro = function (a, ...)
-  local ____r71 = unstash({...})
-  local __a5 = destash33(a, ____r71)
-  local ____id61 = ____r71
-  local __bs7 = cut(____id61, 0)
-  return {"set", __a5, join({"cat", __a5}, __bs7)}
+  local ____r35 = unstash({...})
+  local __a2 = destash33(a, ____r35)
+  local ____id30 = ____r35
+  local __bs3 = cut(____id30, 0)
+  return {"set", __a2, join({"cat", __a2}, __bs3)}
 end})
 setenv("inc", {_stash = true, macro = function (n, by)
-  local __e11
+  local __e3
   if nil63(by) then
-    __e11 = 1
+    __e3 = 1
   else
-    __e11 = by
+    __e3 = by
   end
-  return {"set", n, {"+", n, __e11}}
+  return {"set", n, {"+", n, __e3}}
 end})
 setenv("dec", {_stash = true, macro = function (n, by)
-  local __e12
+  local __e4
   if nil63(by) then
-    __e12 = 1
+    __e4 = 1
   else
-    __e12 = by
+    __e4 = by
   end
-  return {"set", n, {"-", n, __e12}}
+  return {"set", n, {"-", n, __e4}}
 end})
 setenv("with-indent", {_stash = true, macro = function (form)
-  local __x350 = unique("x")
-  return {"do", {"inc", "indent-level"}, {"with", __x350, form, {"dec", "indent-level"}}}
+  local __x186 = unique("x")
+  return {"do", {"inc", "indent-level"}, {"with", __x186, form, {"dec", "indent-level"}}}
 end})
 setenv("export", {_stash = true, macro = function (...)
-  local __names5 = unstash({...})
+  local __names2 = unstash({...})
   if target == "js" then
     return join({"do"}, map(function (k)
-      return {"set", {"get", "exports", {"quote", k}}, k}
-    end, __names5))
+      return {"set", {"exports", "." .. k}, k}
+    end, __names2))
   else
-    local __x367 = {}
-    local ____o7 = __names5
-    local ____i11 = nil
-    for ____i11 in next, ____o7 do
-      local __k6 = ____o7[____i11]
-      __x367[__k6] = __k6
+    local __x195 = {}
+    local ____o3 = __names2
+    local ____i5 = nil
+    for ____i5 in next, ____o3 do
+      local __k2 = ____o3[____i5]
+      local __k3 = compileId(__k2)
+      __x195[__k3] = __k3
     end
     return {"return", join({"%object"}, mapo(function (x)
       return x
-    end, __x367))}
+    end, __x195))}
   end
 end})
 setenv("when-compiling", {_stash = true, macro = function (...)
-  local __body43 = unstash({...})
-  return _eval(join({"do"}, __body43))
+  local __body21 = unstash({...})
+  return _eval(join({"do"}, __body21))
+end})
+setenv("during-compilation", {_stash = true, macro = function (...)
+  local __body22 = unstash({...})
+  local __form2 = join({"do"}, __body22)
+  _eval(__form2)
+  return __form2
 end})
 local reader = require("reader")
 local compiler = require("compiler")
 local system = require("system")
-local function eval_print(form)
+local function evalPrint(form)
   local ____id = {xpcall(function ()
     return compiler["eval"](form)
   end, function (m)
@@ -1097,16 +1123,16 @@ local function eval_print(form)
   end
 end
 local function rep(s)
-  return eval_print(reader["read-string"](s))
+  return evalPrint(reader.readString(s))
 end
 local function repl()
   local __buf = ""
   local function rep1(s)
     __buf = __buf .. s
     local __more = {}
-    local __form = reader["read-string"](__buf, __more)
+    local __form = reader.readString(__buf, __more)
     if not( __form == __more) then
-      eval_print(__form)
+      evalPrint(__form)
       __buf = ""
       return system.write("> ")
     end
@@ -1121,27 +1147,27 @@ local function repl()
     end
   end
 end
-function compile_file(path)
-  local __s1 = reader.stream(system["read-file"](path))
-  local __body = reader["read-all"](__s1)
+function compileFile(path)
+  local __s1 = reader.stream(system.readFile(path))
+  local __body = reader.readAll(__s1)
   local __form1 = compiler.expand(join({"do"}, __body))
   return compiler.compile(__form1, {_stash = true, stmt = true})
 end
 function _load(path)
   local __previous = target
   target = "lua"
-  local __code = compile_file(path)
+  local __code = compileFile(path)
   target = __previous
   return compiler.run(__code)
 end
-local function script_file63(path)
+local function scriptFile63(path)
   return not( "-" == char(path, 0) or ".js" == clip(path, _35(path) - 3) or ".lua" == clip(path, _35(path) - 4))
 end
-local function run_file(path)
-  if script_file63(path) then
+local function runFile(path)
+  if scriptFile63(path) then
     return _load(path)
   else
-    return compiler.run(system["read-file"](path))
+    return compiler.run(system.readFile(path))
   end
 end
 local function usage()
@@ -1157,7 +1183,7 @@ local function usage()
 end
 local function main()
   local __arg = hd(system.argv)
-  if __arg and script_file63(__arg) then
+  if __arg and scriptFile63(__arg) then
     return _load(__arg)
   else
     if __arg == "-h" or __arg == "--help" then
@@ -1205,7 +1231,7 @@ local function main()
       local ____i1 = 0
       while ____i1 < _35(____x2) do
         local __file = ____x2[____i1 + 1]
-        run_file(__file)
+        runFile(__file)
         ____i1 = ____i1 + 1
       end
       if nil63(__input) then
@@ -1218,11 +1244,11 @@ local function main()
         if __target1 then
           target = __target1
         end
-        local __code1 = compile_file(__input)
+        local __code1 = compileFile(__input)
         if nil63(__output) or __output == "-" then
           return print(__code1)
         else
-          return system["write-file"](__output, __code1)
+          return system.writeFile(__output, __code1)
         end
       end
     end

--- a/bin/reader.js
+++ b/bin/reader.js
@@ -3,7 +3,7 @@ var whitespace = {" ": true, "\t": true, "\r": true, "\n": true};
 var stream = function (str, more) {
   return {pos: 0, string: str, len: _35(str), more: more};
 };
-var peek_char = function (s) {
+var peekChar = function (s) {
   var ____id = s;
   var __pos = ____id.pos;
   var __len = ____id.len;
@@ -12,27 +12,27 @@ var peek_char = function (s) {
     return char(__string, __pos);
   }
 };
-var read_char = function (s) {
-  var __c = peek_char(s);
+var readChar = function (s) {
+  var __c = peekChar(s);
   if (__c) {
     s.pos = s.pos + 1;
     return __c;
   }
 };
-var skip_non_code = function (s) {
+var skipNonCode = function (s) {
   while (true) {
-    var __c1 = peek_char(s);
+    var __c1 = peekChar(s);
     if (nil63(__c1)) {
       break;
     } else {
       if (whitespace[__c1]) {
-        read_char(s);
+        readChar(s);
       } else {
         if (__c1 === ";") {
           while (__c1 && !( __c1 === "\n")) {
-            __c1 = read_char(s);
+            __c1 = readChar(s);
           }
-          skip_non_code(s);
+          skipNonCode(s);
         } else {
           break;
         }
@@ -40,18 +40,18 @@ var skip_non_code = function (s) {
     }
   }
 };
-var read_table = {};
+var readTable = {};
 var eof = {};
 var read = function (s) {
-  skip_non_code(s);
-  var __c2 = peek_char(s);
+  skipNonCode(s);
+  var __c2 = peekChar(s);
   if (is63(__c2)) {
-    return (read_table[__c2] || read_table[""])(s);
+    return (readTable[__c2] || readTable[""])(s);
   } else {
     return eof;
   }
 };
-var read_all = function (s) {
+var readAll = function (s) {
   var __l = [];
   while (true) {
     var __form = read(s);
@@ -62,7 +62,7 @@ var read_all = function (s) {
   }
   return __l;
 };
-read_string = function (str, more) {
+readString = function (str, more) {
   var __x = read(stream(str, more));
   if (!( __x === eof)) {
     return __x;
@@ -96,7 +96,7 @@ var wrap = function (s, x) {
     return [x, __y];
   }
 };
-var hex_prefix63 = function (str) {
+var hexPrefix63 = function (str) {
   var __e1;
   if (code(str, 0) === 45) {
     __e1 = 1;
@@ -115,11 +115,11 @@ var hex_prefix63 = function (str) {
   }
   return __e2;
 };
-var maybe_number = function (str) {
-  if (hex_prefix63(str)) {
+var maybeNumber = function (str) {
+  if (hexPrefix63(str)) {
     return parseInt(str, 16);
   } else {
-    if (number_code63(code(str, edge(str)))) {
+    if (numberCode63(code(str, edge(str)))) {
       return number(str);
     }
   }
@@ -127,12 +127,12 @@ var maybe_number = function (str) {
 var real63 = function (x) {
   return number63(x) && ! nan63(x) && ! inf63(x);
 };
-read_table[""] = function (s) {
+readTable[""] = function (s) {
   var __str = "";
   while (true) {
-    var __c3 = peek_char(s);
+    var __c3 = peekChar(s);
     if (__c3 && (! whitespace[__c3] && ! delimiters[__c3])) {
-      __str = __str + read_char(s);
+      __str = __str + readChar(s);
     } else {
       break;
     }
@@ -143,7 +143,7 @@ read_table[""] = function (s) {
     if (__str === "false") {
       return false;
     } else {
-      var __n1 = maybe_number(__str);
+      var __n1 = maybeNumber(__str);
       if (real63(__n1)) {
         return __n1;
       } else {
@@ -152,15 +152,15 @@ read_table[""] = function (s) {
     }
   }
 };
-read_table["("] = function (s) {
-  read_char(s);
+readTable["("] = function (s) {
+  readChar(s);
   var __r16 = undefined;
   var __l1 = [];
   while (nil63(__r16)) {
-    skip_non_code(s);
-    var __c4 = peek_char(s);
+    skipNonCode(s);
+    var __c4 = peekChar(s);
     if (__c4 === ")") {
-      read_char(s);
+      readChar(s);
       __r16 = __l1;
     } else {
       if (nil63(__c4)) {
@@ -183,60 +183,60 @@ read_table["("] = function (s) {
   }
   return __r16;
 };
-read_table[")"] = function (s) {
+readTable[")"] = function (s) {
   throw new Error("Unexpected ) at " + s.pos);
 };
-read_table["\""] = function (s) {
-  read_char(s);
+readTable["\""] = function (s) {
+  readChar(s);
   var __r19 = undefined;
   var __str1 = "\"";
   while (nil63(__r19)) {
-    var __c5 = peek_char(s);
+    var __c5 = peekChar(s);
     if (__c5 === "\"") {
-      __r19 = __str1 + read_char(s);
+      __r19 = __str1 + readChar(s);
     } else {
       if (nil63(__c5)) {
         __r19 = expected(s, "\"");
       } else {
         if (__c5 === "\\") {
-          __str1 = __str1 + read_char(s);
+          __str1 = __str1 + readChar(s);
         }
-        __str1 = __str1 + read_char(s);
+        __str1 = __str1 + readChar(s);
       }
     }
   }
   return __r19;
 };
-read_table["|"] = function (s) {
-  read_char(s);
+readTable["|"] = function (s) {
+  readChar(s);
   var __r21 = undefined;
   var __str2 = "|";
   while (nil63(__r21)) {
-    var __c6 = peek_char(s);
+    var __c6 = peekChar(s);
     if (__c6 === "|") {
-      __r21 = __str2 + read_char(s);
+      __r21 = __str2 + readChar(s);
     } else {
       if (nil63(__c6)) {
         __r21 = expected(s, "|");
       } else {
-        __str2 = __str2 + read_char(s);
+        __str2 = __str2 + readChar(s);
       }
     }
   }
   return __r21;
 };
-read_table["'"] = function (s) {
-  read_char(s);
+readTable["'"] = function (s) {
+  readChar(s);
   return wrap(s, "quote");
 };
-read_table["`"] = function (s) {
-  read_char(s);
+readTable["`"] = function (s) {
+  readChar(s);
   return wrap(s, "quasiquote");
 };
-read_table[","] = function (s) {
-  read_char(s);
-  if (peek_char(s) === "@") {
-    read_char(s);
+readTable[","] = function (s) {
+  readChar(s);
+  if (peekChar(s) === "@") {
+    readChar(s);
     return wrap(s, "unquote-splicing");
   } else {
     return wrap(s, "unquote");
@@ -244,6 +244,6 @@ read_table[","] = function (s) {
 };
 exports.stream = stream;
 exports.read = read;
-exports["read-all"] = read_all;
-exports["read-string"] = read_string;
-exports["read-table"] = read_table;
+exports.readAll = readAll;
+exports.readString = readString;
+exports.readTable = readTable;

--- a/bin/reader.lua
+++ b/bin/reader.lua
@@ -3,7 +3,7 @@ local whitespace = {[" "] = true, ["\t"] = true, ["\r"] = true, ["\n"] = true}
 local function stream(str, more)
   return {pos = 0, string = str, len = _35(str), more = more}
 end
-local function peek_char(s)
+local function peekChar(s)
   local ____id = s
   local __pos = ____id.pos
   local __len = ____id.len
@@ -12,27 +12,27 @@ local function peek_char(s)
     return char(__string, __pos)
   end
 end
-local function read_char(s)
-  local __c = peek_char(s)
+local function readChar(s)
+  local __c = peekChar(s)
   if __c then
     s.pos = s.pos + 1
     return __c
   end
 end
-local function skip_non_code(s)
+local function skipNonCode(s)
   while true do
-    local __c1 = peek_char(s)
+    local __c1 = peekChar(s)
     if nil63(__c1) then
       break
     else
       if whitespace[__c1] then
-        read_char(s)
+        readChar(s)
       else
         if __c1 == ";" then
           while __c1 and not( __c1 == "\n") do
-            __c1 = read_char(s)
+            __c1 = readChar(s)
           end
-          skip_non_code(s)
+          skipNonCode(s)
         else
           break
         end
@@ -40,18 +40,18 @@ local function skip_non_code(s)
     end
   end
 end
-local read_table = {}
+local readTable = {}
 local eof = {}
 local function read(s)
-  skip_non_code(s)
-  local __c2 = peek_char(s)
+  skipNonCode(s)
+  local __c2 = peekChar(s)
   if is63(__c2) then
-    return (read_table[__c2] or read_table[""])(s)
+    return (readTable[__c2] or readTable[""])(s)
   else
     return eof
   end
 end
-local function read_all(s)
+local function readAll(s)
   local __l = {}
   while true do
     local __form = read(s)
@@ -62,7 +62,7 @@ local function read_all(s)
   end
   return __l
 end
-function read_string(str, more)
+function readString(str, more)
   local __x = read(stream(str, more))
   if not( __x == eof) then
     return __x
@@ -96,7 +96,7 @@ local function wrap(s, x)
     return {x, __y}
   end
 end
-local function hex_prefix63(str)
+local function hexPrefix63(str)
   local __e1
   if code(str, 0) == 45 then
     __e1 = 1
@@ -115,11 +115,11 @@ local function hex_prefix63(str)
   end
   return __e2
 end
-local function maybe_number(str)
-  if hex_prefix63(str) then
+local function maybeNumber(str)
+  if hexPrefix63(str) then
     return tonumber(str)
   else
-    if number_code63(code(str, edge(str))) then
+    if numberCode63(code(str, edge(str))) then
       return number(str)
     end
   end
@@ -127,12 +127,12 @@ end
 local function real63(x)
   return number63(x) and not nan63(x) and not inf63(x)
 end
-read_table[""] = function (s)
+readTable[""] = function (s)
   local __str = ""
   while true do
-    local __c3 = peek_char(s)
+    local __c3 = peekChar(s)
     if __c3 and (not whitespace[__c3] and not delimiters[__c3]) then
-      __str = __str .. read_char(s)
+      __str = __str .. readChar(s)
     else
       break
     end
@@ -143,7 +143,7 @@ read_table[""] = function (s)
     if __str == "false" then
       return false
     else
-      local __n1 = maybe_number(__str)
+      local __n1 = maybeNumber(__str)
       if real63(__n1) then
         return __n1
       else
@@ -152,15 +152,15 @@ read_table[""] = function (s)
     end
   end
 end
-read_table["("] = function (s)
-  read_char(s)
+readTable["("] = function (s)
+  readChar(s)
   local __r16 = nil
   local __l1 = {}
   while nil63(__r16) do
-    skip_non_code(s)
-    local __c4 = peek_char(s)
+    skipNonCode(s)
+    local __c4 = peekChar(s)
     if __c4 == ")" then
-      read_char(s)
+      readChar(s)
       __r16 = __l1
     else
       if nil63(__c4) then
@@ -183,63 +183,63 @@ read_table["("] = function (s)
   end
   return __r16
 end
-read_table[")"] = function (s)
+readTable[")"] = function (s)
   error("Unexpected ) at " .. s.pos)
 end
-read_table["\""] = function (s)
-  read_char(s)
+readTable["\""] = function (s)
+  readChar(s)
   local __r19 = nil
   local __str1 = "\""
   while nil63(__r19) do
-    local __c5 = peek_char(s)
+    local __c5 = peekChar(s)
     if __c5 == "\"" then
-      __r19 = __str1 .. read_char(s)
+      __r19 = __str1 .. readChar(s)
     else
       if nil63(__c5) then
         __r19 = expected(s, "\"")
       else
         if __c5 == "\\" then
-          __str1 = __str1 .. read_char(s)
+          __str1 = __str1 .. readChar(s)
         end
-        __str1 = __str1 .. read_char(s)
+        __str1 = __str1 .. readChar(s)
       end
     end
   end
   return __r19
 end
-read_table["|"] = function (s)
-  read_char(s)
+readTable["|"] = function (s)
+  readChar(s)
   local __r21 = nil
   local __str2 = "|"
   while nil63(__r21) do
-    local __c6 = peek_char(s)
+    local __c6 = peekChar(s)
     if __c6 == "|" then
-      __r21 = __str2 .. read_char(s)
+      __r21 = __str2 .. readChar(s)
     else
       if nil63(__c6) then
         __r21 = expected(s, "|")
       else
-        __str2 = __str2 .. read_char(s)
+        __str2 = __str2 .. readChar(s)
       end
     end
   end
   return __r21
 end
-read_table["'"] = function (s)
-  read_char(s)
+readTable["'"] = function (s)
+  readChar(s)
   return wrap(s, "quote")
 end
-read_table["`"] = function (s)
-  read_char(s)
+readTable["`"] = function (s)
+  readChar(s)
   return wrap(s, "quasiquote")
 end
-read_table[","] = function (s)
-  read_char(s)
-  if peek_char(s) == "@" then
-    read_char(s)
+readTable[","] = function (s)
+  readChar(s)
+  if peekChar(s) == "@" then
+    readChar(s)
     return wrap(s, "unquote-splicing")
   else
     return wrap(s, "unquote")
   end
 end
-return {stream = stream, read = read, ["read-all"] = read_all, ["read-string"] = read_string, ["read-table"] = read_table}
+return {stream = stream, read = read, readAll = readAll, readString = readString, readTable = readTable}

--- a/bin/system.js
+++ b/bin/system.js
@@ -1,30 +1,29 @@
 var fs = require("fs");
 var child_process = require("child_process");
-var read_file = function (path) {
+var readFile = function (path) {
   return fs.readFileSync(path, "utf8");
 };
-var write_file = function (path, data) {
+var writeFile = function (path, data) {
   return fs.writeFileSync(path, data, "utf8");
 };
-var file_exists63 = function (path) {
+var fileExists63 = function (path) {
   return fs.existsSync(path, "utf8") && fs.statSync(path).isFile();
 };
-var directory_exists63 = function (path) {
+var directoryExists63 = function (path) {
   return fs.existsSync(path, "utf8") && fs.statSync(path).isDirectory();
 };
-var path_separator = require("path").sep;
-var path_join = function () {
+var pathSeparator = require("path").sep;
+var pathJoin = function () {
   var __parts = unstash(Array.prototype.slice.call(arguments, 0));
   return reduce(function (x, y) {
-    return x + path_separator + y;
+    return x + pathSeparator + y;
   }, __parts) || "";
 };
-var get_environment_variable = function (name) {
+var getEnvironmentVariable = function (name) {
   return process.env[name];
 };
 var write = function (x) {
-  var __out = process.stdout;
-  return __out.write(x);
+  return process.stdout.write(x);
 };
 var exit = function (code) {
   return process.exit(code);
@@ -37,13 +36,13 @@ var reload = function (module) {
 var run = function (command) {
   return child_process.execSync(command).toString();
 };
-exports["read-file"] = read_file;
-exports["write-file"] = write_file;
-exports["file-exists?"] = file_exists63;
-exports["directory-exists?"] = directory_exists63;
-exports["path-separator"] = path_separator;
-exports["path-join"] = path_join;
-exports["get-environment-variable"] = get_environment_variable;
+exports.readFile = readFile;
+exports.writeFile = writeFile;
+exports.fileExists63 = fileExists63;
+exports.directoryExists63 = directoryExists63;
+exports.pathSeparator = pathSeparator;
+exports.pathJoin = pathJoin;
+exports.getEnvironmentVariable = getEnvironmentVariable;
 exports.write = write;
 exports.exit = exit;
 exports.argv = argv;

--- a/bin/system.lua
+++ b/bin/system.lua
@@ -1,4 +1,4 @@
-local function call_with_file(f, path, mode)
+local function callWithFile(f, path, mode)
   local h,e = io.open(path, mode)
   if not h then
     error(e)
@@ -7,17 +7,17 @@ local function call_with_file(f, path, mode)
   h.close(h)
   return __x
 end
-local function read_file(path)
-  return call_with_file(function (f)
+local function readFile(path)
+  return callWithFile(function (f)
     return f.read(f, "*a")
   end, path)
 end
-local function write_file(path, data)
-  return call_with_file(function (f)
+local function writeFile(path, data)
+  return callWithFile(function (f)
     return f.write(f, data)
   end, path, "w")
 end
-local function file_exists63(path)
+local function fileExists63(path)
   local __f = io.open(path)
   local __id = is63(__f)
   local __e
@@ -30,7 +30,7 @@ local function file_exists63(path)
   end
   return __e
 end
-local function directory_exists63(path)
+local function directoryExists63(path)
   local __f1 = io.open(path)
   local __id1 = is63(__f1)
   local __e1
@@ -43,14 +43,14 @@ local function directory_exists63(path)
   end
   return __e1
 end
-local path_separator = char(_G.package.config, 0)
-local function path_join(...)
+local pathSeparator = char(_G.package.config, 0)
+local function pathJoin(...)
   local __parts = unstash({...})
   return reduce(function (x, y)
-    return x .. path_separator .. y
+    return x .. pathSeparator .. y
   end, __parts) or ""
 end
-local function get_environment_variable(name)
+local function getEnvironmentVariable(name)
   return os.getenv(name)
 end
 local function write(x)
@@ -70,4 +70,4 @@ local function run(command)
   __f2.close(__f2)
   return __x2
 end
-return {["read-file"] = read_file, ["write-file"] = write_file, ["file-exists?"] = file_exists63, ["directory-exists?"] = directory_exists63, ["path-separator"] = path_separator, ["path-join"] = path_join, ["get-environment-variable"] = get_environment_variable, write = write, exit = exit, argv = argv, reload = reload, run = run}
+return {readFile = readFile, writeFile = writeFile, fileExists63 = fileExists63, directoryExists63 = directoryExists63, pathSeparator = pathSeparator, pathJoin = pathJoin, getEnvironmentVariable = getEnvironmentVariable, write = write, exit = exit, argv = argv, reload = reload, run = run}

--- a/compiler.l
+++ b/compiler.l
@@ -1,5 +1,3 @@
-(define reader (require 'reader))
-
 (define getenv (k p)
   (when (string? k)
     (let i (edge environment)
@@ -78,7 +76,7 @@
                 (join! bs (bind k x))))))))))
 
 (define-macro arguments% (from)
-  `((get (get (get Array 'prototype) 'slice) 'call) arguments ,from))
+  `(Array .prototype .slice .call arguments ,from))
 
 (define-global bind* (args body)
   (let args1 ()
@@ -240,8 +238,9 @@
       (and (obj? x)
            (= (hd x) '%brackets))))
 
-(define id (id raw?)
-  (let id1 (if (number-code? (code id 0)) "_" "")
+(define-global compile-id (id)
+  (let (id (camel-case id)
+        id1 (if (number-code? (code id 0)) "_" ""))
     (for i (# id)
       (let (c (char id i)
             n (code c)
@@ -252,17 +251,18 @@
                    (= i 0) (cat "_" n)
                  n))
         (cat! id1 c1)))
-    (if raw? id1
-        (reserved? id1)
-        (cat "_" id1)
-        id1)))
+    id1))
 
 (define-global valid-id? (x)
-  (and (some? x) (= x (id x))))
+  (and (some? x)
+       (= x (compile-id x))
+       (if (= target 'lua)
+           (not (reserved? x))
+          true)))
 
 (let (names (obj))
   (define-global unique (x)
-    (let x (id x)
+    (let x (compile-id x)
       (if (get names x)
           (let i (get names x)
             (inc (get names x))
@@ -351,7 +351,7 @@
                    c))))))
 
 (define-global accessor (x)
-  (let prop (id (clip x 1) true)
+  (let prop (compile-id (clip x 1))
     (if (valid-id? prop)
         (cat "." prop)
       (cat "[" (escape prop) "]"))))
@@ -362,7 +362,8 @@
       (= x "nil") "undefined"
       (id-literal? x) (inner x)
       (string-literal? x) (escape-newlines x)
-      (string? x) (id x)
+      (string? x) (let s (compile-id x)
+                    (if (reserved? s) (cat "_" s) s))
       (boolean? x) (if x "true" "false")
       (nan? x) "nan"
       (= x inf) "inf"
@@ -601,7 +602,7 @@
 (define-global expand (form)
   (lower (macroexpand form)))
 
-(target js: (set (get global 'require) |require|))
+(target js: (set (global .require) |require|))
 (target js: (define run |eval|))
 
 (target lua: (define load1 (or |loadstring| |load|)))

--- a/compiler.l
+++ b/compiler.l
@@ -232,7 +232,15 @@
       (and (> n 96) (< n 123)) ; a-z
       (= n 95)))               ; _
 
-(define id (id)
+(define-global accessor? (x)
+  (or (and (string? x)
+           (> (# x) 1)
+           (= (code x 0) (when-compiling (code "." 0)))
+           (not (= (code x 1) (when-compiling (code "." 0)))))
+      (and (obj? x)
+           (= (hd x) '%brackets))))
+
+(define id (id raw?)
   (let id1 (if (number-code? (code id 0)) "_" "")
     (for i (# id)
       (let (c (char id i)
@@ -244,7 +252,8 @@
                    (= i 0) (cat "_" n)
                  n))
         (cat! id1 c1)))
-    (if (reserved? id1)
+    (if raw? id1
+        (reserved? id1)
         (cat "_" id1)
         id1)))
 
@@ -310,12 +319,28 @@
 (define-global infix-operator? (x)
   (and (obj? x) (infix? (hd x))))
 
-(define compile-args (args)
-  (let (s "(" c "")
-    (step x args
-      (cat! s c (compile x))
-      (set c ", "))
-    (cat s ")")))
+(define-global compile-next (x args call?)
+  (if (none? args)
+      (if call? (cat x "()") x)
+    (cat x (compile-args args call?))))
+
+(define-global compile-args (args call?)
+  (let a (hd args)
+    (if (accessor? a)
+        (compile-next (compile a) (tl args) call?)
+        (and (obj? a) (accessor? (hd a)))
+        (let ((x rest: ys) a
+              s (compile-next (compile x) ys true))
+          (compile-next s (tl args) call?))
+      (let (s "" c "")
+        (for i (# args)
+          (let x (at args i)
+            (if (or (accessor? x)
+                    (and (obj? x) (accessor? (hd x))))
+                (return (compile-next (cat "(" s ")") (cut args i) call?))
+              (cat! s c (compile x)))
+            (set c ", ")))
+        (cat "(" s ")")))))
 
 (define escape-newlines (s)
   (with s1 ""
@@ -325,8 +350,15 @@
                      (= c "\r") "\\r"
                    c))))))
 
+(define-global accessor (x)
+  (let prop (id (clip x 1) true)
+    (if (valid-id? prop)
+        (cat "." prop)
+      (cat "[" (escape prop) "]"))))
+
 (define compile-atom (x)
-  (if (and (= x "nil") (= target 'lua)) x
+  (if (accessor? x) (accessor x)
+      (and (= x "nil") (= target 'lua)) x
       (= x "nil") "undefined"
       (id-literal? x) (inner x)
       (string-literal? x) (escape-newlines x)

--- a/macros.l
+++ b/macros.l
@@ -80,12 +80,12 @@
 
 (define-macro define-macro (name args rest: body)
   (let form `(setenv ',name macro: (fn ,args ,@body))
-    (eval form)
+    ; (eval form)
     form))
 
 (define-macro define-special (name args rest: body)
   (let form `(setenv ',name special: (fn ,args ,@body) ,@(keys body))
-    (eval form)
+    ; (eval form)
     form))
 
 (define-macro define-symbol (name expansion)
@@ -123,7 +123,7 @@
 (define-macro let-macro (definitions rest: body)
   (with-frame
     (map (fn (m)
-           (macroexpand `(define-macro ,@m)))
+           (eval `(define-macro ,@m)))
          definitions)
     `(do ,@(macroexpand body))))
 
@@ -156,7 +156,7 @@
              (fn () ,expr)
              (fn (m)
                (if (obj? m) m
-                 (obj stack: ((get debug 'traceback))
+                 (obj stack: (debug (.traceback))
                       message: (if (string? m) (clip m (+ (search m ": ") 2))
                                    (nil? m) ""
                                  (str m)))))))))
@@ -220,12 +220,17 @@
 (define-macro export names
   (if (= target 'js)
       `(do ,@(map (fn (k)
-                    `(set (get exports ',k) ,k))
+                    `(set (exports ,(cat "." k)) ,k))
                   names))
     (let x (obj)
       (each k names
-        (set (get x k) k))
+        (let k (compile-id k)
+          (set (get x k) k)))
       `(return (%object ,@(mapo (fn (x) x) x))))))
 
 (define-macro when-compiling body
   (eval `(do ,@body)))
+
+(define-macro during-compilation body
+  (with form `(do ,@body)
+    (eval form)))

--- a/macros.l
+++ b/macros.l
@@ -80,12 +80,12 @@
 
 (define-macro define-macro (name args rest: body)
   (let form `(setenv ',name macro: (fn ,args ,@body))
-    ; (eval form)
+    (eval form)
     form))
 
 (define-macro define-special (name args rest: body)
   (let form `(setenv ',name special: (fn ,args ,@body) ,@(keys body))
-    ; (eval form)
+    (eval form)
     form))
 
 (define-macro define-symbol (name expansion)
@@ -123,7 +123,7 @@
 (define-macro let-macro (definitions rest: body)
   (with-frame
     (map (fn (m)
-           (eval `(define-macro ,@m)))
+           (macroexpand `(define-macro ,@m)))
          definitions)
     `(do ,@(macroexpand body))))
 

--- a/main.l
+++ b/main.l
@@ -3,47 +3,47 @@
 (define system (require 'system))
 
 (define eval-print (form)
-  (let ((ok v) (guard ((get compiler 'eval) form)))
+  (let ((ok v) (guard (compiler .eval form)))
     (if (not ok)
         (target
-          js: (print (get v 'stack))
-          lua: (print (cat "error: " (get v 'message) "\n" (get v 'stack))))
+          js: (print (v .stack))
+          lua: (print (cat "error: " (v .message) "\n" (v .stack))))
         (is? v) (print (str v)))))
 
 (define rep (s)
-  (eval-print ((get reader 'read-string) s)))
+  (eval-print (reader .read-string s)))
 
 (define repl ()
   (let buf ""
     (define rep1 (s)
       (cat! buf s)
       (let (more ()
-            form ((get reader 'read-string) buf more))
+            form (reader .read-string buf more))
           (unless (= form more)
             (eval-print form)
             (set buf "")
-            ((get system 'write) "> ")))))
-  ((get system 'write) "> ")
+            (system .write "> ")))))
+  (system .write "> ")
   (target
-    js: (let in (get process 'stdin)
-          ((get in 'setEncoding) 'utf8)
-          ((get in 'on) 'data rep1))
+    js: (let in (process .stdin)
+          (in .set-encoding 'utf8)
+          (in .on 'data rep1))
     lua: (while true
-           (let s ((get io 'read))
+           (let s (io (.read))
              (if s (rep1 (cat s "\n")) (break))))))
 
 (define-global compile-file (path)
-  (let (s ((get reader 'stream) ((get system 'read-file) path))
-        body ((get reader 'read-all) s)
-        form ((get compiler 'expand) `(do ,@body)))
-    ((get compiler 'compile) form :stmt)))
+  (let (s (reader .stream (system .read-file path))
+        body (reader .read-all s)
+        form (compiler .expand `(do ,@body)))
+    (compiler .compile form :stmt)))
 
 (define-global load (path)
   (let previous target
     (set target (language))
     (let code (compile-file path)
       (set target previous)
-      ((get compiler 'run) code))))
+      (compiler .run code))))
 
 (define script-file? (path)
   (not (or (= "-" (char path 0))
@@ -53,7 +53,7 @@
 (define run-file (path)
   (if (script-file? path)
       (load path)
-    ((get compiler 'run) ((get system 'read-file) path))))
+    (compiler .run (system .read-file path))))
 
 (define usage ()
   (print "usage: lumen [<file> <arguments> | options <object files>]")
@@ -67,7 +67,7 @@
   (print " -e <expr>\tExpression to evaluate"))
 
 (define main ()
-  (let arg (hd (get system 'argv))
+  (let arg (hd (system .argv))
     (if (and arg (script-file? arg))
         (load arg)
         (or (= arg "-h")
@@ -78,7 +78,7 @@
             output nil
             target1 nil
             expr nil
-            argv (get system 'argv))
+            argv (system .argv))
         (for i (# argv)
           (let a (at argv i)
             (if (or (= a "-c") (= a "-o") (= a "-t") (= a "-e"))
@@ -98,6 +98,6 @@
               (let code (compile-file input)
                 (if (or (nil? output) (= output "-"))
                     (print code)
-                  ((get system 'write-file) output code)))))))))
+                  (system .write-file output code)))))))))
 
 (main)

--- a/runtime.l
+++ b/runtime.l
@@ -13,11 +13,11 @@
 (define-global either (x y) (if (is? x) x y))
 
 (define-global has? (l k)
-  (target js: ((get l 'hasOwnProperty) k)
+  (target js: (l .has-own-property k)
           lua: (is? (get l k))))
 
 (define-global # (x)
-  (target js: (or (get x 'length) 0) lua: |#x|))
+  (target js: (or (x .length) 0) lua: |#x|))
 
 (define-global none? (x) (= (# x) 0))
 (define-global some? (x) (> (# x) 0))
@@ -51,8 +51,8 @@
   (or (= n inf) (= n -inf)))
 
 (define-global clip (s from upto)
-  (target js: ((get s 'substring) from upto)
-          lua: ((get string 'sub) s (+ from 1) upto)))
+  (target js: (s .substring from upto)
+          lua: (string .sub s (+ from 1) upto)))
 
 (define-global cut (x from upto)
   (with l ()
@@ -83,12 +83,31 @@
 (define-global tl (l) (cut l 1))
 
 (define-global char (s n)
-  (target js: ((get s 'charAt) n) lua: (clip s n (+ n 1))))
+  (target js: (s .char-at n) lua: (clip s n (+ n 1))))
 
 (define-global code (s n)
   (target
-    js: ((get s 'charCodeAt) n)
-    lua: ((get string 'byte) s (if n (+ n 1)))))
+    js: (s .char-code-at n)
+    lua: (string .byte s (if n (+ n 1)))))
+
+(define-global from-code (n)
+  (target
+    js: (String .from-char-code n)
+    lua: (string .char n)))
+
+(define-global lowercase? (n)
+  (and (> n 96) (< n 123))) ; a-z
+
+(define-global camel-case (str)
+  (with s ""
+    (let n (# str)
+        (for i n
+          (let c (code str i)
+            (when (and (= c 45) ; "-"
+                       (lowercase? (or (code str (- i 1)) 0))
+                       (lowercase? (or (code str (+ i 1)) 0)))
+              (set c (- (code str (inc i)) 32)))
+            (cat! s (from-code c)))))))
 
 (define-global string-literal? (x)
   (and (string? x) (= (char x 0) "\"")))
@@ -97,12 +116,12 @@
   (and (string? x) (= (char x 0) "|")))
 
 (define-global add (l x)
-  (target js: (do ((get l 'push) x) nil)
-          lua: ((get table 'insert) l x)))
+  (target js: (do (l .push x) nil)
+          lua: (table .insert l x)))
 
 (define-global drop (l)
-  (target js: ((get l 'pop))
-          lua: ((get table 'remove) l)))
+  (target js: (l (.pop))
+          lua: (table .remove l)))
 
 (define-global last (l)
   (at l (edge l)))
@@ -152,8 +171,8 @@
 
 (define-global sort (l f)
   (target
-    lua: (do ((get table 'sort) l f) l)
-    js: ((get l 'sort) (when f (fn (a b) (if (f a b) -1 1))))))
+    lua: (do (table .sort l f) l)
+    js: (l .sort (when f (fn (a b) (if (f a b) -1 1))))))
 
 (define-global map (f x)
   (with t ()
@@ -210,10 +229,10 @@
 
 (define-global search (s pattern start)
   (target
-    js: (let i ((get s 'indexOf) pattern start)
+    js: (let i (s .index-of pattern start)
           (if (>= i 0) i))
     lua: (let (start (if start (+ start 1))
-               i ((get string 'find) s pattern start true))
+               i (string .find s pattern start true))
            (and i (- i 1)))))
 
 (define-global split (s sep)
@@ -275,7 +294,7 @@
         (return false))))
   (some? s))
 
-(target js: (define tostring (x) ((get x 'toString))))
+(target js: (define tostring (x) (x (.to-string))))
 
 (define-global escape (s)
   (let s1 "\""
@@ -320,11 +339,11 @@
       (cat s  ")"))))
 
 (target lua:
-  (define values (or unpack (get table 'unpack))))
+  (define values (or unpack (table .unpack))))
 
 (define-global apply (f args)
   (let args (stash args)
-    (target js: ((get f 'apply) f args)
+    (target js: (f .apply f args)
             lua: (f (values args)))))
 
 (define-global call (f rest: args)
@@ -342,27 +361,27 @@
 
 (target js:
   (define-global print (x)
-    ((get console 'log) x)))
+    (console .log x)))
 
 (define math (target js: Math lua: math))
 
-(define-global abs (get math 'abs))
-(define-global acos (get math 'acos))
-(define-global asin (get math 'asin))
-(define-global atan (get math 'atan))
-(define-global atan2 (get math 'atan2))
-(define-global ceil (get math 'ceil))
-(define-global cos (get math 'cos))
-(define-global floor (get math 'floor))
-(define-global log (get math 'log))
-(define-global log10 (get math 'log10))
-(define-global max (get math 'max))
-(define-global min (get math 'min))
-(define-global pow (get math 'pow))
-(define-global random (get math 'random))
-(define-global sin (get math 'sin))
-(define-global sinh (get math 'sinh))
-(define-global sqrt (get math 'sqrt))
-(define-global tan (get math 'tan))
-(define-global tanh (get math 'tanh))
-(define-global trunc (get math 'floor))
+(define-global abs (math .abs))
+(define-global acos (math .acos))
+(define-global asin (math .asin))
+(define-global atan (math .atan))
+(define-global atan2 (math .atan2))
+(define-global ceil (math .ceil))
+(define-global cos (math .cos))
+(define-global floor (math .floor))
+(define-global log (math .log))
+(define-global log10 (math .log10))
+(define-global max (math .max))
+(define-global min (math .min))
+(define-global pow (math .pow))
+(define-global random (math .random))
+(define-global sin (math .sin))
+(define-global sinh (math .sinh))
+(define-global sqrt (math .sqrt))
+(define-global tan (math .tan))
+(define-global tanh (math .tanh))
+(define-global trunc (math .floor))

--- a/system.l
+++ b/system.l
@@ -3,83 +3,82 @@
 
 (target lua:
   (define call-with-file (f path mode)
-    (let |h,e| ((get io 'open) path mode)
+    (let |h,e| (io .open path mode)
       (unless h
         (error e))
       (with x (f h)
-        ((get h 'close) h)))))
+        (h .close h)))))
 
 (define read-file (path)
   (target
-    js: ((get fs 'readFileSync) path 'utf8)
+    js: (fs .read-file-sync path 'utf8)
     lua: (call-with-file
-          (fn (f) ((get f 'read) f '*a))
+          (fn (f) (f .read f '*a))
           path)))
 
 (define write-file (path data)
   (target
-    js: ((get fs 'writeFileSync) path data 'utf8)
+    js: (fs .write-file-sync path data 'utf8)
     lua: (call-with-file
-          (fn (f) ((get f 'write) f data))
+          (fn (f) (f .write f data))
           path 'w)))
 
 (define file-exists? (path)
   (target
-    js: (and ((get fs 'existsSync) path 'utf8)
-             ((get ((get fs 'statSync) path) 'isFile)))
-    lua: (let f ((get io 'open) path)
+    js: (and (fs .exists-sync path 'utf8)
+             (fs .stat-sync path (.is-file)))
+    lua: (let f (io .open path)
            (and (is? f)
-                (with r (or (is? ((get f 'read) f 0))
-                            (= 0 ((get f 'seek) f 'end)))
-                  ((get f 'close) f))))))
+                (with r (or (is? (f .read f 0))
+                            (= 0 (f .seek f 'end)))
+                  (f .close f))))))
 
 (define directory-exists? (path)
   (target
-    js: (and ((get fs 'existsSync) path 'utf8)
-             ((get ((get fs 'statSync) path) 'isDirectory)))
-    lua: (let f ((get io 'open) path)
+    js: (and (fs .exists-sync path 'utf8)
+             (fs .stat-sync path (.is-directory)))
+    lua: (let f (io .open path)
            (and (is? f)
-                (with r (and (not ((get f 'read) f 0))
-                             (not (= 0 ((get f 'seek) f 'end))))
-                  ((get f 'close) f))))))
+                (with r (and (not (f .read f 0))
+                             (not (= 0 (f .seek f 'end))))
+                  (f .close f))))))
 
 (define path-separator
   (target
-    js: (get (require 'path) 'sep)
-    lua: (char (get (get _G 'package) 'config) 0)))
+    js: (require 'path .sep)
+    lua: (char (_G .package .config) 0)))
 
 (define path-join parts
   (or (reduce (fn (x y) (cat x path-separator y)) parts) ""))
 
 (define get-environment-variable (name)
   (target
-    js: (get (get process 'env) name)
-    lua: ((get os 'getenv) name)))
+    js: (get (process .env) name)
+    lua: (os .getenv name)))
 
 (define write (x)
-  (target js: (let out (get process 'stdout)
-                ((get out 'write) x))
-          lua: ((get io 'write) x)))
+  (target js: (process .stdout .write x)
+          lua: (io .write x)))
 
 (define exit (code)
-  (target js: ((get process 'exit) code)
-          lua: ((get os 'exit) code)))
+  (target js: (process .exit code)
+          lua: (os .exit code)))
 
 (define argv
-  (target js: (cut (get process 'argv) 2) lua: arg))
+  (target js: (cut (process .argv) 2) lua: arg))
 
 (define reload (module)
   (wipe (target
-          lua: (get (get package 'loaded) module)
-          js: (get (get require 'cache) ((get require 'resolve) module))))
+          lua: (get (package .loaded) module)
+          js: (get (require .cache) (require .resolve module))))
   (require module))
 
 (define run (command)
   (target
-    js: ((get ((get child_process 'execSync) command) 'toString))
-    lua: (let f ((get io 'popen) command)
-           (with x ((get f 'read) f '*all)
-             ((get f 'close) f)))))
+    js: (child_process .exec-sync command (.to-string))
+    lua: (let f (io .popen command)
+           (with x (f .read f '*all)
+             (f .close f)))))
 
 (export read-file
         write-file

--- a/test.l
+++ b/test.l
@@ -7,25 +7,24 @@
 (define reader (require 'reader))
 (define compiler (require 'compiler))
 
+(define-macro test (x msg)
+  `(if (not ,x)
+       (do (set failed (+ failed 1))
+           (return ,msg))
+     (inc passed)))
+
 (define equal? (a b)
   (if (atom? a) (= a b)
     (= (str a) (str b))))
 
-(during-compilation
-  (define-macro test (x msg)
-    `(if (not ,x)
-         (do (set failed (+ failed 1))
-             (return ,msg))
-       (inc passed)))
+(define-macro test= (a b)
+  (let-unique (x y)
+    `(let (,x ,a ,y ,b)
+       (test (equal? ,x ,y)
+             (cat "failed: expected " (str ,x) ", was " (str ,y))))))
 
-  (define-macro test= (a b)
-    (let-unique (x y)
-      `(let (,x ,a ,y ,b)
-         (test (equal? ,x ,y)
-               (cat "failed: expected " (str ,x) ", was " (str ,y))))))
-
-  (define-macro define-test (name rest: body)
-    `(add tests (list ',name (fn () ,@body)))))
+(define-macro define-test (name rest: body)
+  `(add tests (list ',name (fn () ,@body))))
 
 (define-global run ()
   (each ((name f)) tests

--- a/test.l
+++ b/test.l
@@ -77,7 +77,7 @@
       (test= more (read "'\"boz" more)))
     (let ((ok e) (guard (read "(open")))
       (test= false ok)
-      (test= "Expected ) at 5" (get e 'message)))))
+      (test= "Expected ) at 5" (e .message)))))
 
 (define-test nil?
   (test= true (nil? nil))
@@ -329,7 +329,7 @@ c"
          (macroexpand '``(,x))))
 
 (define-test calls
-  (let (f (fn () 42)
+  (let (f (fn (x) (or x 42))
         l (list f)
         t (obj f: f))
     (f)
@@ -337,6 +337,10 @@ c"
       (test= 42 (f))))
     (test= 42 ((at l 0)))
     (test= 42 ((get t 'f)))
+    (test= 42 ((t .f)))
+    (test= 42 (t (.f)))
+    (test= 1 (t .f 1))
+    (test= 1 ((t .f) 1))
     (test= nil ((fn () (return))))
     (test= 10 ((fn (x) (- x 2)) 12))))
 

--- a/test.l
+++ b/test.l
@@ -7,24 +7,25 @@
 (define reader (require 'reader))
 (define compiler (require 'compiler))
 
-(define-macro test (x msg)
-  `(if (not ,x)
-       (do (set failed (+ failed 1))
-           (return ,msg))
-     (inc passed)))
-
 (define equal? (a b)
   (if (atom? a) (= a b)
     (= (str a) (str b))))
 
-(define-macro test= (a b)
-  (let-unique (x y)
-    `(let (,x ,a ,y ,b)
-       (test (equal? ,x ,y)
-             (cat "failed: expected " (str ,x) ", was " (str ,y))))))
+(during-compilation
+  (define-macro test (x msg)
+    `(if (not ,x)
+         (do (set failed (+ failed 1))
+             (return ,msg))
+       (inc passed)))
 
-(define-macro define-test (name rest: body)
-  `(add tests (list ',name (fn () ,@body))))
+  (define-macro test= (a b)
+    (let-unique (x y)
+      `(let (,x ,a ,y ,b)
+         (test (equal? ,x ,y)
+               (cat "failed: expected " (str ,x) ", was " (str ,y))))))
+
+  (define-macro define-test (name rest: body)
+    `(add tests (list ',name (fn () ,@body)))))
 
 (define-global run ()
   (each ((name f)) tests
@@ -34,7 +35,7 @@
   (print (cat " " passed " passed, " failed " failed")))
 
 (define-test reader
-  (let read (get reader 'read-string)
+  (let read (reader .read-string)
     (test= nil (read ""))
     (test= "nil" (read "nil"))
     (test= 17 (read "17"))
@@ -64,7 +65,7 @@
     (test= "0." (read "0."))))
 
 (define-test read-more
-  (let read (get reader 'read-string)
+  (let read (reader .read-string)
     (test= 17 (read "17" true))
     (let more ()
       (test= more (read "(open" more))
@@ -206,7 +207,7 @@
   (test= 3 (# "foo"))
   (test= 3 (# "\"a\""))
   (test= 'a "a")
-  (test= "a" (char "bar" 1))
+  (test= "a" (from-code (code (char "bar" 1))))
   (let s "a
 b"
     (test= 3 (# s)))
@@ -602,7 +603,7 @@ c"
   (let-macro ((guard1 (x)
                 (let-unique (ok v)
                   `(let ((,ok ,v) (guard ,x))
-                     (list ,ok (if ,ok ,v (get ,v 'message)))))))
+                     (list ,ok (if ,ok ,v (,v .message)))))))
     (test= (list false "") (guard1 (error)))
     (test= (list false "") (guard1 (error nil)))
     (test= (list false "false") (guard1 (error false)))
@@ -1034,7 +1035,7 @@ c"
   (test= 116 (apply + 1 5 '(100 10))))
 
 (define-test eval
-  (let eval (get compiler 'eval)
+  (let eval (compiler .eval)
     (test= 4 (eval '(+ 2 2)))
     (test= 5 (eval '(let a 3 (+ 2 a))))
     (test= 9 (eval '(do (define x 7) (+ x 2))))


### PR DESCRIPTION
I was hoping to get your thoughts on this dot syntax I've devised.

The benefit is that it distinguishes between field accessors and field lookups; the two aren't the same thing. For example, in Python foo["bar"] isn't equivalent to foo.bar.

The PR also compiles identifiers to camelCase, which helps with JS interop.

The main thing I'd like to know is whether this new syntax is readable. The rules are:

`(foo .bar)` compiles to `foo.bar`

`(foo (.bar))` compiles to `foo.bar()`

`(foo .bar 1 2 3)` compiles to `foo.bar(1,2,3)`

`(foo (.bar 1 2 3))` compiles to `foo.bar(1,2,3)`

`(require 'fs .read-file-sync 'reader.l 'utf8)` compiles to `require("fs").readFileSync("reader.l", "utf8")`

Some examples:

https://github.com/shawwn/motor/blob/e259e2475e9a99f2c8a61fd9b2ca6cfed2169c49/stream.l#L11-L15

https://github.com/shawwn/lumen/blob/97d6d0c43b61f226827811e75dae740c7edfc1a2/system.l#L38-L39

The weirdest aspect of this syntax is probably that `(foo .bar "x" "y")` compiles to a method call, but `(foo .bar)` compiles to a property access. That means if you want to call a method and pass in zero arguments, you must write `(foo (.bar))` or `((foo .bar))`.

I was hoping you'd call out any potential downsides before I make this official in my own fork.