### PR TITLE
Let APPLY take keyword arguments

### DIFF
--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -1034,24 +1034,28 @@ setenv("apply", {_stash: true, macro: function (f) {
   var ____id49 = ____r57;
   var __args9 = cut(____id49, 0);
   if (_35(__args9) > 1) {
-    return ["%call", "apply", __f1, ["join", join(["list"], almost(__args9)), last(__args9)]];
+    return ["%call", "apply", __f1, ["join", join(["list"], almost(__args9)), last(__args9), join(["list"], keys(__args9))]];
   } else {
-    return join(["%call", "apply", __f1], __args9);
+    if (keys63(__args9)) {
+      return ["%call", "apply", __f1, join(["join"], __args9, [join(["list"], keys(__args9))])];
+    } else {
+      return join(["%call", "apply", __f1], __args9);
+    }
   }
 }});
 setenv("guard", {_stash: true, macro: function (expr) {
   if (target === "js") {
     return [["fn", join(), ["%try", ["list", true, expr]]]];
   } else {
-    var ____x230 = ["obj"];
-    ____x230.stack = [["get", "debug", ["quote", "traceback"]]];
-    ____x230.message = ["if", ["string?", "m"], ["clip", "m", ["+", ["or", ["search", "m", "\": \""], -2], 2]], ["nil?", "m"], "\"\"", ["str", "m"]];
-    return ["list", ["xpcall", ["fn", join(), expr], ["fn", ["m"], ["if", ["obj?", "m"], "m", ____x230]]]];
+    var ____x240 = ["obj"];
+    ____x240.stack = [["get", "debug", ["quote", "traceback"]]];
+    ____x240.message = ["if", ["string?", "m"], ["clip", "m", ["+", ["or", ["search", "m", "\": \""], -2], 2]], ["nil?", "m"], "\"\"", ["str", "m"]];
+    return ["list", ["xpcall", ["fn", join(), expr], ["fn", ["m"], ["if", ["obj?", "m"], "m", ____x240]]]];
   }
 }});
 setenv("each", {_stash: true, macro: function (x, t) {
   var ____r61 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __x256 = destash33(x, ____r61);
+  var __x266 = destash33(x, ____r61);
   var __t1 = destash33(t, ____r61);
   var ____id52 = ____r61;
   var __body37 = cut(____id52, 0);
@@ -1059,14 +1063,14 @@ setenv("each", {_stash: true, macro: function (x, t) {
   var __n3 = unique("n");
   var __i3 = unique("i");
   var __e9 = undefined;
-  if (atom63(__x256)) {
-    __e9 = [__i3, __x256];
+  if (atom63(__x266)) {
+    __e9 = [__i3, __x266];
   } else {
     var __e10 = undefined;
-    if (_35(__x256) > 1) {
-      __e10 = __x256;
+    if (_35(__x266) > 1) {
+      __e10 = __x266;
     } else {
-      __e10 = [__i3, hd(__x256)];
+      __e10 = [__i3, hd(__x266)];
     }
     __e9 = __e10;
   }
@@ -1095,9 +1099,9 @@ setenv("step", {_stash: true, macro: function (v, t) {
   var __t3 = destash33(t, ____r65);
   var ____id57 = ____r65;
   var __body41 = cut(____id57, 0);
-  var __x288 = unique("x");
+  var __x298 = unique("x");
   var __i7 = unique("i");
-  return ["let", [__x288, __t3], ["for", __i7, ["#", __x288], join(["let", [__v9, ["at", __x288, __i7]]], __body41)]];
+  return ["let", [__x298, __t3], ["for", __i7, ["#", __x298], join(["let", [__v9, ["at", __x298, __i7]]], __body41)]];
 }});
 setenv("set-of", {_stash: true, macro: function () {
   var __xs1 = unstash(Array.prototype.slice.call(arguments, 0));
@@ -1105,7 +1109,7 @@ setenv("set-of", {_stash: true, macro: function () {
   var ____o5 = __xs1;
   var ____i9 = undefined;
   for (____i9 in ____o5) {
-    var __x298 = ____o5[____i9];
+    var __x308 = ____o5[____i9];
     var __e12 = undefined;
     if (numeric63(____i9)) {
       __e12 = parseInt(____i9);
@@ -1113,7 +1117,7 @@ setenv("set-of", {_stash: true, macro: function () {
       __e12 = ____i9;
     }
     var ____i91 = __e12;
-    __l3[__x298] = true;
+    __l3[__x308] = true;
   }
   return join(["obj"], __l3);
 }});
@@ -1157,8 +1161,8 @@ setenv("dec", {_stash: true, macro: function (n, by) {
   return ["set", n, ["-", n, __e14]];
 }});
 setenv("with-indent", {_stash: true, macro: function (form) {
-  var __x323 = unique("x");
-  return ["do", ["inc", "indent-level"], ["with", __x323, form, ["dec", "indent-level"]]];
+  var __x333 = unique("x");
+  return ["do", ["inc", "indent-level"], ["with", __x333, form, ["dec", "indent-level"]]];
 }});
 setenv("export", {_stash: true, macro: function () {
   var __names5 = unstash(Array.prototype.slice.call(arguments, 0));
@@ -1167,7 +1171,7 @@ setenv("export", {_stash: true, macro: function () {
       return ["set", ["get", "exports", ["quote", k]], k];
     }, __names5));
   } else {
-    var __x339 = {};
+    var __x349 = {};
     var ____o7 = __names5;
     var ____i11 = undefined;
     for (____i11 in ____o7) {
@@ -1179,11 +1183,11 @@ setenv("export", {_stash: true, macro: function () {
         __e15 = ____i11;
       }
       var ____i111 = __e15;
-      __x339[__k7] = __k7;
+      __x349[__k7] = __k7;
     }
     return ["return", join(["%object"], mapo(function (x) {
       return x;
-    }, __x339))];
+    }, __x349))];
   }
 }});
 setenv("when-compiling", {_stash: true, macro: function () {

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -922,24 +922,28 @@ setenv("apply", {_stash = true, macro = function (f, ...)
   local ____id49 = ____r57
   local __args9 = cut(____id49, 0)
   if _35(__args9) > 1 then
-    return {"%call", "apply", __f1, {"join", join({"list"}, almost(__args9)), last(__args9)}}
+    return {"%call", "apply", __f1, {"join", join({"list"}, almost(__args9)), last(__args9), join({"list"}, keys(__args9))}}
   else
-    return join({"%call", "apply", __f1}, __args9)
+    if keys63(__args9) then
+      return {"%call", "apply", __f1, join({"join"}, __args9, {join({"list"}, keys(__args9))})}
+    else
+      return join({"%call", "apply", __f1}, __args9)
+    end
   end
 end})
 setenv("guard", {_stash = true, macro = function (expr)
   if target == "js" then
     return {{"fn", join(), {"%try", {"list", true, expr}}}}
   else
-    local ____x252 = {"obj"}
-    ____x252.stack = {{"get", "debug", {"quote", "traceback"}}}
-    ____x252.message = {"if", {"string?", "m"}, {"clip", "m", {"+", {"or", {"search", "m", "\": \""}, -2}, 2}}, {"nil?", "m"}, "\"\"", {"str", "m"}}
-    return {"list", {"xpcall", {"fn", join(), expr}, {"fn", {"m"}, {"if", {"obj?", "m"}, "m", ____x252}}}}
+    local ____x262 = {"obj"}
+    ____x262.stack = {{"get", "debug", {"quote", "traceback"}}}
+    ____x262.message = {"if", {"string?", "m"}, {"clip", "m", {"+", {"or", {"search", "m", "\": \""}, -2}, 2}}, {"nil?", "m"}, "\"\"", {"str", "m"}}
+    return {"list", {"xpcall", {"fn", join(), expr}, {"fn", {"m"}, {"if", {"obj?", "m"}, "m", ____x262}}}}
   end
 end})
 setenv("each", {_stash = true, macro = function (x, t, ...)
   local ____r61 = unstash({...})
-  local __x279 = destash33(x, ____r61)
+  local __x289 = destash33(x, ____r61)
   local __t1 = destash33(t, ____r61)
   local ____id52 = ____r61
   local __body37 = cut(____id52, 0)
@@ -947,14 +951,14 @@ setenv("each", {_stash = true, macro = function (x, t, ...)
   local __n3 = unique("n")
   local __i3 = unique("i")
   local __e8 = nil
-  if atom63(__x279) then
-    __e8 = {__i3, __x279}
+  if atom63(__x289) then
+    __e8 = {__i3, __x289}
   else
     local __e9 = nil
-    if _35(__x279) > 1 then
-      __e9 = __x279
+    if _35(__x289) > 1 then
+      __e9 = __x289
     else
-      __e9 = {__i3, hd(__x279)}
+      __e9 = {__i3, hd(__x289)}
     end
     __e8 = __e9
   end
@@ -983,9 +987,9 @@ setenv("step", {_stash = true, macro = function (v, t, ...)
   local __t3 = destash33(t, ____r65)
   local ____id57 = ____r65
   local __body41 = cut(____id57, 0)
-  local __x313 = unique("x")
+  local __x323 = unique("x")
   local __i7 = unique("i")
-  return {"let", {__x313, __t3}, {"for", __i7, {"#", __x313}, join({"let", {__v9, {"at", __x313, __i7}}}, __body41)}}
+  return {"let", {__x323, __t3}, {"for", __i7, {"#", __x323}, join({"let", {__v9, {"at", __x323, __i7}}}, __body41)}}
 end})
 setenv("set-of", {_stash = true, macro = function (...)
   local __xs1 = unstash({...})
@@ -993,8 +997,8 @@ setenv("set-of", {_stash = true, macro = function (...)
   local ____o5 = __xs1
   local ____i9 = nil
   for ____i9 in next, ____o5 do
-    local __x324 = ____o5[____i9]
-    __l3[__x324] = true
+    local __x334 = ____o5[____i9]
+    __l3[__x334] = true
   end
   return join({"obj"}, __l3)
 end})
@@ -1038,8 +1042,8 @@ setenv("dec", {_stash = true, macro = function (n, by)
   return {"set", n, {"-", n, __e12}}
 end})
 setenv("with-indent", {_stash = true, macro = function (form)
-  local __x352 = unique("x")
-  return {"do", {"inc", "indent-level"}, {"with", __x352, form, {"dec", "indent-level"}}}
+  local __x362 = unique("x")
+  return {"do", {"inc", "indent-level"}, {"with", __x362, form, {"dec", "indent-level"}}}
 end})
 setenv("export", {_stash = true, macro = function (...)
   local __names5 = unstash({...})
@@ -1048,16 +1052,16 @@ setenv("export", {_stash = true, macro = function (...)
       return {"set", {"get", "exports", {"quote", k}}, k}
     end, __names5))
   else
-    local __x369 = {}
+    local __x379 = {}
     local ____o7 = __names5
     local ____i11 = nil
     for ____i11 in next, ____o7 do
       local __k6 = ____o7[____i11]
-      __x369[__k6] = __k6
+      __x379[__k6] = __k6
     end
     return {"return", join({"%object"}, mapo(function (x)
       return x
-    end, __x369))}
+    end, __x379))}
   end
 end})
 setenv("when-compiling", {_stash = true, macro = function (...)

--- a/macros.l
+++ b/macros.l
@@ -146,7 +146,9 @@
 
 (define-macro apply (f rest: args)
   (if (> (# args) 1)
-      `(%call apply ,f (join (list ,@(almost args)) ,(last args)))
+      `(%call apply ,f (join (list ,@(almost args)) ,(last args) (list ,@(keys args))))
+      (keys? args)
+      `(%call apply ,f (join ,@args (list ,@(keys args))))
       `(%call apply ,f ,@args)))
 
 (define-macro guard (expr)

--- a/test.l
+++ b/test.l
@@ -1030,7 +1030,13 @@ c"
     (test= 17 (apply (fn a (get a 'foo)) t)))
   (test= 42 (apply (fn (:foo) foo) (list foo: 42)))
   (test= 42 (apply (fn ((:foo)) foo) (list (list foo: 42))))
-  (test= 116 (apply + 1 5 '(100 10))))
+  (test= 116 (apply + 1 5 '(100 10)))
+  (let f (fn (a :b) (+ (or a 1) b))
+    (test= 3 (apply f b: 2))
+    (test= 3 (apply f '(1) b: 2))
+    (test= 3 (apply f '(1 b: 42) b: 2))
+    (test= 3 (apply f 1 '(b: 42) b: 2))
+    (test= 3 (apply f 1 '(b: 2)))))
 
 (define-test eval
   (let eval (get compiler 'eval)


### PR DESCRIPTION
This PR adds the following tests (which now pass):

```
  (let f (fn (a :b) (+ (or a 1) b))
    (test= 3 (apply f b: 2))
    (test= 3 (apply f '(1) b: 2))
    (test= 3 (apply f '(1 b: 42) b: 2))
    (test= 3 (apply f 1 '(b: 42) b: 2))
    (test= 3 (apply f 1 '(b: 2))))
```

Letting `apply` take keyword arguments is a handy way to forward arguments while overriding keyword values:

```
(define-global foo (args :name)
  (list name: name args: args))

(define-global bar args
  (apply foo name: 'bar (list args)))
```

```
> (bar 1 2)
(name: "bar" args: (1 2))
> (bar 1 2 name: "ignored")
(name: "bar" args: (1 2 name: "ignored"))
```