### PR TITLE
Simplify CALL-WITH-FILE

### DIFF
--- a/bin/system.lua
+++ b/bin/system.lua
@@ -1,11 +1,13 @@
 local function call_with_file(f, path, mode)
-  local h,e = io.open(path, mode)
-  if not h then
-    error(e)
+  local ____id = {io.open(path, mode)}
+  local __h = ____id[1]
+  local __e = ____id[2]
+  if not __h then
+    error(__e)
   end
-  local __x = f(h)
-  h.close(h)
-  return __x
+  local __x1 = f(__h)
+  __h.close(__h)
+  return __x1
 end
 local function read_file(path)
   return call_with_file(function (f)
@@ -19,29 +21,29 @@ local function write_file(path, data)
 end
 local function file_exists63(path)
   local __f = io.open(path)
-  local __id = is63(__f)
-  local __e = nil
-  if __id then
-    local __r6 = is63(__f.read(__f, 0)) or 0 == __f.seek(__f, "end")
-    __f.close(__f)
-    __e = __r6
-  else
-    __e = __id
-  end
-  return __e
-end
-local function directory_exists63(path)
-  local __f1 = io.open(path)
-  local __id1 = is63(__f1)
+  local __id1 = is63(__f)
   local __e1 = nil
   if __id1 then
-    local __r8 = not __f1.read(__f1, 0) and not( 0 == __f1.seek(__f1, "end"))
-    __f1.close(__f1)
-    __e1 = __r8
+    local __r6 = is63(__f.read(__f, 0)) or 0 == __f.seek(__f, "end")
+    __f.close(__f)
+    __e1 = __r6
   else
     __e1 = __id1
   end
   return __e1
+end
+local function directory_exists63(path)
+  local __f1 = io.open(path)
+  local __id2 = is63(__f1)
+  local __e2 = nil
+  if __id2 then
+    local __r8 = not __f1.read(__f1, 0) and not( 0 == __f1.seek(__f1, "end"))
+    __f1.close(__f1)
+    __e2 = __r8
+  else
+    __e2 = __id2
+  end
+  return __e2
 end
 local path_separator = char(_G.package.config, 0)
 local function path_join(...)
@@ -74,8 +76,8 @@ local function reload(module)
 end
 local function run(command)
   local __f2 = io.popen(command)
-  local __x2 = __f2.read(__f2, "*all")
+  local __x3 = __f2.read(__f2, "*all")
   __f2.close(__f2)
-  return __x2
+  return __x3
 end
 return {["read-file"] = read_file, ["write-file"] = write_file, ["file-exists?"] = file_exists63, ["directory-exists?"] = directory_exists63, ["path-separator"] = path_separator, ["path-join"] = path_join, ["get-environment-variable"] = get_environment_variable, stdout = stdout, stderr = stderr, write = write, exit = exit, argv = argv, reload = reload, run = run}

--- a/system.l
+++ b/system.l
@@ -3,7 +3,7 @@
 
 (target lua:
   (define call-with-file (f path mode)
-    (let |h,e| ((get io 'open) path mode)
+    (let ((h e) (list ((get io 'open) path mode)))
       (unless h
         (error e))
       (with x (f h)


### PR DESCRIPTION
This PR makes it easier to write an interpreter for Lumen by removing an instance of lua-specific id-literal syntax.