### PR TITLE
Update LUA_PATH

### DIFF
--- a/bin/lumen
+++ b/bin/lumen
@@ -34,7 +34,7 @@ case $host in
         export NODE_PATH="$NODE_PATH:${home}:${dir}/lib:${dir}/node_modules";;
     *)
         code=lumen.lua
-        export LUA_PATH="$LUA_PATH;${home}/?.lua;${dir}/lib/?.lua;;";;
+        export LUA_PATH="$LUA_PATH;${home}/?.lua;${dir}/lib/?.lua;${dir}/lib/?/init.lua;${dir}/node_modules/?/init.lua;;";;
 esac
 
 exec ${host} "${home}/${code}" "$@"


### PR DESCRIPTION
- Support libraries installed as `lib/?/init.lua`

Some libraries, particularly those shipped with [OpenResity](https://opm.openresty.org/api/pkg/list) install themselves under `lib/?/init.lua`.

- Support Lumen libraries shipped as a node module

With this change, Lumen libraries can be shipped via npm. See [shawwn/lumen-string-replace](https://github.com/shawwn/lumen-string-replace) for an example.