### PR TITLE
Definitions can be used as expressions

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -958,12 +958,15 @@ var lower_function = function (args) {
   var __body7 = cut(____id22, 1);
   return ["%function", __a4, lower_body(__body7, true)];
 };
-var lower_definition = function (kind, args, hoist) {
+var lower_definition = function (kind, args, hoist, stmt63, tail63) {
   var ____id23 = args;
   var __name4 = ____id23[0];
   var __args6 = ____id23[1];
   var __body8 = cut(____id23, 2);
-  return add(hoist, [kind, __name4, __args6, lower_body(__body8, true)]);
+  add(hoist, [kind, __name4, __args6, lower_body(__body8, true)]);
+  if (!( stmt63 && ! tail63)) {
+    return __name4;
+  }
 };
 var lower_call = function (form, hoist) {
   var __form2 = map(function (x) {
@@ -1050,7 +1053,7 @@ lower = function (form, hoist, stmt63, tail63) {
                           return lower_function(__args9);
                         } else {
                           if (__x131 === "%local-function" || __x131 === "%global-function") {
-                            return lower_definition(__x131, __args9, hoist);
+                            return lower_definition(__x131, __args9, hoist, stmt63, tail63);
                           } else {
                             if (in63(__x131, ["and", "or"])) {
                               return lower_short(__x131, __args9, hoist);

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -904,12 +904,15 @@ local function lower_function(args)
   local __body7 = cut(____id22, 1)
   return {"%function", __a4, lower_body(__body7, true)}
 end
-local function lower_definition(kind, args, hoist)
+local function lower_definition(kind, args, hoist, stmt63, tail63)
   local ____id23 = args
   local __name4 = ____id23[1]
   local __args6 = ____id23[2]
   local __body8 = cut(____id23, 2)
-  return add(hoist, {kind, __name4, __args6, lower_body(__body8, true)})
+  add(hoist, {kind, __name4, __args6, lower_body(__body8, true)})
+  if not( stmt63 and not tail63) then
+    return __name4
+  end
 end
 local function lower_call(form, hoist)
   local __form2 = map(function (x)
@@ -996,7 +999,7 @@ function lower(form, hoist, stmt63, tail63)
                           return lower_function(__args9)
                         else
                           if __x134 == "%local-function" or __x134 == "%global-function" then
-                            return lower_definition(__x134, __args9, hoist)
+                            return lower_definition(__x134, __args9, hoist, stmt63, tail63)
                           else
                             if in63(__x134, {"and", "or"}) then
                               return lower_short(__x134, __args9, hoist)

--- a/compiler.l
+++ b/compiler.l
@@ -509,9 +509,11 @@
   (let ((a rest: body) args)
     `(%function ,a ,(lower-body body true))))
 
-(define lower-definition (kind args hoist)
+(define lower-definition (kind args hoist stmt? tail?)
   (let ((name args rest: body) args)
-    (add hoist `(,kind ,name ,args ,(lower-body body true)))))
+    (add hoist `(,kind ,name ,args ,(lower-body body true)))
+    (unless (and stmt? (not tail?))
+      name)))
 
 (define lower-call (form hoist)
   (let form (map (fn (x) (lower x hoist)) form)
@@ -560,7 +562,7 @@
           (= x '%function) (lower-function args)
           (or (= x '%local-function)
               (= x '%global-function))
-          (lower-definition x args hoist)
+          (lower-definition x args hoist stmt? tail?)
           (in? x '(and or))
           (lower-short x args hoist)
           (statement? x) (lower-special form hoist)

--- a/test.l
+++ b/test.l
@@ -581,7 +581,13 @@ c"
   (test= 42 (f))
   ((fn ()
      (define f () 38)
-     (test= 38 (f))))
+     (test= 38 (f))
+     (test= 21 ((define f (n)
+                  (if (< n 2) n
+                    (+ (f (- n 1))
+                       (f (- n 2)))))
+                8))
+     (test= 21 (f 8))))
   (test= 42 (f)))
 
 (define-test return


### PR DESCRIPTION
In Arc, `afn` is used to create a recursive function:

```
arc> ((afn (n)
        (if (< n 2) n
            (+ (self (- n 1))
               (self (- n 2)))))
      8)
21
```

This PR lowers definitions as expressions, achieving the same thing in a natural way:

```diff
diff --git a/test.l b/test.l
index 80b089a..e71f09c 100755
--- a/test.l
+++ b/test.l
@@ -581,7 +581,13 @@ c"
   (test= 42 (f))
   ((fn ()
      (define f () 38)
-     (test= 38 (f))))
+     (test= 38 (f))
+     (test= 21 ((define f (n)
+                  (if (< n 2) n
+                    (+ (f (- n 1))
+                       (f (- n 2)))))
+                8))
+     (test= 21 (f 8))))
   (test= 42 (f)))
```