### PR TITLE
If a macro returns a function, call it.

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -256,7 +256,12 @@ var expand_definition = function (__x46) {
   return ____x49;
 };
 var expand_macro = function (form) {
-  return macroexpand(expand1(form));
+  var __result = expand1(form);
+  if (function63(__result)) {
+    return __result(form);
+  } else {
+    return macroexpand(__result);
+  }
 };
 expand1 = function (__x51) {
   var ____id4 = __x51;

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -221,7 +221,12 @@ local function expand_definition(__x46)
   return ____x49
 end
 local function expand_macro(form)
-  return macroexpand(expand1(form))
+  local __result = expand1(form)
+  if function63(__result) then
+    return __result(form)
+  else
+    return macroexpand(__result)
+  end
 end
 function expand1(__x51)
   local ____id4 = __x51

--- a/compiler.l
+++ b/compiler.l
@@ -133,7 +133,8 @@
     `(,x ,name ,args ,@(macroexpand body))))
 
 (define expand-macro (form)
-  (macroexpand (expand1 form)))
+  (let result (expand1 form)
+    (if (function? result) (result form) (macroexpand result))))
 
 (define-global expand1 ((name rest: body))
   (apply (macro-function name) body))


### PR DESCRIPTION
This allows macros like `%local` to be defined:

```
(define-macro %local ()
  (define expand-local ((x name value))
    (setenv name :variable)
    `(%local ,name ,(macroexpand value)))
  expand-local)
```