### PR TITLE
Define and use MAPCAT; support multiple return values

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -4,13 +4,13 @@ var getenv = function (k, p) {
     while (__i >= 0) {
       var __b = environment[__i][k];
       if (is63(__b)) {
-        var __e21 = undefined;
+        var __e19 = undefined;
         if (p) {
-          __e21 = __b[p];
+          __e19 = __b[p];
         } else {
-          __e21 = __b;
+          __e19 = __b;
         }
-        return __e21;
+        return __e19;
       } else {
         __i = __i - 1;
       }
@@ -69,13 +69,13 @@ var stash42 = function (args) {
     var __k = undefined;
     for (__k in ____o) {
       var __v = ____o[__k];
-      var __e22 = undefined;
+      var __e20 = undefined;
       if (numeric63(__k)) {
-        __e22 = parseInt(__k);
+        __e20 = parseInt(__k);
       } else {
-        __e22 = __k;
+        __e20 = __k;
       }
-      var __k1 = __e22;
+      var __k1 = __e20;
       if (! number63(__k1)) {
         add(__l, literal(__k1));
         add(__l, __v);
@@ -106,28 +106,28 @@ bind = function (lh, rh) {
     var __k2 = undefined;
     for (__k2 in ____o1) {
       var __v1 = ____o1[__k2];
-      var __e23 = undefined;
+      var __e21 = undefined;
       if (numeric63(__k2)) {
-        __e23 = parseInt(__k2);
+        __e21 = parseInt(__k2);
       } else {
-        __e23 = __k2;
+        __e21 = __k2;
       }
-      var __k3 = __e23;
-      var __e24 = undefined;
+      var __k3 = __e21;
+      var __e22 = undefined;
       if (__k3 === "rest") {
-        __e24 = ["cut", __id, _35(lh)];
+        __e22 = ["cut", __id, _35(lh)];
       } else {
-        __e24 = ["get", __id, ["quote", bias(__k3)]];
+        __e22 = ["get", __id, ["quote", bias(__k3)]];
       }
-      var __x5 = __e24;
+      var __x5 = __e22;
       if (is63(__k3)) {
-        var __e25 = undefined;
+        var __e23 = undefined;
         if (__v1 === true) {
-          __e25 = __k3;
+          __e23 = __k3;
         } else {
-          __e25 = __v1;
+          __e23 = __v1;
         }
-        var __k4 = __e25;
+        var __k4 = __e23;
         __bs = join(__bs, bind(__k4, __x5));
       }
     }
@@ -156,13 +156,13 @@ bind42 = function (args, body) {
     var __k5 = undefined;
     for (__k5 in ____o2) {
       var __v2 = ____o2[__k5];
-      var __e26 = undefined;
+      var __e24 = undefined;
       if (numeric63(__k5)) {
-        __e26 = parseInt(__k5);
+        __e24 = parseInt(__k5);
       } else {
-        __e26 = __k5;
+        __e24 = __k5;
       }
-      var __k6 = __e26;
+      var __k6 = __e24;
       if (number63(__k6)) {
         if (atom63(__v2)) {
           add(__args1, __v2);
@@ -217,13 +217,13 @@ var expand_function = function (__x41) {
   var ____i5 = undefined;
   for (____i5 in ____o3) {
     var ____x43 = ____o3[____i5];
-    var __e27 = undefined;
+    var __e25 = undefined;
     if (numeric63(____i5)) {
-      __e27 = parseInt(____i5);
+      __e25 = parseInt(____i5);
     } else {
-      __e27 = ____i5;
+      __e25 = ____i5;
     }
-    var ____i51 = __e27;
+    var ____i51 = __e25;
     setenv(____x43, {_stash: true, variable: true});
   }
   var ____x44 = join(["%function", __args], macroexpand(__body));
@@ -241,13 +241,13 @@ var expand_definition = function (__x46) {
   var ____i6 = undefined;
   for (____i6 in ____o4) {
     var ____x48 = ____o4[____i6];
-    var __e28 = undefined;
+    var __e26 = undefined;
     if (numeric63(____i6)) {
-      __e28 = parseInt(____i6);
+      __e26 = parseInt(____i6);
     } else {
-      __e28 = ____i6;
+      __e26 = ____i6;
     }
-    var ____i61 = __e28;
+    var ____i61 = __e26;
     setenv(____x48, {_stash: true, variable: true});
   }
   var ____x49 = join([__x47, __name1, __args11], macroexpand(__body1));
@@ -301,21 +301,21 @@ var quasiquote_list = function (form, depth) {
   var __k7 = undefined;
   for (__k7 in ____o5) {
     var __v4 = ____o5[__k7];
-    var __e29 = undefined;
+    var __e27 = undefined;
     if (numeric63(__k7)) {
-      __e29 = parseInt(__k7);
+      __e27 = parseInt(__k7);
     } else {
-      __e29 = __k7;
+      __e27 = __k7;
     }
-    var __k8 = __e29;
+    var __k8 = __e27;
     if (! number63(__k8)) {
-      var __e30 = undefined;
+      var __e28 = undefined;
       if (quasisplice63(__v4, depth)) {
-        __e30 = quasiexpand(__v4[1]);
+        __e28 = quasiexpand(__v4[1]);
       } else {
-        __e30 = quasiexpand(__v4, depth);
+        __e28 = quasiexpand(__v4, depth);
       }
-      var __v5 = __e30;
+      var __v5 = __e28;
       last(__xs)[__k8] = __v5;
     }
   }
@@ -409,36 +409,36 @@ var valid_code63 = function (n) {
   return number_code63(n) || n > 64 && n < 91 || n > 96 && n < 123 || n === 95;
 };
 var id = function (id) {
-  var __e31 = undefined;
+  var __e29 = undefined;
   if (number_code63(code(id, 0))) {
-    __e31 = "_";
+    __e29 = "_";
   } else {
-    __e31 = "";
+    __e29 = "";
   }
-  var __id11 = __e31;
+  var __id11 = __e29;
   var __i10 = 0;
   while (__i10 < _35(id)) {
     var __c1 = char(id, __i10);
     var __n7 = code(__c1);
-    var __e32 = undefined;
+    var __e30 = undefined;
     if (__c1 === "-" && !( id === "-")) {
-      __e32 = "_";
+      __e30 = "_";
     } else {
-      var __e33 = undefined;
+      var __e31 = undefined;
       if (valid_code63(__n7)) {
-        __e33 = __c1;
+        __e31 = __c1;
       } else {
-        var __e34 = undefined;
+        var __e32 = undefined;
         if (__i10 === 0) {
-          __e34 = "_" + __n7;
+          __e32 = "_" + __n7;
         } else {
-          __e34 = __n7;
+          __e32 = __n7;
         }
-        __e33 = __e34;
+        __e31 = __e32;
       }
-      __e32 = __e33;
+      __e30 = __e31;
     }
-    var __c11 = __e32;
+    var __c11 = __e30;
     __id11 = __id11 + __c11;
     __i10 = __i10 + 1;
   }
@@ -481,13 +481,13 @@ mapo = function (f, t) {
   var __k9 = undefined;
   for (__k9 in ____o7) {
     var __v6 = ____o7[__k9];
-    var __e35 = undefined;
+    var __e33 = undefined;
     if (numeric63(__k9)) {
-      __e35 = parseInt(__k9);
+      __e33 = parseInt(__k9);
     } else {
-      __e35 = __k9;
+      __e33 = __k9;
     }
-    var __k10 = __e35;
+    var __k10 = __e33;
     var __x66 = f(__v6);
     if (is63(__x66)) {
       add(__o6, literal(__k10));
@@ -546,13 +546,13 @@ var precedence = function (form) {
     var __k11 = undefined;
     for (__k11 in ____o8) {
       var __v7 = ____o8[__k11];
-      var __e36 = undefined;
+      var __e34 = undefined;
       if (numeric63(__k11)) {
-        __e36 = parseInt(__k11);
+        __e34 = parseInt(__k11);
       } else {
-        __e36 = __k11;
+        __e34 = __k11;
       }
-      var __k12 = __e36;
+      var __k12 = __e34;
       if (__v7[hd(form)]) {
         return index(__k12);
       }
@@ -579,39 +579,29 @@ infix_operator63 = function (x) {
   return obj63(x) && infix63(hd(x));
 };
 var compile_args = function (args) {
-  var __s1 = "(";
-  var __c2 = "";
-  var ____x83 = args;
-  var ____i15 = 0;
-  while (____i15 < _35(____x83)) {
-    var __x84 = ____x83[____i15];
-    __s1 = __s1 + __c2 + compile(__x84);
-    __c2 = ", ";
-    ____i15 = ____i15 + 1;
-  }
-  return __s1 + ")";
+  return "(" + mapcat(compile, args, ", ") + ")";
 };
 var escape_newlines = function (s) {
-  var __s11 = "";
-  var __i16 = 0;
-  while (__i16 < _35(s)) {
-    var __c3 = char(s, __i16);
-    var __e37 = undefined;
-    if (__c3 === "\n") {
-      __e37 = "\\n";
+  var __s1 = "";
+  var __i15 = 0;
+  while (__i15 < _35(s)) {
+    var __c2 = char(s, __i15);
+    var __e35 = undefined;
+    if (__c2 === "\n") {
+      __e35 = "\\n";
     } else {
-      var __e38 = undefined;
-      if (__c3 === "\r") {
-        __e38 = "\\r";
+      var __e36 = undefined;
+      if (__c2 === "\r") {
+        __e36 = "\\r";
       } else {
-        __e38 = __c3;
+        __e36 = __c2;
       }
-      __e37 = __e38;
+      __e35 = __e36;
     }
-    __s11 = __s11 + __e37;
-    __i16 = __i16 + 1;
+    __s1 = __s1 + __e35;
+    __i15 = __i15 + 1;
   }
-  return __s11;
+  return __s1;
 };
 var compile_atom = function (x) {
   if (x === "nil" && target === "lua") {
@@ -673,9 +663,9 @@ var terminator = function (stmt63) {
 };
 var compile_special = function (form, stmt63) {
   var ____id6 = form;
-  var __x85 = ____id6[0];
+  var __x83 = ____id6[0];
   var __args2 = cut(____id6, 1);
-  var ____id7 = getenv(__x85);
+  var ____id7 = getenv(__x83);
   var __special = ____id7.special;
   var __stmt = ____id7.stmt;
   var __self_tr63 = ____id7.tr;
@@ -701,13 +691,13 @@ var op_delims = function (parent, child) {
   var __child = destash33(child, ____r57);
   var ____id8 = ____r57;
   var __right = ____id8.right;
-  var __e39 = undefined;
+  var __e37 = undefined;
   if (__right) {
-    __e39 = _6261;
+    __e37 = _6261;
   } else {
-    __e39 = _62;
+    __e37 = _62;
   }
-  if (__e39(precedence(__child), precedence(__parent))) {
+  if (__e37(precedence(__child), precedence(__parent))) {
     return ["(", ")"];
   } else {
     return ["", ""];
@@ -741,40 +731,40 @@ compile_function = function (args, body) {
   var ____id13 = ____r59;
   var __name3 = ____id13.name;
   var __prefix = ____id13.prefix;
-  var __e40 = undefined;
+  var __e38 = undefined;
   if (__name3) {
-    __e40 = compile(__name3);
+    __e38 = compile(__name3);
+  } else {
+    __e38 = "";
+  }
+  var __id14 = __e38;
+  var __e39 = undefined;
+  if (target === "lua" && __args4.rest) {
+    __e39 = join(__args4, ["|...|"]);
+  } else {
+    __e39 = __args4;
+  }
+  var __args12 = __e39;
+  var __args5 = compile_args(__args12);
+  indent_level = indent_level + 1;
+  var ____x87 = compile(__body3, {_stash: true, stmt: true});
+  indent_level = indent_level - 1;
+  var __body4 = ____x87;
+  var __ind = indentation();
+  var __e40 = undefined;
+  if (__prefix) {
+    __e40 = __prefix + " ";
   } else {
     __e40 = "";
   }
-  var __id14 = __e40;
+  var __p = __e40;
   var __e41 = undefined;
-  if (target === "lua" && __args4.rest) {
-    __e41 = join(__args4, ["|...|"]);
-  } else {
-    __e41 = __args4;
-  }
-  var __args12 = __e41;
-  var __args5 = compile_args(__args12);
-  indent_level = indent_level + 1;
-  var ____x89 = compile(__body3, {_stash: true, stmt: true});
-  indent_level = indent_level - 1;
-  var __body4 = ____x89;
-  var __ind = indentation();
-  var __e42 = undefined;
-  if (__prefix) {
-    __e42 = __prefix + " ";
-  } else {
-    __e42 = "";
-  }
-  var __p = __e42;
-  var __e43 = undefined;
   if (target === "js") {
-    __e43 = "";
+    __e41 = "";
   } else {
-    __e43 = "end";
+    __e41 = "end";
   }
-  var __tr1 = __e43;
+  var __tr1 = __e41;
   if (__name3) {
     __tr1 = __tr1 + "\n";
   }
@@ -799,26 +789,26 @@ compile = function (form) {
       return compile_special(__form, __stmt1);
     } else {
       var __tr2 = terminator(__stmt1);
-      var __e44 = undefined;
+      var __e42 = undefined;
       if (__stmt1) {
-        __e44 = indentation();
+        __e42 = indentation();
       } else {
-        __e44 = "";
+        __e42 = "";
       }
-      var __ind1 = __e44;
-      var __e45 = undefined;
+      var __ind1 = __e42;
+      var __e43 = undefined;
       if (atom63(__form)) {
-        __e45 = compile_atom(__form);
+        __e43 = compile_atom(__form);
       } else {
-        var __e46 = undefined;
+        var __e44 = undefined;
         if (infix63(hd(__form))) {
-          __e46 = compile_infix(__form);
+          __e44 = compile_infix(__form);
         } else {
-          __e46 = compile_call(__form);
+          __e44 = compile_call(__form);
         }
-        __e45 = __e46;
+        __e43 = __e44;
       }
-      var __form1 = __e45;
+      var __form1 = __e43;
       return __ind1 + __form1 + __tr2;
     }
   }
@@ -826,25 +816,25 @@ compile = function (form) {
 var lower_statement = function (form, tail63) {
   var __hoist = [];
   var __e = lower(form, __hoist, true, tail63);
-  var __e47 = undefined;
+  var __e45 = undefined;
   if (some63(__hoist) && is63(__e)) {
-    __e47 = join(["do"], __hoist, [__e]);
+    __e45 = join(["do"], __hoist, [__e]);
   } else {
-    var __e48 = undefined;
+    var __e46 = undefined;
     if (is63(__e)) {
-      __e48 = __e;
+      __e46 = __e;
     } else {
-      var __e49 = undefined;
+      var __e47 = undefined;
       if (_35(__hoist) > 1) {
-        __e49 = join(["do"], __hoist);
+        __e47 = join(["do"], __hoist);
       } else {
-        __e49 = hd(__hoist);
+        __e47 = hd(__hoist);
       }
-      __e48 = __e49;
+      __e46 = __e47;
     }
-    __e47 = __e48;
+    __e45 = __e46;
   }
-  return either(__e47, ["do"]);
+  return either(__e45, ["do"]);
 };
 var lower_body = function (body, tail63) {
   return lower_statement(join(["do"], body), tail63);
@@ -856,18 +846,18 @@ var standalone63 = function (form) {
   return ! atom63(form) && ! infix63(hd(form)) && ! literal63(form) && !( "get" === hd(form)) || id_literal63(form);
 };
 var lower_do = function (args, hoist, stmt63, tail63) {
-  var ____x95 = almost(args);
-  var ____i17 = 0;
-  while (____i17 < _35(____x95)) {
-    var __x96 = ____x95[____i17];
-    var ____y = lower(__x96, hoist, stmt63);
+  var ____x93 = almost(args);
+  var ____i16 = 0;
+  while (____i16 < _35(____x93)) {
+    var __x94 = ____x93[____i16];
+    var ____y = lower(__x94, hoist, stmt63);
     if (yes(____y)) {
       var __e1 = ____y;
       if (standalone63(__e1)) {
         add(hoist, __e1);
       }
     }
-    ____i17 = ____i17 + 1;
+    ____i16 = ____i16 + 1;
   }
   var __e2 = lower(last(args), hoist, stmt63, tail63);
   if (tail63 && can_return63(__e2)) {
@@ -893,19 +883,19 @@ var lower_if = function (args, hoist, stmt63, tail63) {
   var ___then = ____id17[1];
   var ___else = ____id17[2];
   if (stmt63) {
-    var __e51 = undefined;
+    var __e49 = undefined;
     if (is63(___else)) {
-      __e51 = [lower_body([___else], tail63)];
+      __e49 = [lower_body([___else], tail63)];
     }
-    return add(hoist, join(["%if", lower(__cond, hoist), lower_body([___then], tail63)], __e51));
+    return add(hoist, join(["%if", lower(__cond, hoist), lower_body([___then], tail63)], __e49));
   } else {
     var __e3 = unique("e");
     add(hoist, ["%local", __e3, "nil"]);
-    var __e50 = undefined;
+    var __e48 = undefined;
     if (is63(___else)) {
-      __e50 = [lower(["%set", __e3, ___else])];
+      __e48 = [lower(["%set", __e3, ___else])];
     }
-    add(hoist, join(["%if", lower(__cond, hoist), lower(["%set", __e3, ___then])], __e50));
+    add(hoist, join(["%if", lower(__cond, hoist), lower(["%set", __e3, ___then])], __e48));
     return __e3;
   }
 };
@@ -917,13 +907,13 @@ var lower_short = function (x, args, hoist) {
   var __b11 = lower(__b4, __hoist1);
   if (some63(__hoist1)) {
     var __id19 = unique("id");
-    var __e52 = undefined;
+    var __e50 = undefined;
     if (x === "and") {
-      __e52 = ["%if", __id19, __b4, __id19];
+      __e50 = ["%if", __id19, __b4, __id19];
     } else {
-      __e52 = ["%if", __id19, __id19, __b4];
+      __e50 = ["%if", __id19, __id19, __b4];
     }
-    return lower(["do", ["%local", __id19, __a3], __e52], hoist);
+    return lower(["do", ["%local", __id19, __a3], __e50], hoist);
   } else {
     return [x, lower(__a3, hoist), __b11];
   }
@@ -933,17 +923,17 @@ var lower_try = function (args, hoist, tail63) {
 };
 var lower_while = function (args, hoist) {
   var ____id20 = args;
-  var __c4 = ____id20[0];
+  var __c3 = ____id20[0];
   var __body5 = cut(____id20, 1);
   var __pre = [];
-  var __c5 = lower(__c4, __pre);
-  var __e53 = undefined;
+  var __c4 = lower(__c3, __pre);
+  var __e51 = undefined;
   if (none63(__pre)) {
-    __e53 = ["while", __c5, lower_body(__body5)];
+    __e51 = ["while", __c4, lower_body(__body5)];
   } else {
-    __e53 = ["while", true, join(["do"], __pre, [["%if", ["not", __c5], ["break"]], lower_body(__body5)])];
+    __e51 = ["while", true, join(["do"], __pre, [["%if", ["not", __c4], ["break"]], lower_body(__body5)])];
   }
-  return add(hoist, __e53);
+  return add(hoist, __e51);
 };
 var lower_for = function (args, hoist) {
   var ____id21 = args;
@@ -980,10 +970,10 @@ var lower_pairwise = function (form) {
   if (pairwise63(form)) {
     var __e4 = [];
     var ____id24 = form;
-    var __x125 = ____id24[0];
+    var __x123 = ____id24[0];
     var __args7 = cut(____id24, 1);
     reduce(function (a, b) {
-      add(__e4, [__x125, a, b]);
+      add(__e4, [__x123, a, b]);
       return a;
     }, __args7);
     return join(["and"], reverse(__e4));
@@ -997,10 +987,10 @@ var lower_infix63 = function (form) {
 var lower_infix = function (form, hoist) {
   var __form3 = lower_pairwise(form);
   var ____id25 = __form3;
-  var __x128 = ____id25[0];
+  var __x126 = ____id25[0];
   var __args8 = cut(____id25, 1);
   return lower(reduce(function (a, b) {
-    return [__x128, b, a];
+    return [__x126, b, a];
   }, reverse(__args8)), hoist);
 };
 var lower_special = function (form, hoist) {
@@ -1023,39 +1013,39 @@ lower = function (form, hoist, stmt63, tail63) {
           return lower_infix(form, hoist);
         } else {
           var ____id26 = form;
-          var __x131 = ____id26[0];
+          var __x129 = ____id26[0];
           var __args9 = cut(____id26, 1);
-          if (__x131 === "do") {
+          if (__x129 === "do") {
             return lower_do(__args9, hoist, stmt63, tail63);
           } else {
-            if (__x131 === "%call") {
+            if (__x129 === "%call") {
               return lower(__args9, hoist, stmt63, tail63);
             } else {
-              if (__x131 === "%set") {
+              if (__x129 === "%set") {
                 return lower_set(__args9, hoist, stmt63, tail63);
               } else {
-                if (__x131 === "%if") {
+                if (__x129 === "%if") {
                   return lower_if(__args9, hoist, stmt63, tail63);
                 } else {
-                  if (__x131 === "%try") {
+                  if (__x129 === "%try") {
                     return lower_try(__args9, hoist, tail63);
                   } else {
-                    if (__x131 === "while") {
+                    if (__x129 === "while") {
                       return lower_while(__args9, hoist);
                     } else {
-                      if (__x131 === "%for") {
+                      if (__x129 === "%for") {
                         return lower_for(__args9, hoist);
                       } else {
-                        if (__x131 === "%function") {
+                        if (__x129 === "%function") {
                           return lower_function(__args9);
                         } else {
-                          if (__x131 === "%local-function" || __x131 === "%global-function") {
-                            return lower_definition(__x131, __args9, hoist);
+                          if (__x129 === "%local-function" || __x129 === "%global-function") {
+                            return lower_definition(__x129, __args9, hoist);
                           } else {
-                            if (in63(__x131, ["and", "or"])) {
-                              return lower_short(__x131, __args9, hoist);
+                            if (in63(__x129, ["and", "or"])) {
+                              return lower_short(__x129, __args9, hoist);
                             } else {
-                              if (statement63(__x131)) {
+                              if (statement63(__x129)) {
                                 return lower_special(form, hoist);
                               } else {
                                 return lower_call(form, hoist);
@@ -1094,64 +1084,64 @@ immediate_call63 = function (x) {
 };
 setenv("do", {_stash: true, special: function () {
   var __forms1 = unstash(Array.prototype.slice.call(arguments, 0));
-  var __s3 = "";
-  var ____x136 = __forms1;
-  var ____i19 = 0;
-  while (____i19 < _35(____x136)) {
-    var __x137 = ____x136[____i19];
-    if (target === "lua" && immediate_call63(__x137) && "\n" === char(__s3, edge(__s3))) {
-      __s3 = clip(__s3, 0, edge(__s3)) + ";\n";
+  var __s2 = "";
+  var ____x134 = __forms1;
+  var ____i18 = 0;
+  while (____i18 < _35(____x134)) {
+    var __x135 = ____x134[____i18];
+    if (target === "lua" && immediate_call63(__x135) && "\n" === char(__s2, edge(__s2))) {
+      __s2 = clip(__s2, 0, edge(__s2)) + ";\n";
     }
-    __s3 = __s3 + compile(__x137, {_stash: true, stmt: true});
-    if (! atom63(__x137)) {
-      if (hd(__x137) === "return" || hd(__x137) === "break") {
+    __s2 = __s2 + compile(__x135, {_stash: true, stmt: true});
+    if (! atom63(__x135)) {
+      if (hd(__x135) === "return" || hd(__x135) === "break") {
         break;
       }
     }
-    ____i19 = ____i19 + 1;
+    ____i18 = ____i18 + 1;
   }
-  return __s3;
+  return __s2;
 }, stmt: true, tr: true});
 setenv("%if", {_stash: true, special: function (cond, cons, alt) {
   var __cond2 = compile(cond);
   indent_level = indent_level + 1;
-  var ____x140 = compile(cons, {_stash: true, stmt: true});
+  var ____x138 = compile(cons, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __cons1 = ____x140;
-  var __e54 = undefined;
+  var __cons1 = ____x138;
+  var __e52 = undefined;
   if (alt) {
     indent_level = indent_level + 1;
-    var ____x141 = compile(alt, {_stash: true, stmt: true});
+    var ____x139 = compile(alt, {_stash: true, stmt: true});
     indent_level = indent_level - 1;
-    __e54 = ____x141;
+    __e52 = ____x139;
   }
-  var __alt1 = __e54;
+  var __alt1 = __e52;
   var __ind3 = indentation();
-  var __s5 = "";
+  var __s4 = "";
   if (target === "js") {
-    __s5 = __s5 + __ind3 + "if (" + __cond2 + ") {\n" + __cons1 + __ind3 + "}";
+    __s4 = __s4 + __ind3 + "if (" + __cond2 + ") {\n" + __cons1 + __ind3 + "}";
   } else {
-    __s5 = __s5 + __ind3 + "if " + __cond2 + " then\n" + __cons1;
+    __s4 = __s4 + __ind3 + "if " + __cond2 + " then\n" + __cons1;
   }
   if (__alt1 && target === "js") {
-    __s5 = __s5 + " else {\n" + __alt1 + __ind3 + "}";
+    __s4 = __s4 + " else {\n" + __alt1 + __ind3 + "}";
   } else {
     if (__alt1) {
-      __s5 = __s5 + __ind3 + "else\n" + __alt1;
+      __s4 = __s4 + __ind3 + "else\n" + __alt1;
     }
   }
   if (target === "lua") {
-    return __s5 + __ind3 + "end\n";
+    return __s4 + __ind3 + "end\n";
   } else {
-    return __s5 + "\n";
+    return __s4 + "\n";
   }
 }, stmt: true, tr: true});
 setenv("while", {_stash: true, special: function (cond, form) {
   var __cond4 = compile(cond);
   indent_level = indent_level + 1;
-  var ____x143 = compile(form, {_stash: true, stmt: true});
+  var ____x141 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __body10 = ____x143;
+  var __body10 = ____x141;
   var __ind5 = indentation();
   if (target === "js") {
     return __ind5 + "while (" + __cond4 + ") {\n" + __body10 + __ind5 + "}\n";
@@ -1163,9 +1153,9 @@ setenv("%for", {_stash: true, special: function (t, k, form) {
   var __t2 = compile(t);
   var __ind7 = indentation();
   indent_level = indent_level + 1;
-  var ____x145 = compile(form, {_stash: true, stmt: true});
+  var ____x143 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __body12 = ____x145;
+  var __body12 = ____x143;
   if (target === "lua") {
     return __ind7 + "for " + k + " in next, " + __t2 + " do\n" + __body12 + __ind7 + "end\n";
   } else {
@@ -1176,14 +1166,14 @@ setenv("%try", {_stash: true, special: function (form) {
   var __e8 = unique("e");
   var __ind9 = indentation();
   indent_level = indent_level + 1;
-  var ____x150 = compile(form, {_stash: true, stmt: true});
+  var ____x148 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __body14 = ____x150;
+  var __body14 = ____x148;
   var __hf1 = ["return", ["%array", false, __e8]];
   indent_level = indent_level + 1;
-  var ____x153 = compile(__hf1, {_stash: true, stmt: true});
+  var ____x151 = compile(__hf1, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __h1 = ____x153;
+  var __h1 = ____x151;
   return __ind9 + "try {\n" + __body14 + __ind9 + "}\n" + __ind9 + "catch (" + __e8 + ") {\n" + __h1 + __ind9 + "}\n";
 }, stmt: true, tr: true});
 setenv("%delete", {_stash: true, special: function (place) {
@@ -1197,29 +1187,29 @@ setenv("%function", {_stash: true, special: function (args, body) {
 }});
 setenv("%global-function", {_stash: true, special: function (name, args, body) {
   if (target === "lua") {
-    var __x157 = compile_function(args, body, {_stash: true, name: name});
-    return indentation() + __x157;
+    var __x155 = compile_function(args, body, {_stash: true, name: name});
+    return indentation() + __x155;
   } else {
     return compile(["%set", name, ["%function", args, body]], {_stash: true, stmt: true});
   }
 }, stmt: true, tr: true});
 setenv("%local-function", {_stash: true, special: function (name, args, body) {
   if (target === "lua") {
-    var __x163 = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
-    return indentation() + __x163;
+    var __x161 = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
+    return indentation() + __x161;
   } else {
     return compile(["%local", name, ["%function", args, body]], {_stash: true, stmt: true});
   }
 }, stmt: true, tr: true});
 setenv("return", {_stash: true, special: function (x) {
-  var __e55 = undefined;
+  var __e53 = undefined;
   if (nil63(x)) {
-    __e55 = "return";
+    __e53 = "return";
   } else {
-    __e55 = "return " + compile(x);
+    __e53 = "return " + compile(x);
   }
-  var __x167 = __e55;
-  return indentation() + __x167;
+  var __x165 = __e53;
+  return indentation() + __x165;
 }, stmt: true});
 setenv("new", {_stash: true, special: function (x) {
   return "new " + compile(x);
@@ -1228,44 +1218,44 @@ setenv("typeof", {_stash: true, special: function (x) {
   return "typeof(" + compile(x) + ")";
 }});
 setenv("throw", {_stash: true, special: function (x) {
-  var __e56 = undefined;
+  var __e54 = undefined;
   if (target === "js") {
-    __e56 = "throw " + compile(x);
+    __e54 = "throw " + compile(x);
   } else {
-    __e56 = "error(" + compile(x) + ")";
+    __e54 = "error(" + compile(x) + ")";
   }
-  var __e12 = __e56;
+  var __e12 = __e54;
   return indentation() + __e12;
 }, stmt: true});
 setenv("%local", {_stash: true, special: function (name, value) {
   var __id28 = compile(name);
   var __value11 = compile(value);
-  var __e57 = undefined;
+  var __e55 = undefined;
   if (is63(value)) {
-    __e57 = " = " + __value11;
+    __e55 = " = " + __value11;
   } else {
-    __e57 = "";
+    __e55 = "";
   }
-  var __rh2 = __e57;
-  var __e58 = undefined;
+  var __rh2 = __e55;
+  var __e56 = undefined;
   if (target === "js") {
-    __e58 = "var ";
+    __e56 = "var ";
   } else {
-    __e58 = "local ";
+    __e56 = "local ";
   }
-  var __keyword1 = __e58;
+  var __keyword1 = __e56;
   var __ind11 = indentation();
   return __ind11 + __keyword1 + __id28 + __rh2;
 }, stmt: true});
 setenv("%set", {_stash: true, special: function (lh, rh) {
   var __lh2 = compile(lh);
-  var __e59 = undefined;
+  var __e57 = undefined;
   if (nil63(rh)) {
-    __e59 = "nil";
+    __e57 = "nil";
   } else {
-    __e59 = rh;
+    __e57 = rh;
   }
-  var __rh4 = compile(__e59);
+  var __rh4 = compile(__e57);
   return indentation() + __lh2 + " = " + __rh4;
 }, stmt: true});
 setenv("get", {_stash: true, special: function (t, k) {
@@ -1282,78 +1272,42 @@ setenv("get", {_stash: true, special: function (t, k) {
 }});
 setenv("%array", {_stash: true, special: function () {
   var __forms3 = unstash(Array.prototype.slice.call(arguments, 0));
-  var __e60 = undefined;
+  var __e58 = undefined;
   if (target === "lua") {
-    __e60 = "{";
+    __e58 = "{";
   } else {
-    __e60 = "[";
+    __e58 = "[";
   }
-  var __open1 = __e60;
-  var __e61 = undefined;
+  var __open1 = __e58;
+  var __e59 = undefined;
   if (target === "lua") {
-    __e61 = "}";
+    __e59 = "}";
   } else {
-    __e61 = "]";
+    __e59 = "]";
   }
-  var __close1 = __e61;
-  var __s7 = "";
-  var __c7 = "";
-  var ____o10 = __forms3;
-  var __k16 = undefined;
-  for (__k16 in ____o10) {
-    var __v9 = ____o10[__k16];
-    var __e62 = undefined;
-    if (numeric63(__k16)) {
-      __e62 = parseInt(__k16);
-    } else {
-      __e62 = __k16;
-    }
-    var __k17 = __e62;
-    if (number63(__k17)) {
-      __s7 = __s7 + __c7 + compile(__v9);
-      __c7 = ", ";
-    }
-  }
-  return __open1 + __s7 + __close1;
+  var __close1 = __e59;
+  return __open1 + mapcat(compile, __forms3, ", ") + __close1;
 }});
 setenv("%object", {_stash: true, special: function () {
   var __forms5 = unstash(Array.prototype.slice.call(arguments, 0));
-  var __s9 = "{";
-  var __c9 = "";
-  var __e63 = undefined;
+  var __e60 = undefined;
   if (target === "lua") {
-    __e63 = " = ";
+    __e60 = " = ";
   } else {
-    __e63 = ": ";
+    __e60 = ": ";
   }
-  var __sep1 = __e63;
-  var ____o12 = pair(__forms5);
-  var __k21 = undefined;
-  for (__k21 in ____o12) {
-    var __v12 = ____o12[__k21];
-    var __e64 = undefined;
-    if (numeric63(__k21)) {
-      __e64 = parseInt(__k21);
-    } else {
-      __e64 = __k21;
-    }
-    var __k22 = __e64;
-    if (number63(__k22)) {
-      var ____id30 = __v12;
-      var __k23 = ____id30[0];
-      var __v13 = ____id30[1];
-      if (! string63(__k23)) {
-        error("Illegal key: " + str(__k23));
-      }
-      __s9 = __s9 + __c9 + key(__k23) + __sep1 + compile(__v13);
-      __c9 = ", ";
-    }
-  }
-  return __s9 + "}";
+  var __sep1 = __e60;
+  var __s6 = mapcat(function (__x167) {
+    var ____id30 = __x167;
+    var __k15 = ____id30[0];
+    var __v9 = ____id30[1];
+    return key(__k15) + __sep1 + compile(__v9);
+  }, pair(__forms5), ", ");
+  return "{" + __s6 + "}";
 }});
 setenv("%literal", {_stash: true, special: function () {
   var __args111 = unstash(Array.prototype.slice.call(arguments, 0));
-  return apply(cat, map(compile, __args111));
+  return mapcat(compile, __args111);
 }});
 exports.run = run;
 exports["eval"] = _eval;

--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -4,13 +4,13 @@ var getenv = function (k, p) {
     while (__i >= 0) {
       var __b = environment[__i][k];
       if (is63(__b)) {
-        var __e19 = undefined;
+        var __e21 = undefined;
         if (p) {
-          __e19 = __b[p];
+          __e21 = __b[p];
         } else {
-          __e19 = __b;
+          __e21 = __b;
         }
-        return __e19;
+        return __e21;
       } else {
         __i = __i - 1;
       }
@@ -69,13 +69,13 @@ var stash42 = function (args) {
     var __k = undefined;
     for (__k in ____o) {
       var __v = ____o[__k];
-      var __e20 = undefined;
+      var __e22 = undefined;
       if (numeric63(__k)) {
-        __e20 = parseInt(__k);
+        __e22 = parseInt(__k);
       } else {
-        __e20 = __k;
+        __e22 = __k;
       }
-      var __k1 = __e20;
+      var __k1 = __e22;
       if (! number63(__k1)) {
         add(__l, literal(__k1));
         add(__l, __v);
@@ -106,28 +106,28 @@ bind = function (lh, rh) {
     var __k2 = undefined;
     for (__k2 in ____o1) {
       var __v1 = ____o1[__k2];
-      var __e21 = undefined;
+      var __e23 = undefined;
       if (numeric63(__k2)) {
-        __e21 = parseInt(__k2);
+        __e23 = parseInt(__k2);
       } else {
-        __e21 = __k2;
+        __e23 = __k2;
       }
-      var __k3 = __e21;
-      var __e22 = undefined;
+      var __k3 = __e23;
+      var __e24 = undefined;
       if (__k3 === "rest") {
-        __e22 = ["cut", __id, _35(lh)];
+        __e24 = ["cut", __id, _35(lh)];
       } else {
-        __e22 = ["get", __id, ["quote", bias(__k3)]];
+        __e24 = ["get", __id, ["quote", bias(__k3)]];
       }
-      var __x5 = __e22;
+      var __x5 = __e24;
       if (is63(__k3)) {
-        var __e23 = undefined;
+        var __e25 = undefined;
         if (__v1 === true) {
-          __e23 = __k3;
+          __e25 = __k3;
         } else {
-          __e23 = __v1;
+          __e25 = __v1;
         }
-        var __k4 = __e23;
+        var __k4 = __e25;
         __bs = join(__bs, bind(__k4, __x5));
       }
     }
@@ -156,13 +156,13 @@ bind42 = function (args, body) {
     var __k5 = undefined;
     for (__k5 in ____o2) {
       var __v2 = ____o2[__k5];
-      var __e24 = undefined;
+      var __e26 = undefined;
       if (numeric63(__k5)) {
-        __e24 = parseInt(__k5);
+        __e26 = parseInt(__k5);
       } else {
-        __e24 = __k5;
+        __e26 = __k5;
       }
-      var __k6 = __e24;
+      var __k6 = __e26;
       if (number63(__k6)) {
         if (atom63(__v2)) {
           add(__args1, __v2);
@@ -204,61 +204,73 @@ var expand_local = function (__x38) {
   var __x39 = ____id1[0];
   var __name = ____id1[1];
   var __value = ____id1[2];
-  setenv(__name, {_stash: true, variable: true});
+  var __e27 = undefined;
+  if (obj63(__name)) {
+    __e27 = __name;
+  } else {
+    __e27 = [__name];
+  }
+  var ____x40 = __e27;
+  var ____i5 = 0;
+  while (____i5 < _35(____x40)) {
+    var __x42 = ____x40[____i5];
+    setenv(__x42, {_stash: true, variable: true});
+    ____i5 = ____i5 + 1;
+  }
   return ["%local", __name, macroexpand(__value)];
 };
-var expand_function = function (__x41) {
-  var ____id2 = __x41;
-  var __x42 = ____id2[0];
+var expand_function = function (__x44) {
+  var ____id2 = __x44;
+  var __x45 = ____id2[0];
   var __args = ____id2[1];
   var __body = cut(____id2, 2);
   add(environment, {});
   var ____o3 = __args;
-  var ____i5 = undefined;
-  for (____i5 in ____o3) {
-    var ____x43 = ____o3[____i5];
-    var __e25 = undefined;
-    if (numeric63(____i5)) {
-      __e25 = parseInt(____i5);
+  var ____i6 = undefined;
+  for (____i6 in ____o3) {
+    var ____x46 = ____o3[____i6];
+    var __e28 = undefined;
+    if (numeric63(____i6)) {
+      __e28 = parseInt(____i6);
     } else {
-      __e25 = ____i5;
+      __e28 = ____i6;
     }
-    var ____i51 = __e25;
-    setenv(____x43, {_stash: true, variable: true});
+    var ____i61 = __e28;
+    setenv(____x46, {_stash: true, variable: true});
   }
-  var ____x44 = join(["%function", __args], macroexpand(__body));
+  var ____x47 = join(["%function", __args], macroexpand(__body));
   drop(environment);
-  return ____x44;
+  return ____x47;
 };
-var expand_definition = function (__x46) {
-  var ____id3 = __x46;
-  var __x47 = ____id3[0];
+var expand_definition = function (__x49) {
+  var ____id3 = __x49;
+  var __x50 = ____id3[0];
   var __name1 = ____id3[1];
   var __args11 = ____id3[2];
   var __body1 = cut(____id3, 3);
   add(environment, {});
   var ____o4 = __args11;
-  var ____i6 = undefined;
-  for (____i6 in ____o4) {
-    var ____x48 = ____o4[____i6];
-    var __e26 = undefined;
-    if (numeric63(____i6)) {
-      __e26 = parseInt(____i6);
+  var ____i7 = undefined;
+  for (____i7 in ____o4) {
+    var ____x51 = ____o4[____i7];
+    var __e29 = undefined;
+    if (numeric63(____i7)) {
+      __e29 = parseInt(____i7);
     } else {
-      __e26 = ____i6;
+      __e29 = ____i7;
     }
-    var ____i61 = __e26;
-    setenv(____x48, {_stash: true, variable: true});
+    var ____i71 = __e29;
+    setenv(____x51, {_stash: true, variable: true});
   }
-  var ____x49 = join([__x47, __name1, __args11], macroexpand(__body1));
+  var ____x52 = join([__x50, __name1, __args11], macroexpand(__body1));
   drop(environment);
-  return ____x49;
+  return ____x52;
 };
 var expand_macro = function (form) {
   return macroexpand(expand1(form));
 };
-expand1 = function (__x51) {
-  var ____id4 = __x51;
+expand1 = function (__x54) {
+  var ____id4 = __x54;
   var __name2 = ____id4[0];
   var __body2 = cut(____id4, 1);
   return apply(macro_function(__name2), __body2);
@@ -270,20 +282,20 @@ macroexpand = function (form) {
     if (atom63(form)) {
       return form;
     } else {
-      var __x52 = hd(form);
-      if (__x52 === "%local") {
+      var __x55 = hd(form);
+      if (__x55 === "%local") {
         return expand_local(form);
       } else {
-        if (__x52 === "%function") {
+        if (__x55 === "%function") {
           return expand_function(form);
         } else {
-          if (__x52 === "%global-function") {
+          if (__x55 === "%global-function") {
             return expand_definition(form);
           } else {
-            if (__x52 === "%local-function") {
+            if (__x55 === "%local-function") {
               return expand_definition(form);
             } else {
-              if (macro63(__x52)) {
+              if (macro63(__x55)) {
                 return expand_macro(form);
               } else {
                 return map(macroexpand, form);
@@ -301,36 +313,36 @@ var quasiquote_list = function (form, depth) {
   var __k7 = undefined;
   for (__k7 in ____o5) {
     var __v4 = ____o5[__k7];
-    var __e27 = undefined;
+    var __e30 = undefined;
     if (numeric63(__k7)) {
-      __e27 = parseInt(__k7);
+      __e30 = parseInt(__k7);
     } else {
-      __e27 = __k7;
+      __e30 = __k7;
     }
-    var __k8 = __e27;
+    var __k8 = __e30;
     if (! number63(__k8)) {
-      var __e28 = undefined;
+      var __e31 = undefined;
       if (quasisplice63(__v4, depth)) {
-        __e28 = quasiexpand(__v4[1]);
+        __e31 = quasiexpand(__v4[1]);
       } else {
-        __e28 = quasiexpand(__v4, depth);
+        __e31 = quasiexpand(__v4, depth);
       }
-      var __v5 = __e28;
+      var __v5 = __e31;
       last(__xs)[__k8] = __v5;
     }
   }
-  var ____x55 = form;
-  var ____i8 = 0;
-  while (____i8 < _35(____x55)) {
-    var __x56 = ____x55[____i8];
-    if (quasisplice63(__x56, depth)) {
-      var __x57 = quasiexpand(__x56[1]);
-      add(__xs, __x57);
+  var ____x58 = form;
+  var ____i9 = 0;
+  while (____i9 < _35(____x58)) {
+    var __x59 = ____x58[____i9];
+    if (quasisplice63(__x59, depth)) {
+      var __x60 = quasiexpand(__x59[1]);
+      add(__xs, __x60);
       add(__xs, ["list"]);
     } else {
-      add(last(__xs), quasiexpand(__x56, depth));
+      add(last(__xs), quasiexpand(__x59, depth));
     }
-    ____i8 = ____i8 + 1;
+    ____i9 = ____i9 + 1;
   }
   var __pruned = keep(function (x) {
     return _35(x) > 1 || !( hd(x) === "list") || keys63(x);
@@ -378,8 +390,8 @@ quasiexpand = function (form, depth) {
     }
   }
 };
-expand_if = function (__x61) {
-  var ____id5 = __x61;
+expand_if = function (__x64) {
+  var ____id5 = __x64;
   var __a = ____id5[0];
   var __b1 = ____id5[1];
   var __c = cut(____id5, 2);
@@ -394,10 +406,10 @@ expand_if = function (__x61) {
 indent_level = 0;
 indentation = function () {
   var __s = "";
-  var __i9 = 0;
-  while (__i9 < indent_level) {
+  var __i10 = 0;
+  while (__i10 < indent_level) {
     __s = __s + "  ";
-    __i9 = __i9 + 1;
+    __i10 = __i10 + 1;
   }
   return __s;
 };
@@ -409,38 +421,38 @@ var valid_code63 = function (n) {
   return number_code63(n) || n > 64 && n < 91 || n > 96 && n < 123 || n === 95;
 };
 var id = function (id) {
-  var __e29 = undefined;
+  var __e32 = undefined;
   if (number_code63(code(id, 0))) {
-    __e29 = "_";
+    __e32 = "_";
   } else {
-    __e29 = "";
+    __e32 = "";
   }
-  var __id11 = __e29;
-  var __i10 = 0;
-  while (__i10 < _35(id)) {
-    var __c1 = char(id, __i10);
+  var __id11 = __e32;
+  var __i11 = 0;
+  while (__i11 < _35(id)) {
+    var __c1 = char(id, __i11);
     var __n7 = code(__c1);
-    var __e30 = undefined;
+    var __e33 = undefined;
     if (__c1 === "-" && !( id === "-")) {
-      __e30 = "_";
+      __e33 = "_";
     } else {
-      var __e31 = undefined;
+      var __e34 = undefined;
       if (valid_code63(__n7)) {
-        __e31 = __c1;
+        __e34 = __c1;
       } else {
-        var __e32 = undefined;
-        if (__i10 === 0) {
-          __e32 = "_" + __n7;
+        var __e35 = undefined;
+        if (__i11 === 0) {
+          __e35 = "_" + __n7;
         } else {
-          __e32 = __n7;
+          __e35 = __n7;
         }
-        __e31 = __e32;
+        __e34 = __e35;
       }
-      __e30 = __e31;
+      __e33 = __e34;
     }
-    var __c11 = __e30;
+    var __c11 = __e33;
     __id11 = __id11 + __c11;
-    __i10 = __i10 + 1;
+    __i11 = __i11 + 1;
   }
   if (reserved63(__id11)) {
     return "_" + __id11;
@@ -453,20 +465,20 @@ valid_id63 = function (x) {
 };
 var __names = {};
 unique = function (x) {
-  var __x65 = id(x);
-  if (has63(__names, __x65)) {
-    var __i11 = __names[__x65];
-    __names[__x65] = __names[__x65] + 1;
-    return unique(__x65 + __i11);
+  var __x68 = id(x);
+  if (has63(__names, __x68)) {
+    var __i12 = __names[__x68];
+    __names[__x68] = __names[__x68] + 1;
+    return unique(__x68 + __i12);
   } else {
-    __names[__x65] = 1;
-    return "__" + __x65;
+    __names[__x68] = 1;
+    return "__" + __x68;
   }
 };
 key = function (k) {
-  var __i12 = inner(k);
-  if (valid_id63(__i12)) {
-    return __i12;
+  var __i13 = inner(k);
+  if (valid_id63(__i13)) {
+    return __i13;
   } else {
     if (target === "js") {
       return k;
@@ -481,59 +493,59 @@ mapo = function (f, t) {
   var __k9 = undefined;
   for (__k9 in ____o7) {
     var __v6 = ____o7[__k9];
-    var __e33 = undefined;
+    var __e36 = undefined;
     if (numeric63(__k9)) {
-      __e33 = parseInt(__k9);
+      __e36 = parseInt(__k9);
     } else {
-      __e33 = __k9;
+      __e36 = __k9;
     }
-    var __k10 = __e33;
-    var __x66 = f(__v6);
-    if (is63(__x66)) {
+    var __k10 = __e36;
+    var __x69 = f(__v6);
+    if (is63(__x69)) {
       add(__o6, literal(__k10));
-      add(__o6, __x66);
+      add(__o6, __x69);
     }
   }
   return __o6;
 };
-var ____x68 = [];
-var ____x69 = [];
-____x69.js = "!";
-____x69.lua = "not";
-____x68["not"] = ____x69;
-var ____x70 = [];
-____x70["*"] = true;
-____x70["/"] = true;
-____x70["%"] = true;
 var ____x71 = [];
 var ____x72 = [];
-____x72.js = "+";
-____x72.lua = "..";
-____x71.cat = ____x72;
+____x72.js = "!";
+____x72.lua = "not";
+____x71["not"] = ____x72;
 var ____x73 = [];
-____x73["+"] = true;
-____x73["-"] = true;
+____x73["*"] = true;
+____x73["/"] = true;
+____x73["%"] = true;
 var ____x74 = [];
-____x74["<"] = true;
-____x74[">"] = true;
-____x74["<="] = true;
-____x74[">="] = true;
 var ____x75 = [];
+____x75.js = "+";
+____x75.lua = "..";
+____x74.cat = ____x75;
 var ____x76 = [];
-____x76.js = "===";
-____x76.lua = "==";
-____x75["="] = ____x76;
+____x76["+"] = true;
+____x76["-"] = true;
 var ____x77 = [];
+____x77["<"] = true;
+____x77[">"] = true;
+____x77["<="] = true;
+____x77[">="] = true;
 var ____x78 = [];
-____x78.js = "&&";
-____x78.lua = "and";
-____x77["and"] = ____x78;
 var ____x79 = [];
+____x79.js = "===";
+____x79.lua = "==";
+____x78["="] = ____x79;
 var ____x80 = [];
-____x80.js = "||";
-____x80.lua = "or";
-____x79["or"] = ____x80;
-var infix = [____x68, ____x70, ____x71, ____x73, ____x74, ____x75, ____x77, ____x79];
+var ____x81 = [];
+____x81.js = "&&";
+____x81.lua = "and";
+____x80["and"] = ____x81;
+var ____x82 = [];
+var ____x83 = [];
+____x83.js = "||";
+____x83.lua = "or";
+____x82["or"] = ____x83;
+var infix = [____x71, ____x73, ____x74, ____x76, ____x77, ____x78, ____x80, ____x82];
 var unary63 = function (form) {
   return two63(form) && in63(hd(form), ["not", "-"]);
 };
@@ -546,13 +558,13 @@ var precedence = function (form) {
     var __k11 = undefined;
     for (__k11 in ____o8) {
       var __v7 = ____o8[__k11];
-      var __e34 = undefined;
+      var __e37 = undefined;
       if (numeric63(__k11)) {
-        __e34 = parseInt(__k11);
+        __e37 = parseInt(__k11);
       } else {
-        __e34 = __k11;
+        __e37 = __k11;
       }
-      var __k12 = __e34;
+      var __k12 = __e37;
       if (__v7[hd(form)]) {
         return index(__k12);
       }
@@ -562,12 +574,12 @@ var precedence = function (form) {
 };
 var getop = function (op) {
   return find(function (level) {
-    var __x82 = level[op];
-    if (__x82 === true) {
+    var __x85 = level[op];
+    if (__x85 === true) {
       return op;
     } else {
-      if (is63(__x82)) {
-        return __x82[target];
+      if (is63(__x85)) {
+        return __x85[target];
       }
     }
   }, infix);
@@ -583,23 +595,23 @@ var compile_args = function (args) {
 };
 var escape_newlines = function (s) {
   var __s1 = "";
-  var __i15 = 0;
-  while (__i15 < _35(s)) {
-    var __c2 = char(s, __i15);
-    var __e35 = undefined;
+  var __i16 = 0;
+  while (__i16 < _35(s)) {
+    var __c2 = char(s, __i16);
+    var __e38 = undefined;
     if (__c2 === "\n") {
-      __e35 = "\\n";
+      __e38 = "\\n";
     } else {
-      var __e36 = undefined;
+      var __e39 = undefined;
       if (__c2 === "\r") {
-        __e36 = "\\r";
+        __e39 = "\\r";
       } else {
-        __e36 = __c2;
+        __e39 = __c2;
       }
-      __e35 = __e36;
+      __e38 = __e39;
     }
-    __s1 = __s1 + __e35;
-    __i15 = __i15 + 1;
+    __s1 = __s1 + __e38;
+    __i16 = __i16 + 1;
   }
   return __s1;
 };
@@ -663,9 +675,9 @@ var terminator = function (stmt63) {
 };
 var compile_special = function (form, stmt63) {
   var ____id6 = form;
-  var __x83 = ____id6[0];
+  var __x86 = ____id6[0];
   var __args2 = cut(____id6, 1);
-  var ____id7 = getenv(__x83);
+  var ____id7 = getenv(__x86);
   var __special = ____id7.special;
   var __stmt = ____id7.stmt;
   var __self_tr63 = ____id7.tr;
@@ -691,13 +703,13 @@ var op_delims = function (parent, child) {
   var __child = destash33(child, ____r57);
   var ____id8 = ____r57;
   var __right = ____id8.right;
-  var __e37 = undefined;
+  var __e40 = undefined;
   if (__right) {
-    __e37 = _6261;
+    __e40 = _6261;
   } else {
-    __e37 = _62;
+    __e40 = _62;
   }
-  if (__e37(precedence(__child), precedence(__parent))) {
+  if (__e40(precedence(__child), precedence(__parent))) {
     return ["(", ")"];
   } else {
     return ["", ""];
@@ -731,40 +743,40 @@ compile_function = function (args, body) {
   var ____id13 = ____r59;
   var __name3 = ____id13.name;
   var __prefix = ____id13.prefix;
-  var __e38 = undefined;
+  var __e41 = undefined;
   if (__name3) {
-    __e38 = compile(__name3);
+    __e41 = compile(__name3);
   } else {
-    __e38 = "";
+    __e41 = "";
   }
-  var __id14 = __e38;
-  var __e39 = undefined;
+  var __id14 = __e41;
+  var __e42 = undefined;
   if (target === "lua" && __args4.rest) {
-    __e39 = join(__args4, ["|...|"]);
+    __e42 = join(__args4, ["|...|"]);
   } else {
-    __e39 = __args4;
+    __e42 = __args4;
   }
-  var __args12 = __e39;
+  var __args12 = __e42;
   var __args5 = compile_args(__args12);
   indent_level = indent_level + 1;
-  var ____x87 = compile(__body3, {_stash: true, stmt: true});
+  var ____x90 = compile(__body3, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __body4 = ____x87;
+  var __body4 = ____x90;
   var __ind = indentation();
-  var __e40 = undefined;
+  var __e43 = undefined;
   if (__prefix) {
-    __e40 = __prefix + " ";
+    __e43 = __prefix + " ";
   } else {
-    __e40 = "";
+    __e43 = "";
   }
-  var __p = __e40;
-  var __e41 = undefined;
+  var __p = __e43;
+  var __e44 = undefined;
   if (target === "js") {
-    __e41 = "";
+    __e44 = "";
   } else {
-    __e41 = "end";
+    __e44 = "end";
   }
-  var __tr1 = __e41;
+  var __tr1 = __e44;
   if (__name3) {
     __tr1 = __tr1 + "\n";
   }
@@ -789,26 +801,26 @@ compile = function (form) {
       return compile_special(__form, __stmt1);
     } else {
       var __tr2 = terminator(__stmt1);
-      var __e42 = undefined;
+      var __e45 = undefined;
       if (__stmt1) {
-        __e42 = indentation();
+        __e45 = indentation();
       } else {
-        __e42 = "";
+        __e45 = "";
       }
-      var __ind1 = __e42;
-      var __e43 = undefined;
+      var __ind1 = __e45;
+      var __e46 = undefined;
       if (atom63(__form)) {
-        __e43 = compile_atom(__form);
+        __e46 = compile_atom(__form);
       } else {
-        var __e44 = undefined;
+        var __e47 = undefined;
         if (infix63(hd(__form))) {
-          __e44 = compile_infix(__form);
+          __e47 = compile_infix(__form);
         } else {
-          __e44 = compile_call(__form);
+          __e47 = compile_call(__form);
         }
-        __e43 = __e44;
+        __e46 = __e47;
       }
-      var __form1 = __e43;
+      var __form1 = __e46;
       return __ind1 + __form1 + __tr2;
     }
   }
@@ -816,25 +828,25 @@ compile = function (form) {
 var lower_statement = function (form, tail63) {
   var __hoist = [];
   var __e = lower(form, __hoist, true, tail63);
-  var __e45 = undefined;
+  var __e48 = undefined;
   if (some63(__hoist) && is63(__e)) {
-    __e45 = join(["do"], __hoist, [__e]);
+    __e48 = join(["do"], __hoist, [__e]);
   } else {
-    var __e46 = undefined;
+    var __e49 = undefined;
     if (is63(__e)) {
-      __e46 = __e;
+      __e49 = __e;
     } else {
-      var __e47 = undefined;
+      var __e50 = undefined;
       if (_35(__hoist) > 1) {
-        __e47 = join(["do"], __hoist);
+        __e50 = join(["do"], __hoist);
       } else {
-        __e47 = hd(__hoist);
+        __e50 = hd(__hoist);
       }
-      __e46 = __e47;
+      __e49 = __e50;
     }
-    __e45 = __e46;
+    __e48 = __e49;
   }
-  return either(__e45, ["do"]);
+  return either(__e48, ["do"]);
 };
 var lower_body = function (body, tail63) {
   return lower_statement(join(["do"], body), tail63);
@@ -846,18 +858,18 @@ var standalone63 = function (form) {
   return ! atom63(form) && ! infix63(hd(form)) && ! literal63(form) && !( "get" === hd(form)) || id_literal63(form);
 };
 var lower_do = function (args, hoist, stmt63, tail63) {
-  var ____x93 = almost(args);
-  var ____i16 = 0;
-  while (____i16 < _35(____x93)) {
-    var __x94 = ____x93[____i16];
-    var ____y = lower(__x94, hoist, stmt63);
+  var ____x96 = almost(args);
+  var ____i17 = 0;
+  while (____i17 < _35(____x96)) {
+    var __x97 = ____x96[____i17];
+    var ____y = lower(__x97, hoist, stmt63);
     if (yes(____y)) {
       var __e1 = ____y;
       if (standalone63(__e1)) {
         add(hoist, __e1);
       }
     }
-    ____i16 = ____i16 + 1;
+    ____i17 = ____i17 + 1;
   }
   var __e2 = lower(last(args), hoist, stmt63, tail63);
   if (tail63 && can_return63(__e2)) {
@@ -883,19 +895,19 @@ var lower_if = function (args, hoist, stmt63, tail63) {
   var ___then = ____id17[1];
   var ___else = ____id17[2];
   if (stmt63) {
-    var __e49 = undefined;
+    var __e52 = undefined;
     if (is63(___else)) {
-      __e49 = [lower_body([___else], tail63)];
+      __e52 = [lower_body([___else], tail63)];
     }
-    return add(hoist, join(["%if", lower(__cond, hoist), lower_body([___then], tail63)], __e49));
+    return add(hoist, join(["%if", lower(__cond, hoist), lower_body([___then], tail63)], __e52));
   } else {
     var __e3 = unique("e");
     add(hoist, ["%local", __e3, "nil"]);
-    var __e48 = undefined;
+    var __e51 = undefined;
     if (is63(___else)) {
-      __e48 = [lower(["%set", __e3, ___else])];
+      __e51 = [lower(["%set", __e3, ___else])];
     }
-    add(hoist, join(["%if", lower(__cond, hoist), lower(["%set", __e3, ___then])], __e48));
+    add(hoist, join(["%if", lower(__cond, hoist), lower(["%set", __e3, ___then])], __e51));
     return __e3;
   }
 };
@@ -907,13 +919,13 @@ var lower_short = function (x, args, hoist) {
   var __b11 = lower(__b4, __hoist1);
   if (some63(__hoist1)) {
     var __id19 = unique("id");
-    var __e50 = undefined;
+    var __e53 = undefined;
     if (x === "and") {
-      __e50 = ["%if", __id19, __b4, __id19];
+      __e53 = ["%if", __id19, __b4, __id19];
     } else {
-      __e50 = ["%if", __id19, __id19, __b4];
+      __e53 = ["%if", __id19, __id19, __b4];
     }
-    return lower(["do", ["%local", __id19, __a3], __e50], hoist);
+    return lower(["do", ["%local", __id19, __a3], __e53], hoist);
   } else {
     return [x, lower(__a3, hoist), __b11];
   }
@@ -927,13 +939,13 @@ var lower_while = function (args, hoist) {
   var __body5 = cut(____id20, 1);
   var __pre = [];
   var __c4 = lower(__c3, __pre);
-  var __e51 = undefined;
+  var __e54 = undefined;
   if (none63(__pre)) {
-    __e51 = ["while", __c4, lower_body(__body5)];
+    __e54 = ["while", __c4, lower_body(__body5)];
   } else {
-    __e51 = ["while", true, join(["do"], __pre, [["%if", ["not", __c4], ["break"]], lower_body(__body5)])];
+    __e54 = ["while", true, join(["do"], __pre, [["%if", ["not", __c4], ["break"]], lower_body(__body5)])];
   }
-  return add(hoist, __e51);
+  return add(hoist, __e54);
 };
 var lower_for = function (args, hoist) {
   var ____id21 = args;
@@ -970,10 +982,10 @@ var lower_pairwise = function (form) {
   if (pairwise63(form)) {
     var __e4 = [];
     var ____id24 = form;
-    var __x123 = ____id24[0];
+    var __x126 = ____id24[0];
     var __args7 = cut(____id24, 1);
     reduce(function (a, b) {
-      add(__e4, [__x123, a, b]);
+      add(__e4, [__x126, a, b]);
       return a;
     }, __args7);
     return join(["and"], reverse(__e4));
@@ -987,10 +999,10 @@ var lower_infix63 = function (form) {
 var lower_infix = function (form, hoist) {
   var __form3 = lower_pairwise(form);
   var ____id25 = __form3;
-  var __x126 = ____id25[0];
+  var __x129 = ____id25[0];
   var __args8 = cut(____id25, 1);
   return lower(reduce(function (a, b) {
-    return [__x126, b, a];
+    return [__x129, b, a];
   }, reverse(__args8)), hoist);
 };
 var lower_special = function (form, hoist) {
@@ -1013,39 +1025,39 @@ lower = function (form, hoist, stmt63, tail63) {
           return lower_infix(form, hoist);
         } else {
           var ____id26 = form;
-          var __x129 = ____id26[0];
+          var __x132 = ____id26[0];
           var __args9 = cut(____id26, 1);
-          if (__x129 === "do") {
+          if (__x132 === "do") {
             return lower_do(__args9, hoist, stmt63, tail63);
           } else {
-            if (__x129 === "%call") {
+            if (__x132 === "%call") {
               return lower(__args9, hoist, stmt63, tail63);
             } else {
-              if (__x129 === "%set") {
+              if (__x132 === "%set") {
                 return lower_set(__args9, hoist, stmt63, tail63);
               } else {
-                if (__x129 === "%if") {
+                if (__x132 === "%if") {
                   return lower_if(__args9, hoist, stmt63, tail63);
                 } else {
-                  if (__x129 === "%try") {
+                  if (__x132 === "%try") {
                     return lower_try(__args9, hoist, tail63);
                   } else {
-                    if (__x129 === "while") {
+                    if (__x132 === "while") {
                       return lower_while(__args9, hoist);
                     } else {
-                      if (__x129 === "%for") {
+                      if (__x132 === "%for") {
                         return lower_for(__args9, hoist);
                       } else {
-                        if (__x129 === "%function") {
+                        if (__x132 === "%function") {
                           return lower_function(__args9);
                         } else {
-                          if (__x129 === "%local-function" || __x129 === "%global-function") {
-                            return lower_definition(__x129, __args9, hoist);
+                          if (__x132 === "%local-function" || __x132 === "%global-function") {
+                            return lower_definition(__x132, __args9, hoist);
                           } else {
-                            if (in63(__x129, ["and", "or"])) {
-                              return lower_short(__x129, __args9, hoist);
+                            if (in63(__x132, ["and", "or"])) {
+                              return lower_short(__x132, __args9, hoist);
                             } else {
-                              if (statement63(__x129)) {
+                              if (statement63(__x132)) {
                                 return lower_special(form, hoist);
                               } else {
                                 return lower_call(form, hoist);
@@ -1085,37 +1097,37 @@ immediate_call63 = function (x) {
 setenv("do", {_stash: true, special: function () {
   var __forms1 = unstash(Array.prototype.slice.call(arguments, 0));
   var __s2 = "";
-  var ____x134 = __forms1;
-  var ____i18 = 0;
-  while (____i18 < _35(____x134)) {
-    var __x135 = ____x134[____i18];
-    if (target === "lua" && immediate_call63(__x135) && "\n" === char(__s2, edge(__s2))) {
+  var ____x137 = __forms1;
+  var ____i19 = 0;
+  while (____i19 < _35(____x137)) {
+    var __x138 = ____x137[____i19];
+    if (target === "lua" && immediate_call63(__x138) && "\n" === char(__s2, edge(__s2))) {
       __s2 = clip(__s2, 0, edge(__s2)) + ";\n";
     }
-    __s2 = __s2 + compile(__x135, {_stash: true, stmt: true});
-    if (! atom63(__x135)) {
-      if (hd(__x135) === "return" || hd(__x135) === "break") {
+    __s2 = __s2 + compile(__x138, {_stash: true, stmt: true});
+    if (! atom63(__x138)) {
+      if (hd(__x138) === "return" || hd(__x138) === "break") {
         break;
       }
     }
-    ____i18 = ____i18 + 1;
+    ____i19 = ____i19 + 1;
   }
   return __s2;
 }, stmt: true, tr: true});
 setenv("%if", {_stash: true, special: function (cond, cons, alt) {
   var __cond2 = compile(cond);
   indent_level = indent_level + 1;
-  var ____x138 = compile(cons, {_stash: true, stmt: true});
+  var ____x141 = compile(cons, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __cons1 = ____x138;
-  var __e52 = undefined;
+  var __cons1 = ____x141;
+  var __e55 = undefined;
   if (alt) {
     indent_level = indent_level + 1;
-    var ____x139 = compile(alt, {_stash: true, stmt: true});
+    var ____x142 = compile(alt, {_stash: true, stmt: true});
     indent_level = indent_level - 1;
-    __e52 = ____x139;
+    __e55 = ____x142;
   }
-  var __alt1 = __e52;
+  var __alt1 = __e55;
   var __ind3 = indentation();
   var __s4 = "";
   if (target === "js") {
@@ -1139,9 +1151,9 @@ setenv("%if", {_stash: true, special: function (cond, cons, alt) {
 setenv("while", {_stash: true, special: function (cond, form) {
   var __cond4 = compile(cond);
   indent_level = indent_level + 1;
-  var ____x141 = compile(form, {_stash: true, stmt: true});
+  var ____x144 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __body10 = ____x141;
+  var __body10 = ____x144;
   var __ind5 = indentation();
   if (target === "js") {
     return __ind5 + "while (" + __cond4 + ") {\n" + __body10 + __ind5 + "}\n";
@@ -1153,9 +1165,9 @@ setenv("%for", {_stash: true, special: function (t, k, form) {
   var __t2 = compile(t);
   var __ind7 = indentation();
   indent_level = indent_level + 1;
-  var ____x143 = compile(form, {_stash: true, stmt: true});
+  var ____x146 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __body12 = ____x143;
+  var __body12 = ____x146;
   if (target === "lua") {
     return __ind7 + "for " + k + " in next, " + __t2 + " do\n" + __body12 + __ind7 + "end\n";
   } else {
@@ -1166,14 +1178,14 @@ setenv("%try", {_stash: true, special: function (form) {
   var __e8 = unique("e");
   var __ind9 = indentation();
   indent_level = indent_level + 1;
-  var ____x148 = compile(form, {_stash: true, stmt: true});
+  var ____x151 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __body14 = ____x148;
+  var __body14 = ____x151;
   var __hf1 = ["return", ["%array", false, __e8]];
   indent_level = indent_level + 1;
-  var ____x151 = compile(__hf1, {_stash: true, stmt: true});
+  var ____x154 = compile(__hf1, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __h1 = ____x151;
+  var __h1 = ____x154;
   return __ind9 + "try {\n" + __body14 + __ind9 + "}\n" + __ind9 + "catch (" + __e8 + ") {\n" + __h1 + __ind9 + "}\n";
 }, stmt: true, tr: true});
 setenv("%delete", {_stash: true, special: function (place) {
@@ -1187,29 +1199,33 @@ setenv("%function", {_stash: true, special: function (args, body) {
 }});
 setenv("%global-function", {_stash: true, special: function (name, args, body) {
   if (target === "lua") {
-    var __x155 = compile_function(args, body, {_stash: true, name: name});
-    return indentation() + __x155;
+    var __x158 = compile_function(args, body, {_stash: true, name: name});
+    return indentation() + __x158;
   } else {
     return compile(["%set", name, ["%function", args, body]], {_stash: true, stmt: true});
   }
 }, stmt: true, tr: true});
 setenv("%local-function", {_stash: true, special: function (name, args, body) {
   if (target === "lua") {
-    var __x161 = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
-    return indentation() + __x161;
+    var __x164 = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
+    return indentation() + __x164;
   } else {
     return compile(["%local", name, ["%function", args, body]], {_stash: true, stmt: true});
   }
 }, stmt: true, tr: true});
-setenv("return", {_stash: true, special: function (x) {
-  var __e53 = undefined;
-  if (nil63(x)) {
-    __e53 = "return";
-  } else {
-    __e53 = "return " + compile(x);
+setenv("return", {_stash: true, special: function () {
+  var __args111 = unstash(Array.prototype.slice.call(arguments, 0));
+  var __s6 = mapcat(compile, __args111, ", ");
+  if (target === "js" && _35(__args111) > 1) {
+    __s6 = "[" + __s6 + "]";
   }
-  var __x165 = __e53;
-  return indentation() + __x165;
+  var __e56 = undefined;
+  if (some63(__s6)) {
+    __e56 = " ";
+  } else {
+    __e56 = "";
+  }
+  return indentation() + "return" + __e56 + __s6;
 }, stmt: true});
 setenv("new", {_stash: true, special: function (x) {
   return "new " + compile(x);
@@ -1218,44 +1234,57 @@ setenv("typeof", {_stash: true, special: function (x) {
   return "typeof(" + compile(x) + ")";
 }});
 setenv("throw", {_stash: true, special: function (x) {
-  var __e54 = undefined;
+  var __e57 = undefined;
   if (target === "js") {
-    __e54 = "throw " + compile(x);
+    __e57 = "throw " + compile(x);
   } else {
-    __e54 = "error(" + compile(x) + ")";
+    __e57 = "error(" + compile(x) + ")";
   }
-  var __e12 = __e54;
+  var __e12 = __e57;
   return indentation() + __e12;
 }, stmt: true});
 setenv("%local", {_stash: true, special: function (name, value) {
-  var __id28 = compile(name);
+  var __e58 = undefined;
+  if (obj63(name)) {
+    var __s8 = mapcat(compile, name, ", ");
+    var __e59 = undefined;
+    if (target === "js") {
+      __e59 = "[" + __s8 + "]";
+    } else {
+      __e59 = __s8;
+    }
+    __e58 = __e59;
+  } else {
+    __e58 = compile(name);
+  }
+  var __id28 = __e58;
   var __value11 = compile(value);
-  var __e55 = undefined;
+  var __e60 = undefined;
   if (is63(value)) {
-    __e55 = " = " + __value11;
+    __e60 = " = " + __value11;
   } else {
-    __e55 = "";
+    __e60 = "";
   }
-  var __rh2 = __e55;
-  var __e56 = undefined;
+  var __rh2 = __e60;
+  var __e61 = undefined;
   if (target === "js") {
-    __e56 = "var ";
+    __e61 = "var ";
   } else {
-    __e56 = "local ";
+    __e61 = "local ";
   }
-  var __keyword1 = __e56;
+  var __keyword1 = __e61;
   var __ind11 = indentation();
   return __ind11 + __keyword1 + __id28 + __rh2;
 }, stmt: true});
 setenv("%set", {_stash: true, special: function (lh, rh) {
   var __lh2 = compile(lh);
-  var __e57 = undefined;
+  var __e62 = undefined;
   if (nil63(rh)) {
-    __e57 = "nil";
+    __e62 = "nil";
   } else {
-    __e57 = rh;
+    __e62 = rh;
   }
-  var __rh4 = compile(__e57);
+  var __rh4 = compile(__e62);
   return indentation() + __lh2 + " = " + __rh4;
 }, stmt: true});
 setenv("get", {_stash: true, special: function (t, k) {
@@ -1272,42 +1301,42 @@ setenv("get", {_stash: true, special: function (t, k) {
 }});
 setenv("%array", {_stash: true, special: function () {
   var __forms3 = unstash(Array.prototype.slice.call(arguments, 0));
-  var __e58 = undefined;
+  var __e63 = undefined;
   if (target === "lua") {
-    __e58 = "{";
+    __e63 = "{";
   } else {
-    __e58 = "[";
+    __e63 = "[";
   }
-  var __open1 = __e58;
-  var __e59 = undefined;
+  var __open1 = __e63;
+  var __e64 = undefined;
   if (target === "lua") {
-    __e59 = "}";
+    __e64 = "}";
   } else {
-    __e59 = "]";
+    __e64 = "]";
   }
-  var __close1 = __e59;
+  var __close1 = __e64;
   return __open1 + mapcat(compile, __forms3, ", ") + __close1;
 }});
 setenv("%object", {_stash: true, special: function () {
   var __forms5 = unstash(Array.prototype.slice.call(arguments, 0));
-  var __e60 = undefined;
+  var __e65 = undefined;
   if (target === "lua") {
-    __e60 = " = ";
+    __e65 = " = ";
   } else {
-    __e60 = ": ";
+    __e65 = ": ";
   }
-  var __sep1 = __e60;
-  var __s6 = mapcat(function (__x167) {
-    var ____id30 = __x167;
+  var __sep1 = __e65;
+  var __s10 = mapcat(function (__x168) {
+    var ____id30 = __x168;
     var __k15 = ____id30[0];
     var __v9 = ____id30[1];
     return key(__k15) + __sep1 + compile(__v9);
   }, pair(__forms5), ", ");
-  return "{" + __s6 + "}";
+  return "{" + __s10 + "}";
 }});
 setenv("%literal", {_stash: true, special: function () {
-  var __args111 = unstash(Array.prototype.slice.call(arguments, 0));
-  return mapcat(compile, __args111);
+  var __args13 = unstash(Array.prototype.slice.call(arguments, 0));
+  return mapcat(compile, __args13);
 }});
 exports.run = run;
 exports["eval"] = _eval;

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -4,13 +4,13 @@ local function getenv(k, p)
     while __i >= 0 do
       local __b = environment[__i + 1][k]
       if is63(__b) then
-        local __e21 = nil
+        local __e19 = nil
         if p then
-          __e21 = __b[p]
+          __e19 = __b[p]
         else
-          __e21 = __b
+          __e19 = __b
         end
-        return __e21
+        return __e19
       else
         __i = __i - 1
       end
@@ -99,21 +99,21 @@ function bind(lh, rh)
     local __k1 = nil
     for __k1 in next, ____o1 do
       local __v1 = ____o1[__k1]
-      local __e22 = nil
+      local __e20 = nil
       if __k1 == "rest" then
-        __e22 = {"cut", __id, _35(lh)}
+        __e20 = {"cut", __id, _35(lh)}
       else
-        __e22 = {"get", __id, {"quote", bias(__k1)}}
+        __e20 = {"get", __id, {"quote", bias(__k1)}}
       end
-      local __x5 = __e22
+      local __x5 = __e20
       if is63(__k1) then
-        local __e23 = nil
+        local __e21 = nil
         if __v1 == true then
-          __e23 = __k1
+          __e21 = __k1
         else
-          __e23 = __v1
+          __e21 = __v1
         end
-        local __k2 = __e23
+        local __k2 = __e21
         __bs = join(__bs, bind(__k2, __x5))
       end
     end
@@ -267,13 +267,13 @@ local function quasiquote_list(form, depth)
   for __k4 in next, ____o5 do
     local __v4 = ____o5[__k4]
     if not number63(__k4) then
-      local __e24 = nil
+      local __e22 = nil
       if quasisplice63(__v4, depth) then
-        __e24 = quasiexpand(__v4[2])
+        __e22 = quasiexpand(__v4[2])
       else
-        __e24 = quasiexpand(__v4, depth)
+        __e22 = quasiexpand(__v4, depth)
       end
-      local __v5 = __e24
+      local __v5 = __e22
       last(__xs)[__k4] = __v5
     end
   end
@@ -367,36 +367,36 @@ local function valid_code63(n)
   return number_code63(n) or n > 64 and n < 91 or n > 96 and n < 123 or n == 95
 end
 local function id(id)
-  local __e25 = nil
+  local __e23 = nil
   if number_code63(code(id, 0)) then
-    __e25 = "_"
+    __e23 = "_"
   else
-    __e25 = ""
+    __e23 = ""
   end
-  local __id11 = __e25
+  local __id11 = __e23
   local __i10 = 0
   while __i10 < _35(id) do
     local __c1 = char(id, __i10)
     local __n7 = code(__c1)
-    local __e26 = nil
+    local __e24 = nil
     if __c1 == "-" and not( id == "-") then
-      __e26 = "_"
+      __e24 = "_"
     else
-      local __e27 = nil
+      local __e25 = nil
       if valid_code63(__n7) then
-        __e27 = __c1
+        __e25 = __c1
       else
-        local __e28 = nil
+        local __e26 = nil
         if __i10 == 0 then
-          __e28 = "_" .. __n7
+          __e26 = "_" .. __n7
         else
-          __e28 = __n7
+          __e26 = __n7
         end
-        __e27 = __e28
+        __e25 = __e26
       end
-      __e26 = __e27
+      __e24 = __e25
     end
-    local __c11 = __e26
+    local __c11 = __e24
     __id11 = __id11 .. __c11
     __i10 = __i10 + 1
   end
@@ -525,39 +525,29 @@ function infix_operator63(x)
   return obj63(x) and infix63(hd(x))
 end
 local function compile_args(args)
-  local __s1 = "("
-  local __c2 = ""
-  local ____x83 = args
-  local ____i15 = 0
-  while ____i15 < _35(____x83) do
-    local __x84 = ____x83[____i15 + 1]
-    __s1 = __s1 .. __c2 .. compile(__x84)
-    __c2 = ", "
-    ____i15 = ____i15 + 1
-  end
-  return __s1 .. ")"
+  return "(" .. mapcat(compile, args, ", ") .. ")"
 end
 local function escape_newlines(s)
-  local __s11 = ""
-  local __i16 = 0
-  while __i16 < _35(s) do
-    local __c3 = char(s, __i16)
-    local __e29 = nil
-    if __c3 == "\n" then
-      __e29 = "\\n"
+  local __s1 = ""
+  local __i15 = 0
+  while __i15 < _35(s) do
+    local __c2 = char(s, __i15)
+    local __e27 = nil
+    if __c2 == "\n" then
+      __e27 = "\\n"
     else
-      local __e30 = nil
-      if __c3 == "\r" then
-        __e30 = "\\r"
+      local __e28 = nil
+      if __c2 == "\r" then
+        __e28 = "\\r"
       else
-        __e30 = __c3
+        __e28 = __c2
       end
-      __e29 = __e30
+      __e27 = __e28
     end
-    __s11 = __s11 .. __e29
-    __i16 = __i16 + 1
+    __s1 = __s1 .. __e27
+    __i15 = __i15 + 1
   end
-  return __s11
+  return __s1
 end
 local function compile_atom(x)
   if x == "nil" and target == "lua" then
@@ -619,9 +609,9 @@ local function terminator(stmt63)
 end
 local function compile_special(form, stmt63)
   local ____id6 = form
-  local __x85 = ____id6[1]
+  local __x83 = ____id6[1]
   local __args2 = cut(____id6, 1)
-  local ____id7 = getenv(__x85)
+  local ____id7 = getenv(__x83)
   local __special = ____id7.special
   local __stmt = ____id7.stmt
   local __self_tr63 = ____id7.tr
@@ -647,13 +637,13 @@ local function op_delims(parent, child, ...)
   local __child = destash33(child, ____r57)
   local ____id8 = ____r57
   local __right = ____id8.right
-  local __e31 = nil
+  local __e29 = nil
   if __right then
-    __e31 = _6261
+    __e29 = _6261
   else
-    __e31 = _62
+    __e29 = _62
   end
-  if __e31(precedence(__child), precedence(__parent)) then
+  if __e29(precedence(__child), precedence(__parent)) then
     return {"(", ")"}
   else
     return {"", ""}
@@ -687,40 +677,40 @@ function compile_function(args, body, ...)
   local ____id13 = ____r59
   local __name3 = ____id13.name
   local __prefix = ____id13.prefix
-  local __e32 = nil
+  local __e30 = nil
   if __name3 then
-    __e32 = compile(__name3)
+    __e30 = compile(__name3)
+  else
+    __e30 = ""
+  end
+  local __id14 = __e30
+  local __e31 = nil
+  if target == "lua" and __args4.rest then
+    __e31 = join(__args4, {"|...|"})
+  else
+    __e31 = __args4
+  end
+  local __args12 = __e31
+  local __args5 = compile_args(__args12)
+  indent_level = indent_level + 1
+  local ____x89 = compile(__body3, {_stash = true, stmt = true})
+  indent_level = indent_level - 1
+  local __body4 = ____x89
+  local __ind = indentation()
+  local __e32 = nil
+  if __prefix then
+    __e32 = __prefix .. " "
   else
     __e32 = ""
   end
-  local __id14 = __e32
+  local __p = __e32
   local __e33 = nil
-  if target == "lua" and __args4.rest then
-    __e33 = join(__args4, {"|...|"})
-  else
-    __e33 = __args4
-  end
-  local __args12 = __e33
-  local __args5 = compile_args(__args12)
-  indent_level = indent_level + 1
-  local ____x91 = compile(__body3, {_stash = true, stmt = true})
-  indent_level = indent_level - 1
-  local __body4 = ____x91
-  local __ind = indentation()
-  local __e34 = nil
-  if __prefix then
-    __e34 = __prefix .. " "
-  else
-    __e34 = ""
-  end
-  local __p = __e34
-  local __e35 = nil
   if target == "js" then
-    __e35 = ""
+    __e33 = ""
   else
-    __e35 = "end"
+    __e33 = "end"
   end
-  local __tr1 = __e35
+  local __tr1 = __e33
   if __name3 then
     __tr1 = __tr1 .. "\n"
   end
@@ -745,26 +735,26 @@ function compile(form, ...)
       return compile_special(__form, __stmt1)
     else
       local __tr2 = terminator(__stmt1)
-      local __e36 = nil
+      local __e34 = nil
       if __stmt1 then
-        __e36 = indentation()
+        __e34 = indentation()
       else
-        __e36 = ""
+        __e34 = ""
       end
-      local __ind1 = __e36
-      local __e37 = nil
+      local __ind1 = __e34
+      local __e35 = nil
       if atom63(__form) then
-        __e37 = compile_atom(__form)
+        __e35 = compile_atom(__form)
       else
-        local __e38 = nil
+        local __e36 = nil
         if infix63(hd(__form)) then
-          __e38 = compile_infix(__form)
+          __e36 = compile_infix(__form)
         else
-          __e38 = compile_call(__form)
+          __e36 = compile_call(__form)
         end
-        __e37 = __e38
+        __e35 = __e36
       end
-      local __form1 = __e37
+      local __form1 = __e35
       return __ind1 .. __form1 .. __tr2
     end
   end
@@ -772,25 +762,25 @@ end
 local function lower_statement(form, tail63)
   local __hoist = {}
   local __e = lower(form, __hoist, true, tail63)
-  local __e39 = nil
+  local __e37 = nil
   if some63(__hoist) and is63(__e) then
-    __e39 = join({"do"}, __hoist, {__e})
+    __e37 = join({"do"}, __hoist, {__e})
   else
-    local __e40 = nil
+    local __e38 = nil
     if is63(__e) then
-      __e40 = __e
+      __e38 = __e
     else
-      local __e41 = nil
+      local __e39 = nil
       if _35(__hoist) > 1 then
-        __e41 = join({"do"}, __hoist)
+        __e39 = join({"do"}, __hoist)
       else
-        __e41 = hd(__hoist)
+        __e39 = hd(__hoist)
       end
-      __e40 = __e41
+      __e38 = __e39
     end
-    __e39 = __e40
+    __e37 = __e38
   end
-  return either(__e39, {"do"})
+  return either(__e37, {"do"})
 end
 local function lower_body(body, tail63)
   return lower_statement(join({"do"}, body), tail63)
@@ -802,18 +792,18 @@ local function standalone63(form)
   return not atom63(form) and not infix63(hd(form)) and not literal63(form) and not( "get" == hd(form)) or id_literal63(form)
 end
 local function lower_do(args, hoist, stmt63, tail63)
-  local ____x98 = almost(args)
-  local ____i17 = 0
-  while ____i17 < _35(____x98) do
-    local __x99 = ____x98[____i17 + 1]
-    local ____y = lower(__x99, hoist, stmt63)
+  local ____x96 = almost(args)
+  local ____i16 = 0
+  while ____i16 < _35(____x96) do
+    local __x97 = ____x96[____i16 + 1]
+    local ____y = lower(__x97, hoist, stmt63)
     if yes(____y) then
       local __e1 = ____y
       if standalone63(__e1) then
         add(hoist, __e1)
       end
     end
-    ____i17 = ____i17 + 1
+    ____i16 = ____i16 + 1
   end
   local __e2 = lower(last(args), hoist, stmt63, tail63)
   if tail63 and can_return63(__e2) then
@@ -839,19 +829,19 @@ local function lower_if(args, hoist, stmt63, tail63)
   local ___then = ____id17[2]
   local ___else = ____id17[3]
   if stmt63 then
-    local __e43 = nil
+    local __e41 = nil
     if is63(___else) then
-      __e43 = {lower_body({___else}, tail63)}
+      __e41 = {lower_body({___else}, tail63)}
     end
-    return add(hoist, join({"%if", lower(__cond, hoist), lower_body({___then}, tail63)}, __e43))
+    return add(hoist, join({"%if", lower(__cond, hoist), lower_body({___then}, tail63)}, __e41))
   else
     local __e3 = unique("e")
     add(hoist, {"%local", __e3, "nil"})
-    local __e42 = nil
+    local __e40 = nil
     if is63(___else) then
-      __e42 = {lower({"%set", __e3, ___else})}
+      __e40 = {lower({"%set", __e3, ___else})}
     end
-    add(hoist, join({"%if", lower(__cond, hoist), lower({"%set", __e3, ___then})}, __e42))
+    add(hoist, join({"%if", lower(__cond, hoist), lower({"%set", __e3, ___then})}, __e40))
     return __e3
   end
 end
@@ -863,13 +853,13 @@ local function lower_short(x, args, hoist)
   local __b11 = lower(__b4, __hoist1)
   if some63(__hoist1) then
     local __id19 = unique("id")
-    local __e44 = nil
+    local __e42 = nil
     if x == "and" then
-      __e44 = {"%if", __id19, __b4, __id19}
+      __e42 = {"%if", __id19, __b4, __id19}
     else
-      __e44 = {"%if", __id19, __id19, __b4}
+      __e42 = {"%if", __id19, __id19, __b4}
     end
-    return lower({"do", {"%local", __id19, __a3}, __e44}, hoist)
+    return lower({"do", {"%local", __id19, __a3}, __e42}, hoist)
   else
     return {x, lower(__a3, hoist), __b11}
   end
@@ -879,17 +869,17 @@ local function lower_try(args, hoist, tail63)
 end
 local function lower_while(args, hoist)
   local ____id20 = args
-  local __c4 = ____id20[1]
+  local __c3 = ____id20[1]
   local __body5 = cut(____id20, 1)
   local __pre = {}
-  local __c5 = lower(__c4, __pre)
-  local __e45 = nil
+  local __c4 = lower(__c3, __pre)
+  local __e43 = nil
   if none63(__pre) then
-    __e45 = {"while", __c5, lower_body(__body5)}
+    __e43 = {"while", __c4, lower_body(__body5)}
   else
-    __e45 = {"while", true, join({"do"}, __pre, {{"%if", {"not", __c5}, {"break"}}, lower_body(__body5)})}
+    __e43 = {"while", true, join({"do"}, __pre, {{"%if", {"not", __c4}, {"break"}}, lower_body(__body5)})}
   end
-  return add(hoist, __e45)
+  return add(hoist, __e43)
 end
 local function lower_for(args, hoist)
   local ____id21 = args
@@ -926,10 +916,10 @@ local function lower_pairwise(form)
   if pairwise63(form) then
     local __e4 = {}
     local ____id24 = form
-    local __x128 = ____id24[1]
+    local __x126 = ____id24[1]
     local __args7 = cut(____id24, 1)
     reduce(function (a, b)
-      add(__e4, {__x128, a, b})
+      add(__e4, {__x126, a, b})
       return a
     end, __args7)
     return join({"and"}, reverse(__e4))
@@ -943,10 +933,10 @@ end
 local function lower_infix(form, hoist)
   local __form3 = lower_pairwise(form)
   local ____id25 = __form3
-  local __x131 = ____id25[1]
+  local __x129 = ____id25[1]
   local __args8 = cut(____id25, 1)
   return lower(reduce(function (a, b)
-    return {__x131, b, a}
+    return {__x129, b, a}
   end, reverse(__args8)), hoist)
 end
 local function lower_special(form, hoist)
@@ -969,39 +959,39 @@ function lower(form, hoist, stmt63, tail63)
           return lower_infix(form, hoist)
         else
           local ____id26 = form
-          local __x134 = ____id26[1]
+          local __x132 = ____id26[1]
           local __args9 = cut(____id26, 1)
-          if __x134 == "do" then
+          if __x132 == "do" then
             return lower_do(__args9, hoist, stmt63, tail63)
           else
-            if __x134 == "%call" then
+            if __x132 == "%call" then
               return lower(__args9, hoist, stmt63, tail63)
             else
-              if __x134 == "%set" then
+              if __x132 == "%set" then
                 return lower_set(__args9, hoist, stmt63, tail63)
               else
-                if __x134 == "%if" then
+                if __x132 == "%if" then
                   return lower_if(__args9, hoist, stmt63, tail63)
                 else
-                  if __x134 == "%try" then
+                  if __x132 == "%try" then
                     return lower_try(__args9, hoist, tail63)
                   else
-                    if __x134 == "while" then
+                    if __x132 == "while" then
                       return lower_while(__args9, hoist)
                     else
-                      if __x134 == "%for" then
+                      if __x132 == "%for" then
                         return lower_for(__args9, hoist)
                       else
-                        if __x134 == "%function" then
+                        if __x132 == "%function" then
                           return lower_function(__args9)
                         else
-                          if __x134 == "%local-function" or __x134 == "%global-function" then
-                            return lower_definition(__x134, __args9, hoist)
+                          if __x132 == "%local-function" or __x132 == "%global-function" then
+                            return lower_definition(__x132, __args9, hoist)
                           else
-                            if in63(__x134, {"and", "or"}) then
-                              return lower_short(__x134, __args9, hoist)
+                            if in63(__x132, {"and", "or"}) then
+                              return lower_short(__x132, __args9, hoist)
                             else
-                              if statement63(__x134) then
+                              if statement63(__x132) then
                                 return lower_special(form, hoist)
                               else
                                 return lower_call(form, hoist)
@@ -1047,64 +1037,64 @@ function immediate_call63(x)
 end
 setenv("do", {_stash = true, special = function (...)
   local __forms1 = unstash({...})
-  local __s3 = ""
-  local ____x140 = __forms1
-  local ____i19 = 0
-  while ____i19 < _35(____x140) do
-    local __x141 = ____x140[____i19 + 1]
-    if target == "lua" and immediate_call63(__x141) and "\n" == char(__s3, edge(__s3)) then
-      __s3 = clip(__s3, 0, edge(__s3)) .. ";\n"
+  local __s2 = ""
+  local ____x138 = __forms1
+  local ____i18 = 0
+  while ____i18 < _35(____x138) do
+    local __x139 = ____x138[____i18 + 1]
+    if target == "lua" and immediate_call63(__x139) and "\n" == char(__s2, edge(__s2)) then
+      __s2 = clip(__s2, 0, edge(__s2)) .. ";\n"
     end
-    __s3 = __s3 .. compile(__x141, {_stash = true, stmt = true})
-    if not atom63(__x141) then
-      if hd(__x141) == "return" or hd(__x141) == "break" then
+    __s2 = __s2 .. compile(__x139, {_stash = true, stmt = true})
+    if not atom63(__x139) then
+      if hd(__x139) == "return" or hd(__x139) == "break" then
         break
       end
     end
-    ____i19 = ____i19 + 1
+    ____i18 = ____i18 + 1
   end
-  return __s3
+  return __s2
 end, stmt = true, tr = true})
 setenv("%if", {_stash = true, special = function (cond, cons, alt)
   local __cond2 = compile(cond)
   indent_level = indent_level + 1
-  local ____x144 = compile(cons, {_stash = true, stmt = true})
+  local ____x142 = compile(cons, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __cons1 = ____x144
-  local __e46 = nil
+  local __cons1 = ____x142
+  local __e44 = nil
   if alt then
     indent_level = indent_level + 1
-    local ____x145 = compile(alt, {_stash = true, stmt = true})
+    local ____x143 = compile(alt, {_stash = true, stmt = true})
     indent_level = indent_level - 1
-    __e46 = ____x145
+    __e44 = ____x143
   end
-  local __alt1 = __e46
+  local __alt1 = __e44
   local __ind3 = indentation()
-  local __s5 = ""
+  local __s4 = ""
   if target == "js" then
-    __s5 = __s5 .. __ind3 .. "if (" .. __cond2 .. ") {\n" .. __cons1 .. __ind3 .. "}"
+    __s4 = __s4 .. __ind3 .. "if (" .. __cond2 .. ") {\n" .. __cons1 .. __ind3 .. "}"
   else
-    __s5 = __s5 .. __ind3 .. "if " .. __cond2 .. " then\n" .. __cons1
+    __s4 = __s4 .. __ind3 .. "if " .. __cond2 .. " then\n" .. __cons1
   end
   if __alt1 and target == "js" then
-    __s5 = __s5 .. " else {\n" .. __alt1 .. __ind3 .. "}"
+    __s4 = __s4 .. " else {\n" .. __alt1 .. __ind3 .. "}"
   else
     if __alt1 then
-      __s5 = __s5 .. __ind3 .. "else\n" .. __alt1
+      __s4 = __s4 .. __ind3 .. "else\n" .. __alt1
     end
   end
   if target == "lua" then
-    return __s5 .. __ind3 .. "end\n"
+    return __s4 .. __ind3 .. "end\n"
   else
-    return __s5 .. "\n"
+    return __s4 .. "\n"
   end
 end, stmt = true, tr = true})
 setenv("while", {_stash = true, special = function (cond, form)
   local __cond4 = compile(cond)
   indent_level = indent_level + 1
-  local ____x147 = compile(form, {_stash = true, stmt = true})
+  local ____x145 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __body10 = ____x147
+  local __body10 = ____x145
   local __ind5 = indentation()
   if target == "js" then
     return __ind5 .. "while (" .. __cond4 .. ") {\n" .. __body10 .. __ind5 .. "}\n"
@@ -1116,9 +1106,9 @@ setenv("%for", {_stash = true, special = function (t, k, form)
   local __t2 = compile(t)
   local __ind7 = indentation()
   indent_level = indent_level + 1
-  local ____x149 = compile(form, {_stash = true, stmt = true})
+  local ____x147 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __body12 = ____x149
+  local __body12 = ____x147
   if target == "lua" then
     return __ind7 .. "for " .. k .. " in next, " .. __t2 .. " do\n" .. __body12 .. __ind7 .. "end\n"
   else
@@ -1129,14 +1119,14 @@ setenv("%try", {_stash = true, special = function (form)
   local __e8 = unique("e")
   local __ind9 = indentation()
   indent_level = indent_level + 1
-  local ____x154 = compile(form, {_stash = true, stmt = true})
+  local ____x152 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __body14 = ____x154
+  local __body14 = ____x152
   local __hf1 = {"return", {"%array", false, __e8}}
   indent_level = indent_level + 1
-  local ____x157 = compile(__hf1, {_stash = true, stmt = true})
+  local ____x155 = compile(__hf1, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __h1 = ____x157
+  local __h1 = ____x155
   return __ind9 .. "try {\n" .. __body14 .. __ind9 .. "}\n" .. __ind9 .. "catch (" .. __e8 .. ") {\n" .. __h1 .. __ind9 .. "}\n"
 end, stmt = true, tr = true})
 setenv("%delete", {_stash = true, special = function (place)
@@ -1150,29 +1140,29 @@ setenv("%function", {_stash = true, special = function (args, body)
 end})
 setenv("%global-function", {_stash = true, special = function (name, args, body)
   if target == "lua" then
-    local __x161 = compile_function(args, body, {_stash = true, name = name})
-    return indentation() .. __x161
+    local __x159 = compile_function(args, body, {_stash = true, name = name})
+    return indentation() .. __x159
   else
     return compile({"%set", name, {"%function", args, body}}, {_stash = true, stmt = true})
   end
 end, stmt = true, tr = true})
 setenv("%local-function", {_stash = true, special = function (name, args, body)
   if target == "lua" then
-    local __x167 = compile_function(args, body, {_stash = true, name = name, prefix = "local"})
-    return indentation() .. __x167
+    local __x165 = compile_function(args, body, {_stash = true, name = name, prefix = "local"})
+    return indentation() .. __x165
   else
     return compile({"%local", name, {"%function", args, body}}, {_stash = true, stmt = true})
   end
 end, stmt = true, tr = true})
 setenv("return", {_stash = true, special = function (x)
-  local __e47 = nil
+  local __e45 = nil
   if nil63(x) then
-    __e47 = "return"
+    __e45 = "return"
   else
-    __e47 = "return " .. compile(x)
+    __e45 = "return " .. compile(x)
   end
-  local __x171 = __e47
-  return indentation() .. __x171
+  local __x169 = __e45
+  return indentation() .. __x169
 end, stmt = true})
 setenv("new", {_stash = true, special = function (x)
   return "new " .. compile(x)
@@ -1181,44 +1171,44 @@ setenv("typeof", {_stash = true, special = function (x)
   return "typeof(" .. compile(x) .. ")"
 end})
 setenv("throw", {_stash = true, special = function (x)
-  local __e48 = nil
+  local __e46 = nil
   if target == "js" then
-    __e48 = "throw " .. compile(x)
+    __e46 = "throw " .. compile(x)
   else
-    __e48 = "error(" .. compile(x) .. ")"
+    __e46 = "error(" .. compile(x) .. ")"
   end
-  local __e12 = __e48
+  local __e12 = __e46
   return indentation() .. __e12
 end, stmt = true})
 setenv("%local", {_stash = true, special = function (name, value)
   local __id28 = compile(name)
   local __value11 = compile(value)
-  local __e49 = nil
+  local __e47 = nil
   if is63(value) then
-    __e49 = " = " .. __value11
+    __e47 = " = " .. __value11
   else
-    __e49 = ""
+    __e47 = ""
   end
-  local __rh2 = __e49
-  local __e50 = nil
+  local __rh2 = __e47
+  local __e48 = nil
   if target == "js" then
-    __e50 = "var "
+    __e48 = "var "
   else
-    __e50 = "local "
+    __e48 = "local "
   end
-  local __keyword1 = __e50
+  local __keyword1 = __e48
   local __ind11 = indentation()
   return __ind11 .. __keyword1 .. __id28 .. __rh2
 end, stmt = true})
 setenv("%set", {_stash = true, special = function (lh, rh)
   local __lh2 = compile(lh)
-  local __e51 = nil
+  local __e49 = nil
   if nil63(rh) then
-    __e51 = "nil"
+    __e49 = "nil"
   else
-    __e51 = rh
+    __e49 = rh
   end
-  local __rh4 = compile(__e51)
+  local __rh4 = compile(__e49)
   return indentation() .. __lh2 .. " = " .. __rh4
 end, stmt = true})
 setenv("get", {_stash = true, special = function (t, k)
@@ -1235,63 +1225,41 @@ setenv("get", {_stash = true, special = function (t, k)
 end})
 setenv("%array", {_stash = true, special = function (...)
   local __forms3 = unstash({...})
-  local __e52 = nil
+  local __e50 = nil
   if target == "lua" then
-    __e52 = "{"
+    __e50 = "{"
   else
-    __e52 = "["
+    __e50 = "["
   end
-  local __open1 = __e52
-  local __e53 = nil
+  local __open1 = __e50
+  local __e51 = nil
   if target == "lua" then
-    __e53 = "}"
+    __e51 = "}"
   else
-    __e53 = "]"
+    __e51 = "]"
   end
-  local __close1 = __e53
-  local __s7 = ""
-  local __c7 = ""
-  local ____o10 = __forms3
-  local __k10 = nil
-  for __k10 in next, ____o10 do
-    local __v9 = ____o10[__k10]
-    if number63(__k10) then
-      __s7 = __s7 .. __c7 .. compile(__v9)
-      __c7 = ", "
-    end
-  end
-  return __open1 .. __s7 .. __close1
+  local __close1 = __e51
+  return __open1 .. mapcat(compile, __forms3, ", ") .. __close1
 end})
 setenv("%object", {_stash = true, special = function (...)
   local __forms5 = unstash({...})
-  local __s9 = "{"
-  local __c9 = ""
-  local __e54 = nil
+  local __e52 = nil
   if target == "lua" then
-    __e54 = " = "
+    __e52 = " = "
   else
-    __e54 = ": "
+    __e52 = ": "
   end
-  local __sep1 = __e54
-  local ____o12 = pair(__forms5)
-  local __k14 = nil
-  for __k14 in next, ____o12 do
-    local __v12 = ____o12[__k14]
-    if number63(__k14) then
-      local ____id30 = __v12
-      local __k15 = ____id30[1]
-      local __v13 = ____id30[2]
-      if not string63(__k15) then
-        error("Illegal key: " .. str(__k15))
-      end
-      __s9 = __s9 .. __c9 .. key(__k15) .. __sep1 .. compile(__v13)
-      __c9 = ", "
-    end
-  end
-  return __s9 .. "}"
+  local __sep1 = __e52
+  local __s6 = mapcat(function (__x173)
+    local ____id30 = __x173
+    local __k9 = ____id30[1]
+    local __v9 = ____id30[2]
+    return key(__k9) .. __sep1 .. compile(__v9)
+  end, pair(__forms5), ", ")
+  return "{" .. __s6 .. "}"
 end})
 setenv("%literal", {_stash = true, special = function (...)
   local __args111 = unstash({...})
-  return apply(cat, map(compile, __args111))
+  return mapcat(compile, __args111)
 end})
 return {run = run, ["eval"] = _eval, expand = expand, compile = compile}

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -4,13 +4,13 @@ local function getenv(k, p)
     while __i >= 0 do
       local __b = environment[__i + 1][k]
       if is63(__b) then
-        local __e19 = nil
+        local __e21 = nil
         if p then
-          __e19 = __b[p]
+          __e21 = __b[p]
         else
-          __e19 = __b
+          __e21 = __b
         end
-        return __e19
+        return __e21
       else
         __i = __i - 1
       end
@@ -99,21 +99,21 @@ function bind(lh, rh)
     local __k1 = nil
     for __k1 in next, ____o1 do
       local __v1 = ____o1[__k1]
-      local __e20 = nil
+      local __e22 = nil
       if __k1 == "rest" then
-        __e20 = {"cut", __id, _35(lh)}
+        __e22 = {"cut", __id, _35(lh)}
       else
-        __e20 = {"get", __id, {"quote", bias(__k1)}}
+        __e22 = {"get", __id, {"quote", bias(__k1)}}
       end
-      local __x5 = __e20
+      local __x5 = __e22
       if is63(__k1) then
-        local __e21 = nil
+        local __e23 = nil
         if __v1 == true then
-          __e21 = __k1
+          __e23 = __k1
         else
-          __e21 = __v1
+          __e23 = __v1
         end
-        local __k2 = __e21
+        local __k2 = __e23
         __bs = join(__bs, bind(__k2, __x5))
       end
     end
@@ -183,47 +183,59 @@ local function expand_local(__x38)
   local __x39 = ____id1[1]
   local __name = ____id1[2]
   local __value = ____id1[3]
-  setenv(__name, {_stash = true, variable = true})
+  local __e24 = nil
+  if obj63(__name) then
+    __e24 = __name
+  else
+    __e24 = {__name}
+  end
+  local ____x40 = __e24
+  local ____i5 = 0
+  while ____i5 < _35(____x40) do
+    local __x42 = ____x40[____i5 + 1]
+    setenv(__x42, {_stash = true, variable = true})
+    ____i5 = ____i5 + 1
+  end
   return {"%local", __name, macroexpand(__value)}
 end
-local function expand_function(__x41)
-  local ____id2 = __x41
-  local __x42 = ____id2[1]
+local function expand_function(__x44)
+  local ____id2 = __x44
+  local __x45 = ____id2[1]
   local __args = ____id2[2]
   local __body = cut(____id2, 2)
   add(environment, {})
   local ____o3 = __args
-  local ____i5 = nil
-  for ____i5 in next, ____o3 do
-    local ____x43 = ____o3[____i5]
-    setenv(____x43, {_stash = true, variable = true})
+  local ____i6 = nil
+  for ____i6 in next, ____o3 do
+    local ____x46 = ____o3[____i6]
+    setenv(____x46, {_stash = true, variable = true})
   end
-  local ____x44 = join({"%function", __args}, macroexpand(__body))
+  local ____x47 = join({"%function", __args}, macroexpand(__body))
   drop(environment)
-  return ____x44
+  return ____x47
 end
-local function expand_definition(__x46)
-  local ____id3 = __x46
-  local __x47 = ____id3[1]
+local function expand_definition(__x49)
+  local ____id3 = __x49
+  local __x50 = ____id3[1]
   local __name1 = ____id3[2]
   local __args11 = ____id3[3]
   local __body1 = cut(____id3, 3)
   add(environment, {})
   local ____o4 = __args11
-  local ____i6 = nil
-  for ____i6 in next, ____o4 do
-    local ____x48 = ____o4[____i6]
-    setenv(____x48, {_stash = true, variable = true})
+  local ____i7 = nil
+  for ____i7 in next, ____o4 do
+    local ____x51 = ____o4[____i7]
+    setenv(____x51, {_stash = true, variable = true})
   end
-  local ____x49 = join({__x47, __name1, __args11}, macroexpand(__body1))
+  local ____x52 = join({__x50, __name1, __args11}, macroexpand(__body1))
   drop(environment)
-  return ____x49
+  return ____x52
 end
 local function expand_macro(form)
   return macroexpand(expand1(form))
 end
-function expand1(__x51)
-  local ____id4 = __x51
+function expand1(__x54)
+  local ____id4 = __x54
   local __name2 = ____id4[1]
   local __body2 = cut(____id4, 1)
   return apply(macro_function(__name2), __body2)
@@ -235,20 +247,20 @@ function macroexpand(form)
     if atom63(form) then
       return form
     else
-      local __x52 = hd(form)
-      if __x52 == "%local" then
+      local __x55 = hd(form)
+      if __x55 == "%local" then
         return expand_local(form)
       else
-        if __x52 == "%function" then
+        if __x55 == "%function" then
           return expand_function(form)
         else
-          if __x52 == "%global-function" then
+          if __x55 == "%global-function" then
             return expand_definition(form)
           else
-            if __x52 == "%local-function" then
+            if __x55 == "%local-function" then
               return expand_definition(form)
             else
-              if macro63(__x52) then
+              if macro63(__x55) then
                 return expand_macro(form)
               else
                 return map(macroexpand, form)
@@ -267,28 +279,28 @@ local function quasiquote_list(form, depth)
   for __k4 in next, ____o5 do
     local __v4 = ____o5[__k4]
     if not number63(__k4) then
-      local __e22 = nil
+      local __e25 = nil
       if quasisplice63(__v4, depth) then
-        __e22 = quasiexpand(__v4[2])
+        __e25 = quasiexpand(__v4[2])
       else
-        __e22 = quasiexpand(__v4, depth)
+        __e25 = quasiexpand(__v4, depth)
       end
-      local __v5 = __e22
+      local __v5 = __e25
       last(__xs)[__k4] = __v5
     end
   end
-  local ____x55 = form
-  local ____i8 = 0
-  while ____i8 < _35(____x55) do
-    local __x56 = ____x55[____i8 + 1]
-    if quasisplice63(__x56, depth) then
-      local __x57 = quasiexpand(__x56[2])
-      add(__xs, __x57)
+  local ____x58 = form
+  local ____i9 = 0
+  while ____i9 < _35(____x58) do
+    local __x59 = ____x58[____i9 + 1]
+    if quasisplice63(__x59, depth) then
+      local __x60 = quasiexpand(__x59[2])
+      add(__xs, __x60)
       add(__xs, {"list"})
     else
-      add(last(__xs), quasiexpand(__x56, depth))
+      add(last(__xs), quasiexpand(__x59, depth))
     end
-    ____i8 = ____i8 + 1
+    ____i9 = ____i9 + 1
   end
   local __pruned = keep(function (x)
     return _35(x) > 1 or not( hd(x) == "list") or keys63(x)
@@ -336,8 +348,8 @@ function quasiexpand(form, depth)
     end
   end
 end
-function expand_if(__x61)
-  local ____id5 = __x61
+function expand_if(__x64)
+  local ____id5 = __x64
   local __a = ____id5[1]
   local __b1 = ____id5[2]
   local __c = cut(____id5, 2)
@@ -352,10 +364,10 @@ end
 indent_level = 0
 function indentation()
   local __s = ""
-  local __i9 = 0
-  while __i9 < indent_level do
+  local __i10 = 0
+  while __i10 < indent_level do
     __s = __s .. "  "
-    __i9 = __i9 + 1
+    __i10 = __i10 + 1
   end
   return __s
 end
@@ -367,38 +379,38 @@ local function valid_code63(n)
   return number_code63(n) or n > 64 and n < 91 or n > 96 and n < 123 or n == 95
 end
 local function id(id)
-  local __e23 = nil
+  local __e26 = nil
   if number_code63(code(id, 0)) then
-    __e23 = "_"
+    __e26 = "_"
   else
-    __e23 = ""
+    __e26 = ""
   end
-  local __id11 = __e23
-  local __i10 = 0
-  while __i10 < _35(id) do
-    local __c1 = char(id, __i10)
+  local __id11 = __e26
+  local __i11 = 0
+  while __i11 < _35(id) do
+    local __c1 = char(id, __i11)
     local __n7 = code(__c1)
-    local __e24 = nil
+    local __e27 = nil
     if __c1 == "-" and not( id == "-") then
-      __e24 = "_"
+      __e27 = "_"
     else
-      local __e25 = nil
+      local __e28 = nil
       if valid_code63(__n7) then
-        __e25 = __c1
+        __e28 = __c1
       else
-        local __e26 = nil
-        if __i10 == 0 then
-          __e26 = "_" .. __n7
+        local __e29 = nil
+        if __i11 == 0 then
+          __e29 = "_" .. __n7
         else
-          __e26 = __n7
+          __e29 = __n7
         end
-        __e25 = __e26
+        __e28 = __e29
       end
-      __e24 = __e25
+      __e27 = __e28
     end
-    local __c11 = __e24
+    local __c11 = __e27
     __id11 = __id11 .. __c11
-    __i10 = __i10 + 1
+    __i11 = __i11 + 1
   end
   if reserved63(__id11) then
     return "_" .. __id11
@@ -411,20 +423,20 @@ function valid_id63(x)
 end
 local __names = {}
 function unique(x)
-  local __x65 = id(x)
-  if has63(__names, __x65) then
-    local __i11 = __names[__x65]
-    __names[__x65] = __names[__x65] + 1
-    return unique(__x65 .. __i11)
+  local __x68 = id(x)
+  if has63(__names, __x68) then
+    local __i12 = __names[__x68]
+    __names[__x68] = __names[__x68] + 1
+    return unique(__x68 .. __i12)
   else
-    __names[__x65] = 1
-    return "__" .. __x65
+    __names[__x68] = 1
+    return "__" .. __x68
   end
 end
 function key(k)
-  local __i12 = inner(k)
-  if valid_id63(__i12) then
-    return __i12
+  local __i13 = inner(k)
+  if valid_id63(__i13) then
+    return __i13
   else
     if target == "js" then
       return k
@@ -439,52 +451,52 @@ function mapo(f, t)
   local __k5 = nil
   for __k5 in next, ____o7 do
     local __v6 = ____o7[__k5]
-    local __x66 = f(__v6)
-    if is63(__x66) then
+    local __x69 = f(__v6)
+    if is63(__x69) then
       add(__o6, literal(__k5))
-      add(__o6, __x66)
+      add(__o6, __x69)
     end
   end
   return __o6
 end
-local ____x68 = {}
-local ____x69 = {}
-____x69.js = "!"
-____x69.lua = "not"
-____x68["not"] = ____x69
-local ____x70 = {}
-____x70["*"] = true
-____x70["/"] = true
-____x70["%"] = true
 local ____x71 = {}
 local ____x72 = {}
-____x72.js = "+"
-____x72.lua = ".."
-____x71.cat = ____x72
+____x72.js = "!"
+____x72.lua = "not"
+____x71["not"] = ____x72
 local ____x73 = {}
-____x73["+"] = true
-____x73["-"] = true
+____x73["*"] = true
+____x73["/"] = true
+____x73["%"] = true
 local ____x74 = {}
-____x74["<"] = true
-____x74[">"] = true
-____x74["<="] = true
-____x74[">="] = true
 local ____x75 = {}
+____x75.js = "+"
+____x75.lua = ".."
+____x74.cat = ____x75
 local ____x76 = {}
-____x76.js = "==="
-____x76.lua = "=="
-____x75["="] = ____x76
+____x76["+"] = true
+____x76["-"] = true
 local ____x77 = {}
+____x77["<"] = true
+____x77[">"] = true
+____x77["<="] = true
+____x77[">="] = true
 local ____x78 = {}
-____x78.js = "&&"
-____x78.lua = "and"
-____x77["and"] = ____x78
 local ____x79 = {}
+____x79.js = "==="
+____x79.lua = "=="
+____x78["="] = ____x79
 local ____x80 = {}
-____x80.js = "||"
-____x80.lua = "or"
-____x79["or"] = ____x80
-local infix = {____x68, ____x70, ____x71, ____x73, ____x74, ____x75, ____x77, ____x79}
+local ____x81 = {}
+____x81.js = "&&"
+____x81.lua = "and"
+____x80["and"] = ____x81
+local ____x82 = {}
+local ____x83 = {}
+____x83.js = "||"
+____x83.lua = "or"
+____x82["or"] = ____x83
+local infix = {____x71, ____x73, ____x74, ____x76, ____x77, ____x78, ____x80, ____x82}
 local function unary63(form)
   return two63(form) and in63(hd(form), {"not", "-"})
 end
@@ -508,12 +520,12 @@ local function precedence(form)
 end
 local function getop(op)
   return find(function (level)
-    local __x82 = level[op]
-    if __x82 == true then
+    local __x85 = level[op]
+    if __x85 == true then
       return op
     else
-      if is63(__x82) then
-        return __x82[target]
+      if is63(__x85) then
+        return __x85[target]
       end
     end
   end, infix)
@@ -529,23 +541,23 @@ local function compile_args(args)
 end
 local function escape_newlines(s)
   local __s1 = ""
-  local __i15 = 0
-  while __i15 < _35(s) do
-    local __c2 = char(s, __i15)
-    local __e27 = nil
+  local __i16 = 0
+  while __i16 < _35(s) do
+    local __c2 = char(s, __i16)
+    local __e30 = nil
     if __c2 == "\n" then
-      __e27 = "\\n"
+      __e30 = "\\n"
     else
-      local __e28 = nil
+      local __e31 = nil
       if __c2 == "\r" then
-        __e28 = "\\r"
+        __e31 = "\\r"
       else
-        __e28 = __c2
+        __e31 = __c2
       end
-      __e27 = __e28
+      __e30 = __e31
     end
-    __s1 = __s1 .. __e27
-    __i15 = __i15 + 1
+    __s1 = __s1 .. __e30
+    __i16 = __i16 + 1
   end
   return __s1
 end
@@ -609,9 +621,9 @@ local function terminator(stmt63)
 end
 local function compile_special(form, stmt63)
   local ____id6 = form
-  local __x83 = ____id6[1]
+  local __x86 = ____id6[1]
   local __args2 = cut(____id6, 1)
-  local ____id7 = getenv(__x83)
+  local ____id7 = getenv(__x86)
   local __special = ____id7.special
   local __stmt = ____id7.stmt
   local __self_tr63 = ____id7.tr
@@ -637,13 +649,13 @@ local function op_delims(parent, child, ...)
   local __child = destash33(child, ____r57)
   local ____id8 = ____r57
   local __right = ____id8.right
-  local __e29 = nil
+  local __e32 = nil
   if __right then
-    __e29 = _6261
+    __e32 = _6261
   else
-    __e29 = _62
+    __e32 = _62
   end
-  if __e29(precedence(__child), precedence(__parent)) then
+  if __e32(precedence(__child), precedence(__parent)) then
     return {"(", ")"}
   else
     return {"", ""}
@@ -677,40 +689,40 @@ function compile_function(args, body, ...)
   local ____id13 = ____r59
   local __name3 = ____id13.name
   local __prefix = ____id13.prefix
-  local __e30 = nil
+  local __e33 = nil
   if __name3 then
-    __e30 = compile(__name3)
+    __e33 = compile(__name3)
   else
-    __e30 = ""
+    __e33 = ""
   end
-  local __id14 = __e30
-  local __e31 = nil
+  local __id14 = __e33
+  local __e34 = nil
   if target == "lua" and __args4.rest then
-    __e31 = join(__args4, {"|...|"})
+    __e34 = join(__args4, {"|...|"})
   else
-    __e31 = __args4
+    __e34 = __args4
   end
-  local __args12 = __e31
+  local __args12 = __e34
   local __args5 = compile_args(__args12)
   indent_level = indent_level + 1
-  local ____x89 = compile(__body3, {_stash = true, stmt = true})
+  local ____x92 = compile(__body3, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __body4 = ____x89
+  local __body4 = ____x92
   local __ind = indentation()
-  local __e32 = nil
+  local __e35 = nil
   if __prefix then
-    __e32 = __prefix .. " "
+    __e35 = __prefix .. " "
   else
-    __e32 = ""
+    __e35 = ""
   end
-  local __p = __e32
-  local __e33 = nil
+  local __p = __e35
+  local __e36 = nil
   if target == "js" then
-    __e33 = ""
+    __e36 = ""
   else
-    __e33 = "end"
+    __e36 = "end"
   end
-  local __tr1 = __e33
+  local __tr1 = __e36
   if __name3 then
     __tr1 = __tr1 .. "\n"
   end
@@ -735,26 +747,26 @@ function compile(form, ...)
       return compile_special(__form, __stmt1)
     else
       local __tr2 = terminator(__stmt1)
-      local __e34 = nil
+      local __e37 = nil
       if __stmt1 then
-        __e34 = indentation()
+        __e37 = indentation()
       else
-        __e34 = ""
+        __e37 = ""
       end
-      local __ind1 = __e34
-      local __e35 = nil
+      local __ind1 = __e37
+      local __e38 = nil
       if atom63(__form) then
-        __e35 = compile_atom(__form)
+        __e38 = compile_atom(__form)
       else
-        local __e36 = nil
+        local __e39 = nil
         if infix63(hd(__form)) then
-          __e36 = compile_infix(__form)
+          __e39 = compile_infix(__form)
         else
-          __e36 = compile_call(__form)
+          __e39 = compile_call(__form)
         end
-        __e35 = __e36
+        __e38 = __e39
       end
-      local __form1 = __e35
+      local __form1 = __e38
       return __ind1 .. __form1 .. __tr2
     end
   end
@@ -762,25 +774,25 @@ end
 local function lower_statement(form, tail63)
   local __hoist = {}
   local __e = lower(form, __hoist, true, tail63)
-  local __e37 = nil
+  local __e40 = nil
   if some63(__hoist) and is63(__e) then
-    __e37 = join({"do"}, __hoist, {__e})
+    __e40 = join({"do"}, __hoist, {__e})
   else
-    local __e38 = nil
+    local __e41 = nil
     if is63(__e) then
-      __e38 = __e
+      __e41 = __e
     else
-      local __e39 = nil
+      local __e42 = nil
       if _35(__hoist) > 1 then
-        __e39 = join({"do"}, __hoist)
+        __e42 = join({"do"}, __hoist)
       else
-        __e39 = hd(__hoist)
+        __e42 = hd(__hoist)
       end
-      __e38 = __e39
+      __e41 = __e42
     end
-    __e37 = __e38
+    __e40 = __e41
   end
-  return either(__e37, {"do"})
+  return either(__e40, {"do"})
 end
 local function lower_body(body, tail63)
   return lower_statement(join({"do"}, body), tail63)
@@ -792,18 +804,18 @@ local function standalone63(form)
   return not atom63(form) and not infix63(hd(form)) and not literal63(form) and not( "get" == hd(form)) or id_literal63(form)
 end
 local function lower_do(args, hoist, stmt63, tail63)
-  local ____x96 = almost(args)
-  local ____i16 = 0
-  while ____i16 < _35(____x96) do
-    local __x97 = ____x96[____i16 + 1]
-    local ____y = lower(__x97, hoist, stmt63)
+  local ____x99 = almost(args)
+  local ____i17 = 0
+  while ____i17 < _35(____x99) do
+    local __x100 = ____x99[____i17 + 1]
+    local ____y = lower(__x100, hoist, stmt63)
     if yes(____y) then
       local __e1 = ____y
       if standalone63(__e1) then
         add(hoist, __e1)
       end
     end
-    ____i16 = ____i16 + 1
+    ____i17 = ____i17 + 1
   end
   local __e2 = lower(last(args), hoist, stmt63, tail63)
   if tail63 and can_return63(__e2) then
@@ -829,19 +841,19 @@ local function lower_if(args, hoist, stmt63, tail63)
   local ___then = ____id17[2]
   local ___else = ____id17[3]
   if stmt63 then
-    local __e41 = nil
+    local __e44 = nil
     if is63(___else) then
-      __e41 = {lower_body({___else}, tail63)}
+      __e44 = {lower_body({___else}, tail63)}
     end
-    return add(hoist, join({"%if", lower(__cond, hoist), lower_body({___then}, tail63)}, __e41))
+    return add(hoist, join({"%if", lower(__cond, hoist), lower_body({___then}, tail63)}, __e44))
   else
     local __e3 = unique("e")
     add(hoist, {"%local", __e3, "nil"})
-    local __e40 = nil
+    local __e43 = nil
     if is63(___else) then
-      __e40 = {lower({"%set", __e3, ___else})}
+      __e43 = {lower({"%set", __e3, ___else})}
     end
-    add(hoist, join({"%if", lower(__cond, hoist), lower({"%set", __e3, ___then})}, __e40))
+    add(hoist, join({"%if", lower(__cond, hoist), lower({"%set", __e3, ___then})}, __e43))
     return __e3
   end
 end
@@ -853,13 +865,13 @@ local function lower_short(x, args, hoist)
   local __b11 = lower(__b4, __hoist1)
   if some63(__hoist1) then
     local __id19 = unique("id")
-    local __e42 = nil
+    local __e45 = nil
     if x == "and" then
-      __e42 = {"%if", __id19, __b4, __id19}
+      __e45 = {"%if", __id19, __b4, __id19}
     else
-      __e42 = {"%if", __id19, __id19, __b4}
+      __e45 = {"%if", __id19, __id19, __b4}
     end
-    return lower({"do", {"%local", __id19, __a3}, __e42}, hoist)
+    return lower({"do", {"%local", __id19, __a3}, __e45}, hoist)
   else
     return {x, lower(__a3, hoist), __b11}
   end
@@ -873,13 +885,13 @@ local function lower_while(args, hoist)
   local __body5 = cut(____id20, 1)
   local __pre = {}
   local __c4 = lower(__c3, __pre)
-  local __e43 = nil
+  local __e46 = nil
   if none63(__pre) then
-    __e43 = {"while", __c4, lower_body(__body5)}
+    __e46 = {"while", __c4, lower_body(__body5)}
   else
-    __e43 = {"while", true, join({"do"}, __pre, {{"%if", {"not", __c4}, {"break"}}, lower_body(__body5)})}
+    __e46 = {"while", true, join({"do"}, __pre, {{"%if", {"not", __c4}, {"break"}}, lower_body(__body5)})}
   end
-  return add(hoist, __e43)
+  return add(hoist, __e46)
 end
 local function lower_for(args, hoist)
   local ____id21 = args
@@ -916,10 +928,10 @@ local function lower_pairwise(form)
   if pairwise63(form) then
     local __e4 = {}
     local ____id24 = form
-    local __x126 = ____id24[1]
+    local __x129 = ____id24[1]
     local __args7 = cut(____id24, 1)
     reduce(function (a, b)
-      add(__e4, {__x126, a, b})
+      add(__e4, {__x129, a, b})
       return a
     end, __args7)
     return join({"and"}, reverse(__e4))
@@ -933,10 +945,10 @@ end
 local function lower_infix(form, hoist)
   local __form3 = lower_pairwise(form)
   local ____id25 = __form3
-  local __x129 = ____id25[1]
+  local __x132 = ____id25[1]
   local __args8 = cut(____id25, 1)
   return lower(reduce(function (a, b)
-    return {__x129, b, a}
+    return {__x132, b, a}
   end, reverse(__args8)), hoist)
 end
 local function lower_special(form, hoist)
@@ -959,39 +971,39 @@ function lower(form, hoist, stmt63, tail63)
           return lower_infix(form, hoist)
         else
           local ____id26 = form
-          local __x132 = ____id26[1]
+          local __x135 = ____id26[1]
           local __args9 = cut(____id26, 1)
-          if __x132 == "do" then
+          if __x135 == "do" then
             return lower_do(__args9, hoist, stmt63, tail63)
           else
-            if __x132 == "%call" then
+            if __x135 == "%call" then
               return lower(__args9, hoist, stmt63, tail63)
             else
-              if __x132 == "%set" then
+              if __x135 == "%set" then
                 return lower_set(__args9, hoist, stmt63, tail63)
               else
-                if __x132 == "%if" then
+                if __x135 == "%if" then
                   return lower_if(__args9, hoist, stmt63, tail63)
                 else
-                  if __x132 == "%try" then
+                  if __x135 == "%try" then
                     return lower_try(__args9, hoist, tail63)
                   else
-                    if __x132 == "while" then
+                    if __x135 == "while" then
                       return lower_while(__args9, hoist)
                     else
-                      if __x132 == "%for" then
+                      if __x135 == "%for" then
                         return lower_for(__args9, hoist)
                       else
-                        if __x132 == "%function" then
+                        if __x135 == "%function" then
                           return lower_function(__args9)
                         else
-                          if __x132 == "%local-function" or __x132 == "%global-function" then
-                            return lower_definition(__x132, __args9, hoist)
+                          if __x135 == "%local-function" or __x135 == "%global-function" then
+                            return lower_definition(__x135, __args9, hoist)
                           else
-                            if in63(__x132, {"and", "or"}) then
-                              return lower_short(__x132, __args9, hoist)
+                            if in63(__x135, {"and", "or"}) then
+                              return lower_short(__x135, __args9, hoist)
                             else
-                              if statement63(__x132) then
+                              if statement63(__x135) then
                                 return lower_special(form, hoist)
                               else
                                 return lower_call(form, hoist)
@@ -1038,37 +1050,37 @@ end
 setenv("do", {_stash = true, special = function (...)
   local __forms1 = unstash({...})
   local __s2 = ""
-  local ____x138 = __forms1
-  local ____i18 = 0
-  while ____i18 < _35(____x138) do
-    local __x139 = ____x138[____i18 + 1]
-    if target == "lua" and immediate_call63(__x139) and "\n" == char(__s2, edge(__s2)) then
+  local ____x141 = __forms1
+  local ____i19 = 0
+  while ____i19 < _35(____x141) do
+    local __x142 = ____x141[____i19 + 1]
+    if target == "lua" and immediate_call63(__x142) and "\n" == char(__s2, edge(__s2)) then
       __s2 = clip(__s2, 0, edge(__s2)) .. ";\n"
     end
-    __s2 = __s2 .. compile(__x139, {_stash = true, stmt = true})
-    if not atom63(__x139) then
-      if hd(__x139) == "return" or hd(__x139) == "break" then
+    __s2 = __s2 .. compile(__x142, {_stash = true, stmt = true})
+    if not atom63(__x142) then
+      if hd(__x142) == "return" or hd(__x142) == "break" then
         break
       end
     end
-    ____i18 = ____i18 + 1
+    ____i19 = ____i19 + 1
   end
   return __s2
 end, stmt = true, tr = true})
 setenv("%if", {_stash = true, special = function (cond, cons, alt)
   local __cond2 = compile(cond)
   indent_level = indent_level + 1
-  local ____x142 = compile(cons, {_stash = true, stmt = true})
+  local ____x145 = compile(cons, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __cons1 = ____x142
-  local __e44 = nil
+  local __cons1 = ____x145
+  local __e47 = nil
   if alt then
     indent_level = indent_level + 1
-    local ____x143 = compile(alt, {_stash = true, stmt = true})
+    local ____x146 = compile(alt, {_stash = true, stmt = true})
     indent_level = indent_level - 1
-    __e44 = ____x143
+    __e47 = ____x146
   end
-  local __alt1 = __e44
+  local __alt1 = __e47
   local __ind3 = indentation()
   local __s4 = ""
   if target == "js" then
@@ -1092,9 +1104,9 @@ end, stmt = true, tr = true})
 setenv("while", {_stash = true, special = function (cond, form)
   local __cond4 = compile(cond)
   indent_level = indent_level + 1
-  local ____x145 = compile(form, {_stash = true, stmt = true})
+  local ____x148 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __body10 = ____x145
+  local __body10 = ____x148
   local __ind5 = indentation()
   if target == "js" then
     return __ind5 .. "while (" .. __cond4 .. ") {\n" .. __body10 .. __ind5 .. "}\n"
@@ -1106,9 +1118,9 @@ setenv("%for", {_stash = true, special = function (t, k, form)
   local __t2 = compile(t)
   local __ind7 = indentation()
   indent_level = indent_level + 1
-  local ____x147 = compile(form, {_stash = true, stmt = true})
+  local ____x150 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __body12 = ____x147
+  local __body12 = ____x150
   if target == "lua" then
     return __ind7 .. "for " .. k .. " in next, " .. __t2 .. " do\n" .. __body12 .. __ind7 .. "end\n"
   else
@@ -1119,14 +1131,14 @@ setenv("%try", {_stash = true, special = function (form)
   local __e8 = unique("e")
   local __ind9 = indentation()
   indent_level = indent_level + 1
-  local ____x152 = compile(form, {_stash = true, stmt = true})
+  local ____x155 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __body14 = ____x152
+  local __body14 = ____x155
   local __hf1 = {"return", {"%array", false, __e8}}
   indent_level = indent_level + 1
-  local ____x155 = compile(__hf1, {_stash = true, stmt = true})
+  local ____x158 = compile(__hf1, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __h1 = ____x155
+  local __h1 = ____x158
   return __ind9 .. "try {\n" .. __body14 .. __ind9 .. "}\n" .. __ind9 .. "catch (" .. __e8 .. ") {\n" .. __h1 .. __ind9 .. "}\n"
 end, stmt = true, tr = true})
 setenv("%delete", {_stash = true, special = function (place)
@@ -1140,29 +1152,33 @@ setenv("%function", {_stash = true, special = function (args, body)
 end})
 setenv("%global-function", {_stash = true, special = function (name, args, body)
   if target == "lua" then
-    local __x159 = compile_function(args, body, {_stash = true, name = name})
-    return indentation() .. __x159
+    local __x162 = compile_function(args, body, {_stash = true, name = name})
+    return indentation() .. __x162
   else
     return compile({"%set", name, {"%function", args, body}}, {_stash = true, stmt = true})
   end
 end, stmt = true, tr = true})
 setenv("%local-function", {_stash = true, special = function (name, args, body)
   if target == "lua" then
-    local __x165 = compile_function(args, body, {_stash = true, name = name, prefix = "local"})
-    return indentation() .. __x165
+    local __x168 = compile_function(args, body, {_stash = true, name = name, prefix = "local"})
+    return indentation() .. __x168
   else
     return compile({"%local", name, {"%function", args, body}}, {_stash = true, stmt = true})
   end
 end, stmt = true, tr = true})
-setenv("return", {_stash = true, special = function (x)
-  local __e45 = nil
-  if nil63(x) then
-    __e45 = "return"
-  else
-    __e45 = "return " .. compile(x)
+setenv("return", {_stash = true, special = function (...)
+  local __args111 = unstash({...})
+  local __s6 = mapcat(compile, __args111, ", ")
+  if target == "js" and _35(__args111) > 1 then
+    __s6 = "[" .. __s6 .. "]"
   end
-  local __x169 = __e45
-  return indentation() .. __x169
+  local __e48 = nil
+  if some63(__s6) then
+    __e48 = " "
+  else
+    __e48 = ""
+  end
+  return indentation() .. "return" .. __e48 .. __s6
 end, stmt = true})
 setenv("new", {_stash = true, special = function (x)
   return "new " .. compile(x)
@@ -1171,44 +1187,57 @@ setenv("typeof", {_stash = true, special = function (x)
   return "typeof(" .. compile(x) .. ")"
 end})
 setenv("throw", {_stash = true, special = function (x)
-  local __e46 = nil
+  local __e49 = nil
   if target == "js" then
-    __e46 = "throw " .. compile(x)
+    __e49 = "throw " .. compile(x)
   else
-    __e46 = "error(" .. compile(x) .. ")"
+    __e49 = "error(" .. compile(x) .. ")"
   end
-  local __e12 = __e46
+  local __e12 = __e49
   return indentation() .. __e12
 end, stmt = true})
 setenv("%local", {_stash = true, special = function (name, value)
-  local __id28 = compile(name)
+  local __e50 = nil
+  if obj63(name) then
+    local __s8 = mapcat(compile, name, ", ")
+    local __e51 = nil
+    if target == "js" then
+      __e51 = "[" .. __s8 .. "]"
+    else
+      __e51 = __s8
+    end
+    __e50 = __e51
+  else
+    __e50 = compile(name)
+  end
+  local __id28 = __e50
   local __value11 = compile(value)
-  local __e47 = nil
+  local __e52 = nil
   if is63(value) then
-    __e47 = " = " .. __value11
+    __e52 = " = " .. __value11
   else
-    __e47 = ""
+    __e52 = ""
   end
-  local __rh2 = __e47
-  local __e48 = nil
+  local __rh2 = __e52
+  local __e53 = nil
   if target == "js" then
-    __e48 = "var "
+    __e53 = "var "
   else
-    __e48 = "local "
+    __e53 = "local "
   end
-  local __keyword1 = __e48
+  local __keyword1 = __e53
   local __ind11 = indentation()
   return __ind11 .. __keyword1 .. __id28 .. __rh2
 end, stmt = true})
 setenv("%set", {_stash = true, special = function (lh, rh)
   local __lh2 = compile(lh)
-  local __e49 = nil
+  local __e54 = nil
   if nil63(rh) then
-    __e49 = "nil"
+    __e54 = "nil"
   else
-    __e49 = rh
+    __e54 = rh
   end
-  local __rh4 = compile(__e49)
+  local __rh4 = compile(__e54)
   return indentation() .. __lh2 .. " = " .. __rh4
 end, stmt = true})
 setenv("get", {_stash = true, special = function (t, k)
@@ -1225,41 +1254,41 @@ setenv("get", {_stash = true, special = function (t, k)
 end})
 setenv("%array", {_stash = true, special = function (...)
   local __forms3 = unstash({...})
-  local __e50 = nil
+  local __e55 = nil
   if target == "lua" then
-    __e50 = "{"
+    __e55 = "{"
   else
-    __e50 = "["
+    __e55 = "["
   end
-  local __open1 = __e50
-  local __e51 = nil
+  local __open1 = __e55
+  local __e56 = nil
   if target == "lua" then
-    __e51 = "}"
+    __e56 = "}"
   else
-    __e51 = "]"
+    __e56 = "]"
   end
-  local __close1 = __e51
+  local __close1 = __e56
   return __open1 .. mapcat(compile, __forms3, ", ") .. __close1
 end})
 setenv("%object", {_stash = true, special = function (...)
   local __forms5 = unstash({...})
-  local __e52 = nil
+  local __e57 = nil
   if target == "lua" then
-    __e52 = " = "
+    __e57 = " = "
   else
-    __e52 = ": "
+    __e57 = ": "
   end
-  local __sep1 = __e52
-  local __s6 = mapcat(function (__x173)
-    local ____id30 = __x173
+  local __sep1 = __e57
+  local __s10 = mapcat(function (__x175)
+    local ____id30 = __x175
     local __k9 = ____id30[1]
     local __v9 = ____id30[2]
     return key(__k9) .. __sep1 .. compile(__v9)
   end, pair(__forms5), ", ")
-  return "{" .. __s6 .. "}"
+  return "{" .. __s10 .. "}"
 end})
 setenv("%literal", {_stash = true, special = function (...)
-  local __args111 = unstash({...})
-  return mapcat(compile, __args111)
+  local __args13 = unstash({...})
+  return mapcat(compile, __args13)
 end})
 return {run = run, ["eval"] = _eval, expand = expand, compile = compile}

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -309,6 +309,23 @@ map = function (f, x) {
   }
   return __t1;
 };
+mapcat = function (f, x, sep) {
+  var __s = "";
+  var __sep = sep || "";
+  var __c = "";
+  var ____x7 = x;
+  var ____i11 = 0;
+  while (____i11 < _35(____x7)) {
+    var __v5 = ____x7[____i11];
+    var __y4 = f(__v5);
+    if (is63(__y4)) {
+      __s = __s + __c + __y4;
+      __c = __sep;
+    }
+    ____i11 = ____i11 + 1;
+  }
+  return __s;
+};
 keep = function (f, x) {
   return map(function (v) {
     if (yes(f(v))) {
@@ -320,7 +337,7 @@ keys63 = function (t) {
   var ____o5 = t;
   var __k8 = undefined;
   for (__k8 in ____o5) {
-    var __v5 = ____o5[__k8];
+    var __v6 = ____o5[__k8];
     var __e8 = undefined;
     if (numeric63(__k8)) {
       __e8 = parseInt(__k8);
@@ -336,16 +353,16 @@ keys63 = function (t) {
 };
 empty63 = function (t) {
   var ____o6 = t;
-  var ____i12 = undefined;
-  for (____i12 in ____o6) {
-    var __x7 = ____o6[____i12];
+  var ____i13 = undefined;
+  for (____i13 in ____o6) {
+    var __x8 = ____o6[____i13];
     var __e9 = undefined;
-    if (numeric63(____i12)) {
-      __e9 = parseInt(____i12);
+    if (numeric63(____i13)) {
+      __e9 = parseInt(____i13);
     } else {
-      __e9 = ____i12;
+      __e9 = ____i13;
     }
-    var ____i121 = __e9;
+    var ____i131 = __e9;
     return false;
   }
   return true;
@@ -356,7 +373,7 @@ stash = function (args) {
     var ____o7 = args;
     var __k10 = undefined;
     for (__k10 in ____o7) {
-      var __v6 = ____o7[__k10];
+      var __v7 = ____o7[__k10];
       var __e10 = undefined;
       if (numeric63(__k10)) {
         __e10 = parseInt(__k10);
@@ -365,7 +382,7 @@ stash = function (args) {
       }
       var __k11 = __e10;
       if (! number63(__k11)) {
-        __p[__k11] = __v6;
+        __p[__k11] = __v7;
       }
     }
     __p._stash = true;
@@ -383,7 +400,7 @@ unstash = function (args) {
       var ____o8 = __l2;
       var __k12 = undefined;
       for (__k12 in ____o8) {
-        var __v7 = ____o8[__k12];
+        var __v8 = ____o8[__k12];
         var __e11 = undefined;
         if (numeric63(__k12)) {
           __e11 = parseInt(__k12);
@@ -392,7 +409,7 @@ unstash = function (args) {
         }
         var __k13 = __e11;
         if (!( __k13 === "_stash")) {
-          __args1[__k13] = __v7;
+          __args1[__k13] = __v8;
         }
       }
       return __args1;
@@ -406,7 +423,7 @@ destash33 = function (l, args1) {
     var ____o9 = l;
     var __k14 = undefined;
     for (__k14 in ____o9) {
-      var __v8 = ____o9[__k14];
+      var __v9 = ____o9[__k14];
       var __e12 = undefined;
       if (numeric63(__k14)) {
         __e12 = parseInt(__k14);
@@ -415,7 +432,7 @@ destash33 = function (l, args1) {
       }
       var __k15 = __e12;
       if (!( __k15 === "_stash")) {
-        args1[__k15] = __v8;
+        args1[__k15] = __v9;
       }
     }
   } else {
@@ -423,9 +440,9 @@ destash33 = function (l, args1) {
   }
 };
 search = function (s, pattern, start) {
-  var __i16 = s.indexOf(pattern, start);
-  if (__i16 >= 0) {
-    return __i16;
+  var __i17 = s.indexOf(pattern, start);
+  if (__i17 >= 0) {
+    return __i17;
   }
 };
 split = function (s, sep) {
@@ -435,12 +452,12 @@ split = function (s, sep) {
     var __l3 = [];
     var __n12 = _35(sep);
     while (true) {
-      var __i17 = search(s, sep);
-      if (nil63(__i17)) {
+      var __i18 = search(s, sep);
+      if (nil63(__i18)) {
         break;
       } else {
-        add(__l3, clip(s, 0, __i17));
-        s = clip(s, __i17 + __n12);
+        add(__l3, clip(s, 0, __i18));
+        s = clip(s, __i18 + __n12);
       }
     }
     add(__l3, s);
@@ -484,14 +501,14 @@ _37 = function () {
   }, reverse(__xs5)), 0);
 };
 var pairwise = function (f, xs) {
-  var __i18 = 0;
-  while (__i18 < edge(xs)) {
-    var __a = xs[__i18];
-    var __b = xs[__i18 + 1];
+  var __i19 = 0;
+  while (__i19 < edge(xs)) {
+    var __a = xs[__i19];
+    var __b = xs[__i19 + 1];
     if (! f(__a, __b)) {
       return false;
     }
-    __i18 = __i18 + 1;
+    __i19 = __i19 + 1;
   }
   return true;
 };
@@ -536,12 +553,12 @@ number_code63 = function (n) {
 };
 numeric63 = function (s) {
   var __n14 = _35(s);
-  var __i19 = 0;
-  while (__i19 < __n14) {
-    if (! number_code63(code(s, __i19))) {
+  var __i20 = 0;
+  while (__i20 < __n14) {
+    if (! number_code63(code(s, __i20))) {
       return false;
     }
-    __i19 = __i19 + 1;
+    __i20 = __i20 + 1;
   }
   return some63(s);
 };
@@ -550,26 +567,26 @@ var tostring = function (x) {
 };
 escape = function (s) {
   var __s1 = "\"";
-  var __i20 = 0;
-  while (__i20 < _35(s)) {
-    var __c = char(s, __i20);
+  var __i21 = 0;
+  while (__i21 < _35(s)) {
+    var __c1 = char(s, __i21);
     var __e13 = undefined;
-    if (__c === "\n") {
+    if (__c1 === "\n") {
       __e13 = "\\n";
     } else {
       var __e14 = undefined;
-      if (__c === "\r") {
+      if (__c1 === "\r") {
         __e14 = "\\r";
       } else {
         var __e15 = undefined;
-        if (__c === "\"") {
+        if (__c1 === "\"") {
           __e15 = "\\\"";
         } else {
           var __e16 = undefined;
-          if (__c === "\\") {
+          if (__c1 === "\\") {
             __e16 = "\\\\";
           } else {
-            __e16 = __c;
+            __e16 = __c1;
           }
           __e15 = __e16;
         }
@@ -577,9 +594,9 @@ escape = function (s) {
       }
       __e13 = __e14;
     }
-    var __c1 = __e13;
-    __s1 = __s1 + __c1;
-    __i20 = __i20 + 1;
+    var __c11 = __e13;
+    __s1 = __s1 + __c11;
+    __i21 = __i21 + 1;
   }
   return __s1 + "\"";
 };
@@ -618,7 +635,7 @@ str = function (x, stack) {
                     if (false) {
                       return escape(tostring(x));
                     } else {
-                      var __s = "(";
+                      var __s11 = "(";
                       var __sp = "";
                       var __xs11 = [];
                       var __ks = [];
@@ -627,7 +644,7 @@ str = function (x, stack) {
                       var ____o10 = x;
                       var __k16 = undefined;
                       for (__k16 in ____o10) {
-                        var __v9 = ____o10[__k16];
+                        var __v10 = ____o10[__k16];
                         var __e17 = undefined;
                         if (numeric63(__k16)) {
                           __e17 = parseInt(__k16);
@@ -636,28 +653,28 @@ str = function (x, stack) {
                         }
                         var __k17 = __e17;
                         if (number63(__k17)) {
-                          __xs11[__k17] = str(__v9, __l4);
+                          __xs11[__k17] = str(__v10, __l4);
                         } else {
                           add(__ks, __k17 + ":");
-                          add(__ks, str(__v9, __l4));
+                          add(__ks, str(__v10, __l4));
                         }
                       }
                       drop(__l4);
                       var ____o11 = join(__xs11, __ks);
-                      var ____i22 = undefined;
-                      for (____i22 in ____o11) {
-                        var __v10 = ____o11[____i22];
+                      var ____i23 = undefined;
+                      for (____i23 in ____o11) {
+                        var __v11 = ____o11[____i23];
                         var __e18 = undefined;
-                        if (numeric63(____i22)) {
-                          __e18 = parseInt(____i22);
+                        if (numeric63(____i23)) {
+                          __e18 = parseInt(____i23);
                         } else {
-                          __e18 = ____i22;
+                          __e18 = ____i23;
                         }
-                        var ____i221 = __e18;
-                        __s = __s + __sp + __v10;
+                        var ____i231 = __e18;
+                        __s11 = __s11 + __sp + __v11;
                         __sp = " ";
                       }
-                      return __s + ")";
+                      return __s11 + ")";
                     }
                   }
                 }
@@ -674,16 +691,16 @@ apply = function (f, args) {
   return f.apply(f, __args);
 };
 call = function (f) {
-  var ____r75 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __f = destash33(f, ____r75);
-  var ____id = ____r75;
+  var ____r76 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __f = destash33(f, ____r76);
+  var ____id = ____r76;
   var __args11 = cut(____id, 0);
   return apply(__f, __args11);
 };
 setenv = function (k) {
-  var ____r76 = unstash(Array.prototype.slice.call(arguments, 1));
-  var __k18 = destash33(k, ____r76);
-  var ____id1 = ____r76;
+  var ____r77 = unstash(Array.prototype.slice.call(arguments, 1));
+  var __k18 = destash33(k, ____r77);
+  var ____id1 = ____r77;
   var __keys = cut(____id1, 0);
   if (string63(__k18)) {
     var __e19 = undefined;
@@ -697,7 +714,7 @@ setenv = function (k) {
     var ____o12 = __keys;
     var __k19 = undefined;
     for (__k19 in ____o12) {
-      var __v11 = ____o12[__k19];
+      var __v12 = ____o12[__k19];
       var __e20 = undefined;
       if (numeric63(__k19)) {
         __e20 = parseInt(__k19);
@@ -705,7 +722,7 @@ setenv = function (k) {
         __e20 = __k19;
       }
       var __k20 = __e20;
-      __entry[__k20] = __v11;
+      __entry[__k20] = __v12;
     }
     __frame[__k18] = __entry;
     return __frame[__k18];

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -962,7 +962,6 @@ setenv("define", {_stash: true, macro: function (name, x) {
   var __x131 = destash33(x, ____r37);
   var ____id31 = ____r37;
   var __body21 = cut(____id31, 0);
-  setenv(__name5, {_stash: true, variable: true});
   if (some63(__body21)) {
     return join(["%local-function", __name5], bind42(__x131, __body21));
   } else {

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -265,6 +265,23 @@ function map(f, x)
   end
   return __t1
 end
+function mapcat(f, x, sep)
+  local __s = ""
+  local __sep = sep or ""
+  local __c = ""
+  local ____x8 = x
+  local ____i11 = 0
+  while ____i11 < _35(____x8) do
+    local __v5 = ____x8[____i11 + 1]
+    local __y4 = f(__v5)
+    if is63(__y4) then
+      __s = __s .. __c .. __y4
+      __c = __sep
+    end
+    ____i11 = ____i11 + 1
+  end
+  return __s
+end
 function keep(f, x)
   return map(function (v)
     if yes(f(v)) then
@@ -276,7 +293,7 @@ function keys63(t)
   local ____o5 = t
   local __k4 = nil
   for __k4 in next, ____o5 do
-    local __v5 = ____o5[__k4]
+    local __v6 = ____o5[__k4]
     if not number63(__k4) then
       return true
     end
@@ -285,9 +302,9 @@ function keys63(t)
 end
 function empty63(t)
   local ____o6 = t
-  local ____i12 = nil
-  for ____i12 in next, ____o6 do
-    local __x8 = ____o6[____i12]
+  local ____i13 = nil
+  for ____i13 in next, ____o6 do
+    local __x9 = ____o6[____i13]
     return false
   end
   return true
@@ -298,9 +315,9 @@ function stash(args)
     local ____o7 = args
     local __k5 = nil
     for __k5 in next, ____o7 do
-      local __v6 = ____o7[__k5]
+      local __v7 = ____o7[__k5]
       if not number63(__k5) then
-        __p[__k5] = __v6
+        __p[__k5] = __v7
       end
     end
     __p._stash = true
@@ -318,9 +335,9 @@ function unstash(args)
       local ____o8 = __l2
       local __k6 = nil
       for __k6 in next, ____o8 do
-        local __v7 = ____o8[__k6]
+        local __v8 = ____o8[__k6]
         if not( __k6 == "_stash") then
-          __args1[__k6] = __v7
+          __args1[__k6] = __v8
         end
       end
       return __args1
@@ -334,9 +351,9 @@ function destash33(l, args1)
     local ____o9 = l
     local __k7 = nil
     for __k7 in next, ____o9 do
-      local __v8 = ____o9[__k7]
+      local __v9 = ____o9[__k7]
       if not( __k7 == "_stash") then
-        args1[__k7] = __v8
+        args1[__k7] = __v9
       end
     end
   else
@@ -349,8 +366,8 @@ function search(s, pattern, start)
     __e3 = start + 1
   end
   local __start = __e3
-  local __i16 = string.find(s, pattern, __start, true)
-  return __i16 and __i16 - 1
+  local __i17 = string.find(s, pattern, __start, true)
+  return __i17 and __i17 - 1
 end
 function split(s, sep)
   if s == "" or sep == "" then
@@ -359,12 +376,12 @@ function split(s, sep)
     local __l3 = {}
     local __n12 = _35(sep)
     while true do
-      local __i17 = search(s, sep)
-      if nil63(__i17) then
+      local __i18 = search(s, sep)
+      if nil63(__i18) then
         break
       else
-        add(__l3, clip(s, 0, __i17))
-        s = clip(s, __i17 + __n12)
+        add(__l3, clip(s, 0, __i18))
+        s = clip(s, __i18 + __n12)
       end
     end
     add(__l3, s)
@@ -408,14 +425,14 @@ function _37(...)
   end, reverse(__xs5)), 0)
 end
 local function pairwise(f, xs)
-  local __i18 = 0
-  while __i18 < edge(xs) do
-    local __a = xs[__i18 + 1]
-    local __b = xs[__i18 + 1 + 1]
+  local __i19 = 0
+  while __i19 < edge(xs) do
+    local __a = xs[__i19 + 1]
+    local __b = xs[__i19 + 1 + 1]
     if not f(__a, __b) then
       return false
     end
-    __i18 = __i18 + 1
+    __i19 = __i19 + 1
   end
   return true
 end
@@ -457,37 +474,37 @@ function number_code63(n)
 end
 function numeric63(s)
   local __n13 = _35(s)
-  local __i19 = 0
-  while __i19 < __n13 do
-    if not number_code63(code(s, __i19)) then
+  local __i20 = 0
+  while __i20 < __n13 do
+    if not number_code63(code(s, __i20)) then
       return false
     end
-    __i19 = __i19 + 1
+    __i20 = __i20 + 1
   end
   return some63(s)
 end
 function escape(s)
   local __s1 = "\""
-  local __i20 = 0
-  while __i20 < _35(s) do
-    local __c = char(s, __i20)
+  local __i21 = 0
+  while __i21 < _35(s) do
+    local __c1 = char(s, __i21)
     local __e4 = nil
-    if __c == "\n" then
+    if __c1 == "\n" then
       __e4 = "\\n"
     else
       local __e5 = nil
-      if __c == "\r" then
+      if __c1 == "\r" then
         __e5 = "\\r"
       else
         local __e6 = nil
-        if __c == "\"" then
+        if __c1 == "\"" then
           __e6 = "\\\""
         else
           local __e7 = nil
-          if __c == "\\" then
+          if __c1 == "\\" then
             __e7 = "\\\\"
           else
-            __e7 = __c
+            __e7 = __c1
           end
           __e6 = __e7
         end
@@ -495,9 +512,9 @@ function escape(s)
       end
       __e4 = __e5
     end
-    local __c1 = __e4
-    __s1 = __s1 .. __c1
-    __i20 = __i20 + 1
+    local __c11 = __e4
+    __s1 = __s1 .. __c11
+    __i21 = __i21 + 1
   end
   return __s1 .. "\""
 end
@@ -536,7 +553,7 @@ function str(x, stack)
                     if not( type(x) == "table") then
                       return escape(tostring(x))
                     else
-                      local __s = "("
+                      local __s11 = "("
                       local __sp = ""
                       local __xs11 = {}
                       local __ks = {}
@@ -545,26 +562,26 @@ function str(x, stack)
                       local ____o10 = x
                       local __k8 = nil
                       for __k8 in next, ____o10 do
-                        local __v9 = ____o10[__k8]
+                        local __v10 = ____o10[__k8]
                         if number63(__k8) then
-                          __xs11[__k8] = str(__v9, __l4)
+                          __xs11[__k8] = str(__v10, __l4)
                         else
                           if not string63(__k8) then
                             __k8 = str(__k8, __l4)
                           end
                           add(__ks, __k8 .. ":")
-                          add(__ks, str(__v9, __l4))
+                          add(__ks, str(__v10, __l4))
                         end
                       end
                       drop(__l4)
                       local ____o11 = join(__xs11, __ks)
-                      local ____i22 = nil
-                      for ____i22 in next, ____o11 do
-                        local __v10 = ____o11[____i22]
-                        __s = __s .. __sp .. __v10
+                      local ____i23 = nil
+                      for ____i23 in next, ____o11 do
+                        local __v11 = ____o11[____i23]
+                        __s11 = __s11 .. __sp .. __v11
                         __sp = " "
                       end
-                      return __s .. ")"
+                      return __s11 .. ")"
                     end
                   end
                 end
@@ -576,22 +593,22 @@ function str(x, stack)
     end
   end
 end
-local values = unpack or table.unpack
+local unpack = unpack or table.unpack
 function apply(f, args)
   local __args = stash(args)
-  return f(values(__args))
+  return f(unpack(__args))
 end
 function call(f, ...)
-  local ____r72 = unstash({...})
-  local __f = destash33(f, ____r72)
-  local ____id = ____r72
+  local ____r73 = unstash({...})
+  local __f = destash33(f, ____r73)
+  local ____id = ____r73
   local __args11 = cut(____id, 0)
   return apply(__f, __args11)
 end
 function setenv(k, ...)
-  local ____r73 = unstash({...})
-  local __k9 = destash33(k, ____r73)
-  local ____id1 = ____r73
+  local ____r74 = unstash({...})
+  local __k9 = destash33(k, ____r74)
+  local ____id1 = ____r74
   local __keys = cut(____id1, 0)
   if string63(__k9) then
     local __e8 = nil
@@ -605,8 +622,8 @@ function setenv(k, ...)
     local ____o12 = __keys
     local __k10 = nil
     for __k10 in next, ____o12 do
-      local __v11 = ____o12[__k10]
-      __entry[__k10] = __v11
+      local __v12 = ____o12[__k10]
+      __entry[__k10] = __v12
     end
     __frame[__k9] = __entry
     return __frame[__k9]

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -850,7 +850,6 @@ setenv("define", {_stash = true, macro = function (name, x, ...)
   local __x145 = destash33(x, ____r37)
   local ____id31 = ____r37
   local __body21 = cut(____id31, 0)
-  setenv(__name5, {_stash = true, variable = true})
   if some63(__body21) then
     return join({"%local-function", __name5}, bind42(__x145, __body21))
   else

--- a/bin/system.lua
+++ b/bin/system.lua
@@ -1,5 +1,5 @@
 local function call_with_file(f, path, mode)
-  local h,e = io.open(path, mode)
+  local h, e = io.open(path, mode)
   if not h then
     error(e)
   end

--- a/compiler.l
+++ b/compiler.l
@@ -309,11 +309,7 @@
   (and (obj? x) (infix? (hd x))))
 
 (define compile-args (args)
-  (let (s "(" c "")
-    (step x args
-      (cat! s c (compile x))
-      (set c ", "))
-    (cat s ")")))
+  (cat "(" (mapcat compile args ", ") ")"))
 
 (define escape-newlines (s)
   (with s1 ""
@@ -711,28 +707,19 @@
 
 (define-special %array forms
   (let (open (if (= target 'lua) "{" "[")
-        close (if (= target 'lua) "}" "]")
-        s "" c "")
-    (each (k v) forms
-      (when (number? k)
-        (cat! s c (compile v))
-        (set c ", ")))
-    (cat open s close)))
+        close (if (= target 'lua) "}" "]"))
+    (cat open (mapcat compile forms ", ") close)))
 
 (define-special %object forms
-  (let (s "{" c ""
-        sep (if (= target 'lua) " = " ": "))
-    (each (k v) (pair forms)
-      (when (number? k)
-        (let ((k v) v)
-          (unless (string? k)
-            (error (cat "Illegal key: " (str k))))
-          (cat! s c (key k) sep (compile v))
-          (set c ", "))))
-    (cat s "}")))
+  (let (sep (if (= target 'lua) " = " ": ")
+        s (mapcat (fn ((k v))
+                       (cat (key k) sep (compile v)))
+                     (pair forms)
+                     ", "))
+    (cat "{" s "}")))
 
 (define-special %literal args
-  (apply cat (map compile args)))
+  (mapcat compile args))
 
 (export run
         eval

--- a/compiler.l
+++ b/compiler.l
@@ -119,7 +119,8 @@
        (= (hd x) 'unquote-splicing)))
 
 (define expand-local ((x name value))
-  (setenv name :variable)
+  (step x (if (obj? name) name (list name))
+    (setenv x :variable))
   `(%local ,name ,(macroexpand value)))
 
 (define expand-function ((x args rest: body))
@@ -662,11 +663,11 @@
         (cat (indentation) x))
     (compile `(%local ,name (%function ,args ,body)) :stmt)))
 
-(define-special return (x) :stmt
-  (let x (if (nil? x)
-             "return"
-           (cat "return " (compile x)))
-    (cat (indentation) x)))
+(define-special return args :stmt
+  (let s (mapcat compile args ", ")
+    (when (and (= target 'js) (> (# args) 1))
+      (set s (cat "[" s "]")))
+    (cat (indentation) "return" (if (some? s) " " "") s)))
 
 (define-special new (x)
   (cat "new " (compile x)))
@@ -681,7 +682,10 @@
     (cat (indentation) e)))
 
 (define-special %local (name value) :stmt
-  (let (id (compile name)
+  (let (id (if (obj? name)
+               (let s (mapcat compile name ", ")
+                 (if (= target 'js) (cat "[" s "]") s))
+             (compile name))
         value1 (compile value)
         rh (if (is? value) (cat " = " value1) "")
         keyword (if (= target 'js) "var " "local ")

--- a/macros.l
+++ b/macros.l
@@ -96,7 +96,6 @@
   `(set (get read-table ,char) (fn (,s) ,@body)))
 
 (define-macro define (name x rest: body)
-  (setenv name :variable)
   (if (some? body)
       `(%local-function ,name ,@(bind* x body))
     `(%local ,name ,x)))

--- a/runtime.l
+++ b/runtime.l
@@ -170,6 +170,15 @@
           (when (is? y)
             (set (get t k) y)))))))
 
+(define-global mapcat (f x sep)
+  (with s ""
+    (let (sep (or sep "") c "")
+      (step v x
+        (let y (f v)
+          (when (is? y)
+            (cat! s c y)
+            (set c sep)))))))
+
 (define-global keep (f x)
   (map (fn (v) (when (yes (f v)) v)) x))
 
@@ -323,12 +332,12 @@
       (cat s  ")"))))
 
 (target lua:
-  (define values (or unpack (get table 'unpack))))
+  (define unpack (or unpack (get table 'unpack))))
 
 (define-global apply (f args)
   (let args (stash args)
     (target js: ((get f 'apply) f args)
-            lua: (f (values args)))))
+            lua: (f (unpack args)))))
 
 (define-global call (f rest: args)
   (apply f args))

--- a/system.l
+++ b/system.l
@@ -3,11 +3,11 @@
 
 (target lua:
   (define call-with-file (f path mode)
-    (let |h,e| ((get io 'open) path mode)
-      (unless h
-        (error e))
-      (with x (f h)
-        ((get h 'close) h)))))
+    (define (h e) ((get io 'open) path mode))
+    (unless h
+      (error e))
+    (with x (f h)
+      ((get h 'close) h))))
 
 (define read-file (path)
   (target

--- a/test.l
+++ b/test.l
@@ -595,7 +595,9 @@ c"
     (let b ((fn () (inc a)))
       (test= 12 b)
       (test= 12 a)))
-  (test= 1 ((fn () (return (if true (return 1) 2))))))
+  (test= 1 ((fn () (return (if true (return 1) 2)))))
+  (define (a b) ((fn () (return true 1))))
+  (test= '(true 1) (list a b)))
 
 (define-test guard
   (let-macro ((guard1 (x)


### PR DESCRIPTION
This PR simplifies much of the string processing in compiler.l by
defining MAPCAT.

It additionally introduces support for multiple return values:

```
  (define (a b) ((fn () (return true 1))))
  (test= '(true 1) (list a b))
```