### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Every piece of code in Lumen is an expression, and expressions can be evaluated 
 > 17
 17
 > -5e4
--5000
+-50000
 > true
 true
 > false


### PR DESCRIPTION
-5e4 evaluates to -50000, not -5000.

HN user markrages discovered this typo: https://news.ycombinator.com/item?id=27943642