### PR TITLE
Fix unquote-splicing lists within quasiquote

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -347,7 +347,11 @@ quasiexpand = function (form, depth) {
       return ["quote", form];
     } else {
       if (can_unquote63(depth) && hd(form) === "unquote") {
-        return quasiexpand(form[1]);
+        if (_35(form) > 2) {
+          return ["%splice", map(quasiexpand, tl(form))];
+        } else {
+          return quasiexpand(form[1]);
+        }
       } else {
         if (hd(form) === "unquote" || hd(form) === "unquote-splicing") {
           return quasiquote_list(form, depth - 1);
@@ -378,8 +382,8 @@ quasiexpand = function (form, depth) {
     }
   }
 };
-expand_if = function (__x61) {
-  var ____id5 = __x61;
+expand_if = function (__x62) {
+  var ____id5 = __x62;
   var __a = ____id5[0];
   var __b1 = ____id5[1];
   var __c = cut(____id5, 2);
@@ -453,14 +457,14 @@ valid_id63 = function (x) {
 };
 var __names = {};
 unique = function (x) {
-  var __x65 = id(x);
-  if (has63(__names, __x65)) {
-    var __i11 = __names[__x65];
-    __names[__x65] = __names[__x65] + 1;
-    return unique(__x65 + __i11);
+  var __x66 = id(x);
+  if (has63(__names, __x66)) {
+    var __i11 = __names[__x66];
+    __names[__x66] = __names[__x66] + 1;
+    return unique(__x66 + __i11);
   } else {
-    __names[__x65] = 1;
-    return "__" + __x65;
+    __names[__x66] = 1;
+    return "__" + __x66;
   }
 };
 key = function (k) {
@@ -488,52 +492,52 @@ mapo = function (f, t) {
       __e35 = __k9;
     }
     var __k10 = __e35;
-    var __x66 = f(__v6);
-    if (is63(__x66)) {
+    var __x67 = f(__v6);
+    if (is63(__x67)) {
       add(__o6, literal(__k10));
-      add(__o6, __x66);
+      add(__o6, __x67);
     }
   }
   return __o6;
 };
-var ____x68 = [];
 var ____x69 = [];
-____x69.js = "!";
-____x69.lua = "not";
-____x68["not"] = ____x69;
 var ____x70 = [];
-____x70["*"] = true;
-____x70["/"] = true;
-____x70["%"] = true;
+____x70.js = "!";
+____x70.lua = "not";
+____x69["not"] = ____x70;
 var ____x71 = [];
+____x71["*"] = true;
+____x71["/"] = true;
+____x71["%"] = true;
 var ____x72 = [];
-____x72.js = "+";
-____x72.lua = "..";
-____x71.cat = ____x72;
 var ____x73 = [];
-____x73["+"] = true;
-____x73["-"] = true;
+____x73.js = "+";
+____x73.lua = "..";
+____x72.cat = ____x73;
 var ____x74 = [];
-____x74["<"] = true;
-____x74[">"] = true;
-____x74["<="] = true;
-____x74[">="] = true;
+____x74["+"] = true;
+____x74["-"] = true;
 var ____x75 = [];
+____x75["<"] = true;
+____x75[">"] = true;
+____x75["<="] = true;
+____x75[">="] = true;
 var ____x76 = [];
-____x76.js = "===";
-____x76.lua = "==";
-____x75["="] = ____x76;
 var ____x77 = [];
+____x77.js = "===";
+____x77.lua = "==";
+____x76["="] = ____x77;
 var ____x78 = [];
-____x78.js = "&&";
-____x78.lua = "and";
-____x77["and"] = ____x78;
 var ____x79 = [];
+____x79.js = "&&";
+____x79.lua = "and";
+____x78["and"] = ____x79;
 var ____x80 = [];
-____x80.js = "||";
-____x80.lua = "or";
-____x79["or"] = ____x80;
-var infix = [____x68, ____x70, ____x71, ____x73, ____x74, ____x75, ____x77, ____x79];
+var ____x81 = [];
+____x81.js = "||";
+____x81.lua = "or";
+____x80["or"] = ____x81;
+var infix = [____x69, ____x71, ____x72, ____x74, ____x75, ____x76, ____x78, ____x80];
 var unary63 = function (form) {
   return two63(form) && in63(hd(form), ["not", "-"]);
 };
@@ -562,12 +566,12 @@ var precedence = function (form) {
 };
 var getop = function (op) {
   return find(function (level) {
-    var __x82 = level[op];
-    if (__x82 === true) {
+    var __x83 = level[op];
+    if (__x83 === true) {
       return op;
     } else {
-      if (is63(__x82)) {
-        return __x82[target];
+      if (is63(__x83)) {
+        return __x83[target];
       }
     }
   }, infix);
@@ -581,11 +585,11 @@ infix_operator63 = function (x) {
 var compile_args = function (args) {
   var __s1 = "(";
   var __c2 = "";
-  var ____x83 = args;
+  var ____x84 = args;
   var ____i15 = 0;
-  while (____i15 < _35(____x83)) {
-    var __x84 = ____x83[____i15];
-    __s1 = __s1 + __c2 + compile(__x84);
+  while (____i15 < _35(____x84)) {
+    var __x85 = ____x84[____i15];
+    __s1 = __s1 + __c2 + compile(__x85);
     __c2 = ", ";
     ____i15 = ____i15 + 1;
   }
@@ -673,9 +677,9 @@ var terminator = function (stmt63) {
 };
 var compile_special = function (form, stmt63) {
   var ____id6 = form;
-  var __x85 = ____id6[0];
+  var __x86 = ____id6[0];
   var __args2 = cut(____id6, 1);
-  var ____id7 = getenv(__x85);
+  var ____id7 = getenv(__x86);
   var __special = ____id7.special;
   var __stmt = ____id7.stmt;
   var __self_tr63 = ____id7.tr;
@@ -764,9 +768,9 @@ compile_function = function (args, body) {
   var __args12 = __e42;
   var __args5 = compile_args(__args12);
   indent_level = indent_level + 1;
-  var ____x89 = compile(__body3, {_stash: true, stmt: true});
+  var ____x90 = compile(__body3, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __body4 = ____x89;
+  var __body4 = ____x90;
   var __ind = indentation();
   var __e43 = undefined;
   if (__prefix) {
@@ -863,11 +867,11 @@ var standalone63 = function (form) {
   return ! atom63(form) && ! infix63(hd(form)) && ! literal63(form) && !( "get" === hd(form)) || id_literal63(form);
 };
 var lower_do = function (args, hoist, stmt63, tail63) {
-  var ____x95 = almost(args);
+  var ____x96 = almost(args);
   var ____i17 = 0;
-  while (____i17 < _35(____x95)) {
-    var __x96 = ____x95[____i17];
-    var ____y = lower(__x96, hoist, stmt63);
+  while (____i17 < _35(____x96)) {
+    var __x97 = ____x96[____i17];
+    var ____y = lower(__x97, hoist, stmt63);
     if (yes(____y)) {
       var __e1 = ____y;
       if (standalone63(__e1)) {
@@ -987,10 +991,10 @@ var lower_pairwise = function (form) {
   if (pairwise63(form)) {
     var __e4 = [];
     var ____id24 = form;
-    var __x125 = ____id24[0];
+    var __x126 = ____id24[0];
     var __args7 = cut(____id24, 1);
     reduce(function (a, b) {
-      add(__e4, [__x125, a, b]);
+      add(__e4, [__x126, a, b]);
       return a;
     }, __args7);
     return join(["and"], reverse(__e4));
@@ -1004,10 +1008,10 @@ var lower_infix63 = function (form) {
 var lower_infix = function (form, hoist) {
   var __form3 = lower_pairwise(form);
   var ____id25 = __form3;
-  var __x128 = ____id25[0];
+  var __x129 = ____id25[0];
   var __args8 = cut(____id25, 1);
   return lower(reduce(function (a, b) {
-    return [__x128, b, a];
+    return [__x129, b, a];
   }, reverse(__args8)), hoist);
 };
 var lower_special = function (form, hoist) {
@@ -1030,39 +1034,39 @@ lower = function (form, hoist, stmt63, tail63) {
           return lower_infix(form, hoist);
         } else {
           var ____id26 = form;
-          var __x131 = ____id26[0];
+          var __x132 = ____id26[0];
           var __args9 = cut(____id26, 1);
-          if (__x131 === "do") {
+          if (__x132 === "do") {
             return lower_do(__args9, hoist, stmt63, tail63);
           } else {
-            if (__x131 === "%call") {
+            if (__x132 === "%call") {
               return lower(__args9, hoist, stmt63, tail63);
             } else {
-              if (__x131 === "%set") {
+              if (__x132 === "%set") {
                 return lower_set(__args9, hoist, stmt63, tail63);
               } else {
-                if (__x131 === "%if") {
+                if (__x132 === "%if") {
                   return lower_if(__args9, hoist, stmt63, tail63);
                 } else {
-                  if (__x131 === "%try") {
+                  if (__x132 === "%try") {
                     return lower_try(__args9, hoist, tail63);
                   } else {
-                    if (__x131 === "while") {
+                    if (__x132 === "while") {
                       return lower_while(__args9, hoist);
                     } else {
-                      if (__x131 === "%for") {
+                      if (__x132 === "%for") {
                         return lower_for(__args9, hoist);
                       } else {
-                        if (__x131 === "%function") {
+                        if (__x132 === "%function") {
                           return lower_function(__args9);
                         } else {
-                          if (__x131 === "%local-function" || __x131 === "%global-function") {
-                            return lower_definition(__x131, __args9, hoist);
+                          if (__x132 === "%local-function" || __x132 === "%global-function") {
+                            return lower_definition(__x132, __args9, hoist);
                           } else {
-                            if (in63(__x131, ["and", "or"])) {
-                              return lower_short(__x131, __args9, hoist);
+                            if (in63(__x132, ["and", "or"])) {
+                              return lower_short(__x132, __args9, hoist);
                             } else {
-                              if (statement63(__x131)) {
+                              if (statement63(__x132)) {
                                 return lower_special(form, hoist);
                               } else {
                                 return lower_call(form, hoist);
@@ -1102,16 +1106,16 @@ immediate_call63 = function (x) {
 setenv("do", {_stash: true, special: function () {
   var __forms1 = unstash(Array.prototype.slice.call(arguments, 0));
   var __s3 = "";
-  var ____x136 = __forms1;
+  var ____x137 = __forms1;
   var ____i19 = 0;
-  while (____i19 < _35(____x136)) {
-    var __x137 = ____x136[____i19];
-    if (target === "lua" && immediate_call63(__x137) && "\n" === char(__s3, edge(__s3))) {
+  while (____i19 < _35(____x137)) {
+    var __x138 = ____x137[____i19];
+    if (target === "lua" && immediate_call63(__x138) && "\n" === char(__s3, edge(__s3))) {
       __s3 = clip(__s3, 0, edge(__s3)) + ";\n";
     }
-    __s3 = __s3 + compile(__x137, {_stash: true, stmt: true});
-    if (! atom63(__x137)) {
-      if (hd(__x137) === "return" || hd(__x137) === "break") {
+    __s3 = __s3 + compile(__x138, {_stash: true, stmt: true});
+    if (! atom63(__x138)) {
+      if (hd(__x138) === "return" || hd(__x138) === "break") {
         break;
       }
     }
@@ -1122,15 +1126,15 @@ setenv("do", {_stash: true, special: function () {
 setenv("%if", {_stash: true, special: function (cond, cons, alt) {
   var __cond2 = compile(cond);
   indent_level = indent_level + 1;
-  var ____x140 = compile(cons, {_stash: true, stmt: true});
+  var ____x141 = compile(cons, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __cons1 = ____x140;
+  var __cons1 = ____x141;
   var __e55 = undefined;
   if (alt) {
     indent_level = indent_level + 1;
-    var ____x141 = compile(alt, {_stash: true, stmt: true});
+    var ____x142 = compile(alt, {_stash: true, stmt: true});
     indent_level = indent_level - 1;
-    __e55 = ____x141;
+    __e55 = ____x142;
   }
   var __alt1 = __e55;
   var __ind3 = indentation();
@@ -1156,9 +1160,9 @@ setenv("%if", {_stash: true, special: function (cond, cons, alt) {
 setenv("while", {_stash: true, special: function (cond, form) {
   var __cond4 = compile(cond);
   indent_level = indent_level + 1;
-  var ____x143 = compile(form, {_stash: true, stmt: true});
+  var ____x144 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __body10 = ____x143;
+  var __body10 = ____x144;
   var __ind5 = indentation();
   if (target === "js") {
     return __ind5 + "while (" + __cond4 + ") {\n" + __body10 + __ind5 + "}\n";
@@ -1170,9 +1174,9 @@ setenv("%for", {_stash: true, special: function (t, k, form) {
   var __t2 = compile(t);
   var __ind7 = indentation();
   indent_level = indent_level + 1;
-  var ____x145 = compile(form, {_stash: true, stmt: true});
+  var ____x146 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __body12 = ____x145;
+  var __body12 = ____x146;
   if (target === "lua") {
     return __ind7 + "for " + k + " in next, " + __t2 + " do\n" + __body12 + __ind7 + "end\n";
   } else {
@@ -1183,14 +1187,14 @@ setenv("%try", {_stash: true, special: function (form) {
   var __e8 = unique("e");
   var __ind9 = indentation();
   indent_level = indent_level + 1;
-  var ____x150 = compile(form, {_stash: true, stmt: true});
+  var ____x151 = compile(form, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __body14 = ____x150;
+  var __body14 = ____x151;
   var __hf1 = ["return", ["%array", false, __e8]];
   indent_level = indent_level + 1;
-  var ____x153 = compile(__hf1, {_stash: true, stmt: true});
+  var ____x154 = compile(__hf1, {_stash: true, stmt: true});
   indent_level = indent_level - 1;
-  var __h1 = ____x153;
+  var __h1 = ____x154;
   return __ind9 + "try {\n" + __body14 + __ind9 + "}\n" + __ind9 + "catch (" + __e8 + ") {\n" + __h1 + __ind9 + "}\n";
 }, stmt: true, tr: true});
 setenv("%delete", {_stash: true, special: function (place) {
@@ -1204,16 +1208,16 @@ setenv("%function", {_stash: true, special: function (args, body) {
 }});
 setenv("%global-function", {_stash: true, special: function (name, args, body) {
   if (target === "lua") {
-    var __x157 = compile_function(args, body, {_stash: true, name: name});
-    return indentation() + __x157;
+    var __x158 = compile_function(args, body, {_stash: true, name: name});
+    return indentation() + __x158;
   } else {
     return compile(["%set", name, ["%function", args, body]], {_stash: true, stmt: true});
   }
 }, stmt: true, tr: true});
 setenv("%local-function", {_stash: true, special: function (name, args, body) {
   if (target === "lua") {
-    var __x163 = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
-    return indentation() + __x163;
+    var __x164 = compile_function(args, body, {_stash: true, name: name, prefix: "local"});
+    return indentation() + __x164;
   } else {
     return compile(["%local", name, ["%function", args, body]], {_stash: true, stmt: true});
   }
@@ -1225,8 +1229,8 @@ setenv("return", {_stash: true, special: function (x) {
   } else {
     __e56 = "return " + compile(x);
   }
-  var __x167 = __e56;
-  return indentation() + __x167;
+  var __x168 = __e56;
+  return indentation() + __x168;
 }, stmt: true});
 setenv("new", {_stash: true, special: function (x) {
   return "new " + compile(x);

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -305,7 +305,11 @@ function quasiexpand(form, depth)
       return {"quote", form}
     else
       if can_unquote63(depth) and hd(form) == "unquote" then
-        return quasiexpand(form[2])
+        if _35(form) > 2 then
+          return {"%splice", map(quasiexpand, tl(form))}
+        else
+          return quasiexpand(form[2])
+        end
       else
         if hd(form) == "unquote" or hd(form) == "unquote-splicing" then
           return quasiquote_list(form, depth - 1)
@@ -336,8 +340,8 @@ function quasiexpand(form, depth)
     end
   end
 end
-function expand_if(__x61)
-  local ____id5 = __x61
+function expand_if(__x62)
+  local ____id5 = __x62
   local __a = ____id5[1]
   local __b1 = ____id5[2]
   local __c = cut(____id5, 2)
@@ -411,14 +415,14 @@ function valid_id63(x)
 end
 local __names = {}
 function unique(x)
-  local __x65 = id(x)
-  if has63(__names, __x65) then
-    local __i11 = __names[__x65]
-    __names[__x65] = __names[__x65] + 1
-    return unique(__x65 .. __i11)
+  local __x66 = id(x)
+  if has63(__names, __x66) then
+    local __i11 = __names[__x66]
+    __names[__x66] = __names[__x66] + 1
+    return unique(__x66 .. __i11)
   else
-    __names[__x65] = 1
-    return "__" .. __x65
+    __names[__x66] = 1
+    return "__" .. __x66
   end
 end
 function key(k)
@@ -439,52 +443,52 @@ function mapo(f, t)
   local __k5 = nil
   for __k5 in next, ____o7 do
     local __v6 = ____o7[__k5]
-    local __x66 = f(__v6)
-    if is63(__x66) then
+    local __x67 = f(__v6)
+    if is63(__x67) then
       add(__o6, literal(__k5))
-      add(__o6, __x66)
+      add(__o6, __x67)
     end
   end
   return __o6
 end
-local ____x68 = {}
 local ____x69 = {}
-____x69.js = "!"
-____x69.lua = "not"
-____x68["not"] = ____x69
 local ____x70 = {}
-____x70["*"] = true
-____x70["/"] = true
-____x70["%"] = true
+____x70.js = "!"
+____x70.lua = "not"
+____x69["not"] = ____x70
 local ____x71 = {}
+____x71["*"] = true
+____x71["/"] = true
+____x71["%"] = true
 local ____x72 = {}
-____x72.js = "+"
-____x72.lua = ".."
-____x71.cat = ____x72
 local ____x73 = {}
-____x73["+"] = true
-____x73["-"] = true
+____x73.js = "+"
+____x73.lua = ".."
+____x72.cat = ____x73
 local ____x74 = {}
-____x74["<"] = true
-____x74[">"] = true
-____x74["<="] = true
-____x74[">="] = true
+____x74["+"] = true
+____x74["-"] = true
 local ____x75 = {}
+____x75["<"] = true
+____x75[">"] = true
+____x75["<="] = true
+____x75[">="] = true
 local ____x76 = {}
-____x76.js = "==="
-____x76.lua = "=="
-____x75["="] = ____x76
 local ____x77 = {}
+____x77.js = "==="
+____x77.lua = "=="
+____x76["="] = ____x77
 local ____x78 = {}
-____x78.js = "&&"
-____x78.lua = "and"
-____x77["and"] = ____x78
 local ____x79 = {}
+____x79.js = "&&"
+____x79.lua = "and"
+____x78["and"] = ____x79
 local ____x80 = {}
-____x80.js = "||"
-____x80.lua = "or"
-____x79["or"] = ____x80
-local infix = {____x68, ____x70, ____x71, ____x73, ____x74, ____x75, ____x77, ____x79}
+local ____x81 = {}
+____x81.js = "||"
+____x81.lua = "or"
+____x80["or"] = ____x81
+local infix = {____x69, ____x71, ____x72, ____x74, ____x75, ____x76, ____x78, ____x80}
 local function unary63(form)
   return two63(form) and in63(hd(form), {"not", "-"})
 end
@@ -508,12 +512,12 @@ local function precedence(form)
 end
 local function getop(op)
   return find(function (level)
-    local __x82 = level[op]
-    if __x82 == true then
+    local __x83 = level[op]
+    if __x83 == true then
       return op
     else
-      if is63(__x82) then
-        return __x82[target]
+      if is63(__x83) then
+        return __x83[target]
       end
     end
   end, infix)
@@ -527,11 +531,11 @@ end
 local function compile_args(args)
   local __s1 = "("
   local __c2 = ""
-  local ____x83 = args
+  local ____x84 = args
   local ____i15 = 0
-  while ____i15 < _35(____x83) do
-    local __x84 = ____x83[____i15 + 1]
-    __s1 = __s1 .. __c2 .. compile(__x84)
+  while ____i15 < _35(____x84) do
+    local __x85 = ____x84[____i15 + 1]
+    __s1 = __s1 .. __c2 .. compile(__x85)
     __c2 = ", "
     ____i15 = ____i15 + 1
   end
@@ -619,9 +623,9 @@ local function terminator(stmt63)
 end
 local function compile_special(form, stmt63)
   local ____id6 = form
-  local __x85 = ____id6[1]
+  local __x86 = ____id6[1]
   local __args2 = cut(____id6, 1)
-  local ____id7 = getenv(__x85)
+  local ____id7 = getenv(__x86)
   local __special = ____id7.special
   local __stmt = ____id7.stmt
   local __self_tr63 = ____id7.tr
@@ -710,9 +714,9 @@ function compile_function(args, body, ...)
   local __args12 = __e34
   local __args5 = compile_args(__args12)
   indent_level = indent_level + 1
-  local ____x91 = compile(__body3, {_stash = true, stmt = true})
+  local ____x92 = compile(__body3, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __body4 = ____x91
+  local __body4 = ____x92
   local __ind = indentation()
   local __e35 = nil
   if __prefix then
@@ -809,11 +813,11 @@ local function standalone63(form)
   return not atom63(form) and not infix63(hd(form)) and not literal63(form) and not( "get" == hd(form)) or id_literal63(form)
 end
 local function lower_do(args, hoist, stmt63, tail63)
-  local ____x98 = almost(args)
+  local ____x99 = almost(args)
   local ____i17 = 0
-  while ____i17 < _35(____x98) do
-    local __x99 = ____x98[____i17 + 1]
-    local ____y = lower(__x99, hoist, stmt63)
+  while ____i17 < _35(____x99) do
+    local __x100 = ____x99[____i17 + 1]
+    local ____y = lower(__x100, hoist, stmt63)
     if yes(____y) then
       local __e1 = ____y
       if standalone63(__e1) then
@@ -933,10 +937,10 @@ local function lower_pairwise(form)
   if pairwise63(form) then
     local __e4 = {}
     local ____id24 = form
-    local __x128 = ____id24[1]
+    local __x129 = ____id24[1]
     local __args7 = cut(____id24, 1)
     reduce(function (a, b)
-      add(__e4, {__x128, a, b})
+      add(__e4, {__x129, a, b})
       return a
     end, __args7)
     return join({"and"}, reverse(__e4))
@@ -950,10 +954,10 @@ end
 local function lower_infix(form, hoist)
   local __form3 = lower_pairwise(form)
   local ____id25 = __form3
-  local __x131 = ____id25[1]
+  local __x132 = ____id25[1]
   local __args8 = cut(____id25, 1)
   return lower(reduce(function (a, b)
-    return {__x131, b, a}
+    return {__x132, b, a}
   end, reverse(__args8)), hoist)
 end
 local function lower_special(form, hoist)
@@ -976,39 +980,39 @@ function lower(form, hoist, stmt63, tail63)
           return lower_infix(form, hoist)
         else
           local ____id26 = form
-          local __x134 = ____id26[1]
+          local __x135 = ____id26[1]
           local __args9 = cut(____id26, 1)
-          if __x134 == "do" then
+          if __x135 == "do" then
             return lower_do(__args9, hoist, stmt63, tail63)
           else
-            if __x134 == "%call" then
+            if __x135 == "%call" then
               return lower(__args9, hoist, stmt63, tail63)
             else
-              if __x134 == "%set" then
+              if __x135 == "%set" then
                 return lower_set(__args9, hoist, stmt63, tail63)
               else
-                if __x134 == "%if" then
+                if __x135 == "%if" then
                   return lower_if(__args9, hoist, stmt63, tail63)
                 else
-                  if __x134 == "%try" then
+                  if __x135 == "%try" then
                     return lower_try(__args9, hoist, tail63)
                   else
-                    if __x134 == "while" then
+                    if __x135 == "while" then
                       return lower_while(__args9, hoist)
                     else
-                      if __x134 == "%for" then
+                      if __x135 == "%for" then
                         return lower_for(__args9, hoist)
                       else
-                        if __x134 == "%function" then
+                        if __x135 == "%function" then
                           return lower_function(__args9)
                         else
-                          if __x134 == "%local-function" or __x134 == "%global-function" then
-                            return lower_definition(__x134, __args9, hoist)
+                          if __x135 == "%local-function" or __x135 == "%global-function" then
+                            return lower_definition(__x135, __args9, hoist)
                           else
-                            if in63(__x134, {"and", "or"}) then
-                              return lower_short(__x134, __args9, hoist)
+                            if in63(__x135, {"and", "or"}) then
+                              return lower_short(__x135, __args9, hoist)
                             else
-                              if statement63(__x134) then
+                              if statement63(__x135) then
                                 return lower_special(form, hoist)
                               else
                                 return lower_call(form, hoist)
@@ -1055,16 +1059,16 @@ end
 setenv("do", {_stash = true, special = function (...)
   local __forms1 = unstash({...})
   local __s3 = ""
-  local ____x140 = __forms1
+  local ____x141 = __forms1
   local ____i19 = 0
-  while ____i19 < _35(____x140) do
-    local __x141 = ____x140[____i19 + 1]
-    if target == "lua" and immediate_call63(__x141) and "\n" == char(__s3, edge(__s3)) then
+  while ____i19 < _35(____x141) do
+    local __x142 = ____x141[____i19 + 1]
+    if target == "lua" and immediate_call63(__x142) and "\n" == char(__s3, edge(__s3)) then
       __s3 = clip(__s3, 0, edge(__s3)) .. ";\n"
     end
-    __s3 = __s3 .. compile(__x141, {_stash = true, stmt = true})
-    if not atom63(__x141) then
-      if hd(__x141) == "return" or hd(__x141) == "break" then
+    __s3 = __s3 .. compile(__x142, {_stash = true, stmt = true})
+    if not atom63(__x142) then
+      if hd(__x142) == "return" or hd(__x142) == "break" then
         break
       end
     end
@@ -1075,15 +1079,15 @@ end, stmt = true, tr = true})
 setenv("%if", {_stash = true, special = function (cond, cons, alt)
   local __cond2 = compile(cond)
   indent_level = indent_level + 1
-  local ____x144 = compile(cons, {_stash = true, stmt = true})
+  local ____x145 = compile(cons, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __cons1 = ____x144
+  local __cons1 = ____x145
   local __e47 = nil
   if alt then
     indent_level = indent_level + 1
-    local ____x145 = compile(alt, {_stash = true, stmt = true})
+    local ____x146 = compile(alt, {_stash = true, stmt = true})
     indent_level = indent_level - 1
-    __e47 = ____x145
+    __e47 = ____x146
   end
   local __alt1 = __e47
   local __ind3 = indentation()
@@ -1109,9 +1113,9 @@ end, stmt = true, tr = true})
 setenv("while", {_stash = true, special = function (cond, form)
   local __cond4 = compile(cond)
   indent_level = indent_level + 1
-  local ____x147 = compile(form, {_stash = true, stmt = true})
+  local ____x148 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __body10 = ____x147
+  local __body10 = ____x148
   local __ind5 = indentation()
   if target == "js" then
     return __ind5 .. "while (" .. __cond4 .. ") {\n" .. __body10 .. __ind5 .. "}\n"
@@ -1123,9 +1127,9 @@ setenv("%for", {_stash = true, special = function (t, k, form)
   local __t2 = compile(t)
   local __ind7 = indentation()
   indent_level = indent_level + 1
-  local ____x149 = compile(form, {_stash = true, stmt = true})
+  local ____x150 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __body12 = ____x149
+  local __body12 = ____x150
   if target == "lua" then
     return __ind7 .. "for " .. k .. " in next, " .. __t2 .. " do\n" .. __body12 .. __ind7 .. "end\n"
   else
@@ -1136,14 +1140,14 @@ setenv("%try", {_stash = true, special = function (form)
   local __e8 = unique("e")
   local __ind9 = indentation()
   indent_level = indent_level + 1
-  local ____x154 = compile(form, {_stash = true, stmt = true})
+  local ____x155 = compile(form, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __body14 = ____x154
+  local __body14 = ____x155
   local __hf1 = {"return", {"%array", false, __e8}}
   indent_level = indent_level + 1
-  local ____x157 = compile(__hf1, {_stash = true, stmt = true})
+  local ____x158 = compile(__hf1, {_stash = true, stmt = true})
   indent_level = indent_level - 1
-  local __h1 = ____x157
+  local __h1 = ____x158
   return __ind9 .. "try {\n" .. __body14 .. __ind9 .. "}\n" .. __ind9 .. "catch (" .. __e8 .. ") {\n" .. __h1 .. __ind9 .. "}\n"
 end, stmt = true, tr = true})
 setenv("%delete", {_stash = true, special = function (place)
@@ -1157,16 +1161,16 @@ setenv("%function", {_stash = true, special = function (args, body)
 end})
 setenv("%global-function", {_stash = true, special = function (name, args, body)
   if target == "lua" then
-    local __x161 = compile_function(args, body, {_stash = true, name = name})
-    return indentation() .. __x161
+    local __x162 = compile_function(args, body, {_stash = true, name = name})
+    return indentation() .. __x162
   else
     return compile({"%set", name, {"%function", args, body}}, {_stash = true, stmt = true})
   end
 end, stmt = true, tr = true})
 setenv("%local-function", {_stash = true, special = function (name, args, body)
   if target == "lua" then
-    local __x167 = compile_function(args, body, {_stash = true, name = name, prefix = "local"})
-    return indentation() .. __x167
+    local __x168 = compile_function(args, body, {_stash = true, name = name, prefix = "local"})
+    return indentation() .. __x168
   else
     return compile({"%local", name, {"%function", args, body}}, {_stash = true, stmt = true})
   end
@@ -1178,8 +1182,8 @@ setenv("return", {_stash = true, special = function (x)
   else
     __e48 = "return " .. compile(x)
   end
-  local __x171 = __e48
-  return indentation() .. __x171
+  local __x172 = __e48
+  return indentation() .. __x172
 end, stmt = true})
 setenv("new", {_stash = true, special = function (x)
   return "new " .. compile(x)

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -283,9 +283,19 @@ map = function (f, x) {
   var ____i9 = 0;
   while (____i9 < _35(____x6)) {
     var __v3 = ____x6[____i9];
-    var __y2 = f(__v3);
+    var __e7 = undefined;
+    if (f) {
+      __e7 = f(__v3);
+    } else {
+      __e7 = __v3;
+    }
+    var __y2 = __e7;
     if (is63(__y2)) {
-      add(__t1, __y2);
+      if (hd63(__y2, "%splice")) {
+        __t1 = join(__t1, __y2[1]);
+      } else {
+        add(__t1, __y2);
+      }
     }
     ____i9 = ____i9 + 1;
   }
@@ -293,16 +303,25 @@ map = function (f, x) {
   var __k6 = undefined;
   for (__k6 in ____o4) {
     var __v4 = ____o4[__k6];
-    var __e7 = undefined;
+    var __e8 = undefined;
     if (numeric63(__k6)) {
-      __e7 = parseInt(__k6);
+      __e8 = parseInt(__k6);
     } else {
-      __e7 = __k6;
+      __e8 = __k6;
     }
-    var __k7 = __e7;
+    var __k7 = __e8;
     if (! number63(__k7)) {
-      var __y3 = f(__v4);
+      var __e9 = undefined;
+      if (f) {
+        __e9 = f(__v4);
+      } else {
+        __e9 = __v4;
+      }
+      var __y3 = __e9;
       if (is63(__y3)) {
+        if (hd63(__y3, "%splice")) {
+          __y3 = __y3[1];
+        }
         __t1[__k7] = __y3;
       }
     }
@@ -321,13 +340,13 @@ keys63 = function (t) {
   var __k8 = undefined;
   for (__k8 in ____o5) {
     var __v5 = ____o5[__k8];
-    var __e8 = undefined;
+    var __e10 = undefined;
     if (numeric63(__k8)) {
-      __e8 = parseInt(__k8);
+      __e10 = parseInt(__k8);
     } else {
-      __e8 = __k8;
+      __e10 = __k8;
     }
-    var __k9 = __e8;
+    var __k9 = __e10;
     if (! number63(__k9)) {
       return true;
     }
@@ -339,13 +358,13 @@ empty63 = function (t) {
   var ____i12 = undefined;
   for (____i12 in ____o6) {
     var __x7 = ____o6[____i12];
-    var __e9 = undefined;
+    var __e11 = undefined;
     if (numeric63(____i12)) {
-      __e9 = parseInt(____i12);
+      __e11 = parseInt(____i12);
     } else {
-      __e9 = ____i12;
+      __e11 = ____i12;
     }
-    var ____i121 = __e9;
+    var ____i121 = __e11;
     return false;
   }
   return true;
@@ -357,13 +376,13 @@ stash = function (args) {
     var __k10 = undefined;
     for (__k10 in ____o7) {
       var __v6 = ____o7[__k10];
-      var __e10 = undefined;
+      var __e12 = undefined;
       if (numeric63(__k10)) {
-        __e10 = parseInt(__k10);
+        __e12 = parseInt(__k10);
       } else {
-        __e10 = __k10;
+        __e12 = __k10;
       }
-      var __k11 = __e10;
+      var __k11 = __e12;
       if (! number63(__k11)) {
         __p[__k11] = __v6;
       }
@@ -384,13 +403,13 @@ unstash = function (args) {
       var __k12 = undefined;
       for (__k12 in ____o8) {
         var __v7 = ____o8[__k12];
-        var __e11 = undefined;
+        var __e13 = undefined;
         if (numeric63(__k12)) {
-          __e11 = parseInt(__k12);
+          __e13 = parseInt(__k12);
         } else {
-          __e11 = __k12;
+          __e13 = __k12;
         }
-        var __k13 = __e11;
+        var __k13 = __e13;
         if (!( __k13 === "_stash")) {
           __args1[__k13] = __v7;
         }
@@ -407,13 +426,13 @@ destash33 = function (l, args1) {
     var __k14 = undefined;
     for (__k14 in ____o9) {
       var __v8 = ____o9[__k14];
-      var __e12 = undefined;
+      var __e14 = undefined;
       if (numeric63(__k14)) {
-        __e12 = parseInt(__k14);
+        __e14 = parseInt(__k14);
       } else {
-        __e12 = __k14;
+        __e14 = __k14;
       }
-      var __k15 = __e12;
+      var __k15 = __e14;
       if (!( __k15 === "_stash")) {
         args1[__k15] = __v8;
       }
@@ -553,31 +572,31 @@ escape = function (s) {
   var __i20 = 0;
   while (__i20 < _35(s)) {
     var __c = char(s, __i20);
-    var __e13 = undefined;
+    var __e15 = undefined;
     if (__c === "\n") {
-      __e13 = "\\n";
+      __e15 = "\\n";
     } else {
-      var __e14 = undefined;
+      var __e16 = undefined;
       if (__c === "\r") {
-        __e14 = "\\r";
+        __e16 = "\\r";
       } else {
-        var __e15 = undefined;
+        var __e17 = undefined;
         if (__c === "\"") {
-          __e15 = "\\\"";
+          __e17 = "\\\"";
         } else {
-          var __e16 = undefined;
+          var __e18 = undefined;
           if (__c === "\\") {
-            __e16 = "\\\\";
+            __e18 = "\\\\";
           } else {
-            __e16 = __c;
+            __e18 = __c;
           }
-          __e15 = __e16;
+          __e17 = __e18;
         }
-        __e14 = __e15;
+        __e16 = __e17;
       }
-      __e13 = __e14;
+      __e15 = __e16;
     }
-    var __c1 = __e13;
+    var __c1 = __e15;
     __s1 = __s1 + __c1;
     __i20 = __i20 + 1;
   }
@@ -628,13 +647,13 @@ str = function (x, stack) {
                       var __k16 = undefined;
                       for (__k16 in ____o10) {
                         var __v9 = ____o10[__k16];
-                        var __e17 = undefined;
+                        var __e19 = undefined;
                         if (numeric63(__k16)) {
-                          __e17 = parseInt(__k16);
+                          __e19 = parseInt(__k16);
                         } else {
-                          __e17 = __k16;
+                          __e19 = __k16;
                         }
-                        var __k17 = __e17;
+                        var __k17 = __e19;
                         if (number63(__k17)) {
                           __xs11[__k17] = str(__v9, __l4);
                         } else {
@@ -647,13 +666,13 @@ str = function (x, stack) {
                       var ____i22 = undefined;
                       for (____i22 in ____o11) {
                         var __v10 = ____o11[____i22];
-                        var __e18 = undefined;
+                        var __e20 = undefined;
                         if (numeric63(____i22)) {
-                          __e18 = parseInt(____i22);
+                          __e20 = parseInt(____i22);
                         } else {
-                          __e18 = ____i22;
+                          __e20 = ____i22;
                         }
-                        var ____i221 = __e18;
+                        var ____i221 = __e20;
                         __s = __s + __sp + __v10;
                         __sp = " ";
                       }
@@ -686,25 +705,25 @@ setenv = function (k) {
   var ____id1 = ____r76;
   var __keys = cut(____id1, 0);
   if (string63(__k18)) {
-    var __e19 = undefined;
+    var __e21 = undefined;
     if (__keys.toplevel) {
-      __e19 = hd(environment);
+      __e21 = hd(environment);
     } else {
-      __e19 = last(environment);
+      __e21 = last(environment);
     }
-    var __frame = __e19;
+    var __frame = __e21;
     var __entry = __frame[__k18] || {};
     var ____o12 = __keys;
     var __k19 = undefined;
     for (__k19 in ____o12) {
       var __v11 = ____o12[__k19];
-      var __e20 = undefined;
+      var __e22 = undefined;
       if (numeric63(__k19)) {
-        __e20 = parseInt(__k19);
+        __e22 = parseInt(__k19);
       } else {
-        __e20 = __k19;
+        __e22 = __k19;
       }
-      var __k20 = __e20;
+      var __k20 = __e22;
       __entry[__k20] = __v11;
     }
     __frame[__k18] = __entry;

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -246,9 +246,19 @@ function map(f, x)
   local ____i9 = 0
   while ____i9 < _35(____x7) do
     local __v3 = ____x7[____i9 + 1]
-    local __y2 = f(__v3)
+    local __e3 = nil
+    if f then
+      __e3 = f(__v3)
+    else
+      __e3 = __v3
+    end
+    local __y2 = __e3
     if is63(__y2) then
-      add(__t1, __y2)
+      if hd63(__y2, "%splice") then
+        __t1 = join(__t1, __y2[2])
+      else
+        add(__t1, __y2)
+      end
     end
     ____i9 = ____i9 + 1
   end
@@ -257,8 +267,17 @@ function map(f, x)
   for __k3 in next, ____o4 do
     local __v4 = ____o4[__k3]
     if not number63(__k3) then
-      local __y3 = f(__v4)
+      local __e4 = nil
+      if f then
+        __e4 = f(__v4)
+      else
+        __e4 = __v4
+      end
+      local __y3 = __e4
       if is63(__y3) then
+        if hd63(__y3, "%splice") then
+          __y3 = __y3[2]
+        end
         __t1[__k3] = __y3
       end
     end
@@ -344,11 +363,11 @@ function destash33(l, args1)
   end
 end
 function search(s, pattern, start)
-  local __e3 = nil
+  local __e5 = nil
   if start then
-    __e3 = start + 1
+    __e5 = start + 1
   end
-  local __start = __e3
+  local __start = __e5
   local __i16 = string.find(s, pattern, __start, true)
   return __i16 and __i16 - 1
 end
@@ -471,31 +490,31 @@ function escape(s)
   local __i20 = 0
   while __i20 < _35(s) do
     local __c = char(s, __i20)
-    local __e4 = nil
+    local __e6 = nil
     if __c == "\n" then
-      __e4 = "\\n"
+      __e6 = "\\n"
     else
-      local __e5 = nil
+      local __e7 = nil
       if __c == "\r" then
-        __e5 = "\\r"
+        __e7 = "\\r"
       else
-        local __e6 = nil
+        local __e8 = nil
         if __c == "\"" then
-          __e6 = "\\\""
+          __e8 = "\\\""
         else
-          local __e7 = nil
+          local __e9 = nil
           if __c == "\\" then
-            __e7 = "\\\\"
+            __e9 = "\\\\"
           else
-            __e7 = __c
+            __e9 = __c
           end
-          __e6 = __e7
+          __e8 = __e9
         end
-        __e5 = __e6
+        __e7 = __e8
       end
-      __e4 = __e5
+      __e6 = __e7
     end
-    local __c1 = __e4
+    local __c1 = __e6
     __s1 = __s1 .. __c1
     __i20 = __i20 + 1
   end
@@ -594,13 +613,13 @@ function setenv(k, ...)
   local ____id1 = ____r73
   local __keys = cut(____id1, 0)
   if string63(__k9) then
-    local __e8 = nil
+    local __e10 = nil
     if __keys.toplevel then
-      __e8 = hd(environment)
+      __e10 = hd(environment)
     else
-      __e8 = last(environment)
+      __e10 = last(environment)
     end
-    local __frame = __e8
+    local __frame = __e10
     local __entry = __frame[__k9] or {}
     local ____o12 = __keys
     local __k10 = nil

--- a/compiler.l
+++ b/compiler.l
@@ -180,7 +180,9 @@
           ;; unquote
           (and (can-unquote? depth)
                (= (hd form) 'unquote))
-          (quasiexpand (at form 1))
+          (if (> (# form) 2)
+              `(%splice ,(map quasiexpand (tl form)))
+            (quasiexpand (at form 1)))
           ;; decrease quasiquoting depth
           (or (= (hd form) 'unquote)
               (= (hd form) 'unquote-splicing))

--- a/runtime.l
+++ b/runtime.l
@@ -163,11 +163,15 @@
     (step v x
       (let y (f v)
         (if (is? y)
-          (add t y))))
+          (if (hd? y '%splice)
+              (join! t (at y 1))
+            (add t y)))))
     (each (k v) x
       (unless (number? k)
         (let y (f v)
           (when (is? y)
+            (if (hd? y '%splice)
+              (set y (at y 1)))
             (set (get t k) y)))))))
 
 (define-global keep (f x)

--- a/test.l
+++ b/test.l
@@ -326,7 +326,11 @@ c"
   (test= '(%array "quasiquote" (%array "x")) (macroexpand '``(x)))
   (test= '(%array "quasiquote" (%array "unquote" "a")) (macroexpand '``,a))
   (test= '(%array "quasiquote" (%array (%array "unquote" "x")))
-         (macroexpand '``(,x))))
+         (macroexpand '``(,x)))
+  (let l '(y z)
+    (test= '(quasiquote (x (unquote y z))) ``(x ,,@l))
+    (test= '(%array "x" y z) (macroexpand ``(x ,,@l))))
+  (test= '(x y z) (eval `(let (a 'y b 'z) `(x ,,@'(a b))))))
 
 (define-test calls
   (let (f (fn () 42)


### PR DESCRIPTION
- The following expression now correctly returns '(x y z):

    (eval `(let (a 'y b 'z) `(x ,,@'(a b))))

  (It was returning '(x y) since (unquote a b) was ignoring b.)

- MAP now supports splicing. E.g.:

    > (define-global spliced (x)
        (if (hd? x '%splice) x
            (obj? x) `(%splice ,x)
          x))

    > (define-global flatten (l)
        (while (first obj? l)
          (set l (map spliced l)))
        l)
    > (flatten '((1 2) 3 (4 5 (6))))
    (1 2 3 4 5 6)

    > (define-global intersperse (a bs)
        (tl (map (fn (x) `(%splice (,a ,x))) bs)))
    > (apply cat (intersperse ", " '(foo bar baz)))
    "foo, bar, baz"