### PR TITLE
Introduce %EXPANSION, optimize LET-SYMBOL

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -255,7 +255,12 @@ var expand_definition = function (__x46) {
   return ____x49;
 };
 var expand_macro = function (form) {
-  return macroexpand(expand1(form));
+  var __expr = expand1(form);
+  if (hd63(__expr, "%expansion")) {
+    return __expr[1];
+  } else {
+    return macroexpand(__expr);
+  }
 };
 expand1 = function (__x51) {
   var ____id4 = __x51;

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -220,7 +220,12 @@ local function expand_definition(__x46)
   return ____x49
 end
 local function expand_macro(form)
-  return macroexpand(expand1(form))
+  local __expr = expand1(form)
+  if hd63(__expr, "%expansion") then
+    return __expr[2]
+  else
+    return macroexpand(__expr)
+  end
 end
 function expand1(__x51)
   local ____id4 = __x51

--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -1001,15 +1001,15 @@ setenv("let-symbol", {_stash: true, macro: function (expansions) {
   var ____id42 = ____r48;
   var __body31 = cut(____id42, 0);
   add(environment, {});
-  map(function (__x175) {
-    var ____id43 = __x175;
+  map(function (__x176) {
+    var ____id43 = __x176;
     var __name9 = ____id43[0];
     var __exp1 = ____id43[1];
     return macroexpand(["define-symbol", __name9, __exp1]);
   }, pair(__expansions1));
-  var ____x174 = join(["do"], macroexpand(__body31));
+  var ____x175 = ["%expansion", macroexpand(join(["do"], __body31))];
   drop(environment);
-  return ____x174;
+  return ____x175;
 }});
 setenv("let-unique", {_stash: true, macro: function (names) {
   var ____r52 = unstash(Array.prototype.slice.call(arguments, 1));
@@ -1043,15 +1043,15 @@ setenv("guard", {_stash: true, macro: function (expr) {
   if (target === "js") {
     return [["fn", join(), ["%try", ["list", true, expr]]]];
   } else {
-    var ____x230 = ["obj"];
-    ____x230.stack = [["get", "debug", ["quote", "traceback"]]];
-    ____x230.message = ["if", ["string?", "m"], ["clip", "m", ["+", ["or", ["search", "m", "\": \""], -2], 2]], ["nil?", "m"], "\"\"", ["str", "m"]];
-    return ["list", ["xpcall", ["fn", join(), expr], ["fn", ["m"], ["if", ["obj?", "m"], "m", ____x230]]]];
+    var ____x232 = ["obj"];
+    ____x232.stack = [["get", "debug", ["quote", "traceback"]]];
+    ____x232.message = ["if", ["string?", "m"], ["clip", "m", ["+", ["or", ["search", "m", "\": \""], -2], 2]], ["nil?", "m"], "\"\"", ["str", "m"]];
+    return ["list", ["xpcall", ["fn", join(), expr], ["fn", ["m"], ["if", ["obj?", "m"], "m", ____x232]]]];
   }
 }});
 setenv("each", {_stash: true, macro: function (x, t) {
   var ____r61 = unstash(Array.prototype.slice.call(arguments, 2));
-  var __x256 = destash33(x, ____r61);
+  var __x258 = destash33(x, ____r61);
   var __t1 = destash33(t, ____r61);
   var ____id52 = ____r61;
   var __body37 = cut(____id52, 0);
@@ -1059,14 +1059,14 @@ setenv("each", {_stash: true, macro: function (x, t) {
   var __n3 = unique("n");
   var __i3 = unique("i");
   var __e9 = undefined;
-  if (atom63(__x256)) {
-    __e9 = [__i3, __x256];
+  if (atom63(__x258)) {
+    __e9 = [__i3, __x258];
   } else {
     var __e10 = undefined;
-    if (_35(__x256) > 1) {
-      __e10 = __x256;
+    if (_35(__x258) > 1) {
+      __e10 = __x258;
     } else {
-      __e10 = [__i3, hd(__x256)];
+      __e10 = [__i3, hd(__x258)];
     }
     __e9 = __e10;
   }
@@ -1095,9 +1095,9 @@ setenv("step", {_stash: true, macro: function (v, t) {
   var __t3 = destash33(t, ____r65);
   var ____id57 = ____r65;
   var __body41 = cut(____id57, 0);
-  var __x288 = unique("x");
+  var __x290 = unique("x");
   var __i7 = unique("i");
-  return ["let", [__x288, __t3], ["for", __i7, ["#", __x288], join(["let", [__v9, ["at", __x288, __i7]]], __body41)]];
+  return ["let", [__x290, __t3], ["for", __i7, ["#", __x290], join(["let", [__v9, ["at", __x290, __i7]]], __body41)]];
 }});
 setenv("set-of", {_stash: true, macro: function () {
   var __xs1 = unstash(Array.prototype.slice.call(arguments, 0));
@@ -1105,7 +1105,7 @@ setenv("set-of", {_stash: true, macro: function () {
   var ____o5 = __xs1;
   var ____i9 = undefined;
   for (____i9 in ____o5) {
-    var __x298 = ____o5[____i9];
+    var __x300 = ____o5[____i9];
     var __e12 = undefined;
     if (numeric63(____i9)) {
       __e12 = parseInt(____i9);
@@ -1113,7 +1113,7 @@ setenv("set-of", {_stash: true, macro: function () {
       __e12 = ____i9;
     }
     var ____i91 = __e12;
-    __l3[__x298] = true;
+    __l3[__x300] = true;
   }
   return join(["obj"], __l3);
 }});
@@ -1157,8 +1157,8 @@ setenv("dec", {_stash: true, macro: function (n, by) {
   return ["set", n, ["-", n, __e14]];
 }});
 setenv("with-indent", {_stash: true, macro: function (form) {
-  var __x323 = unique("x");
-  return ["do", ["inc", "indent-level"], ["with", __x323, form, ["dec", "indent-level"]]];
+  var __x325 = unique("x");
+  return ["do", ["inc", "indent-level"], ["with", __x325, form, ["dec", "indent-level"]]];
 }});
 setenv("export", {_stash: true, macro: function () {
   var __names5 = unstash(Array.prototype.slice.call(arguments, 0));
@@ -1167,7 +1167,7 @@ setenv("export", {_stash: true, macro: function () {
       return ["set", ["get", "exports", ["quote", k]], k];
     }, __names5));
   } else {
-    var __x339 = {};
+    var __x341 = {};
     var ____o7 = __names5;
     var ____i11 = undefined;
     for (____i11 in ____o7) {
@@ -1179,11 +1179,11 @@ setenv("export", {_stash: true, macro: function () {
         __e15 = ____i11;
       }
       var ____i111 = __e15;
-      __x339[__k7] = __k7;
+      __x341[__k7] = __k7;
     }
     return ["return", join(["%object"], mapo(function (x) {
       return x;
-    }, __x339))];
+    }, __x341))];
   }
 }});
 setenv("when-compiling", {_stash: true, macro: function () {

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -889,15 +889,15 @@ setenv("let-symbol", {_stash = true, macro = function (expansions, ...)
   local ____id42 = ____r48
   local __body31 = cut(____id42, 0)
   add(environment, {})
-  map(function (__x194)
-    local ____id43 = __x194
+  map(function (__x195)
+    local ____id43 = __x195
     local __name9 = ____id43[1]
     local __exp1 = ____id43[2]
     return macroexpand({"define-symbol", __name9, __exp1})
   end, pair(__expansions1))
-  local ____x193 = join({"do"}, macroexpand(__body31))
+  local ____x194 = {"%expansion", macroexpand(join({"do"}, __body31))}
   drop(environment)
-  return ____x193
+  return ____x194
 end})
 setenv("let-unique", {_stash = true, macro = function (names, ...)
   local ____r52 = unstash({...})
@@ -931,15 +931,15 @@ setenv("guard", {_stash = true, macro = function (expr)
   if target == "js" then
     return {{"fn", join(), {"%try", {"list", true, expr}}}}
   else
-    local ____x252 = {"obj"}
-    ____x252.stack = {{"get", "debug", {"quote", "traceback"}}}
-    ____x252.message = {"if", {"string?", "m"}, {"clip", "m", {"+", {"or", {"search", "m", "\": \""}, -2}, 2}}, {"nil?", "m"}, "\"\"", {"str", "m"}}
-    return {"list", {"xpcall", {"fn", join(), expr}, {"fn", {"m"}, {"if", {"obj?", "m"}, "m", ____x252}}}}
+    local ____x254 = {"obj"}
+    ____x254.stack = {{"get", "debug", {"quote", "traceback"}}}
+    ____x254.message = {"if", {"string?", "m"}, {"clip", "m", {"+", {"or", {"search", "m", "\": \""}, -2}, 2}}, {"nil?", "m"}, "\"\"", {"str", "m"}}
+    return {"list", {"xpcall", {"fn", join(), expr}, {"fn", {"m"}, {"if", {"obj?", "m"}, "m", ____x254}}}}
   end
 end})
 setenv("each", {_stash = true, macro = function (x, t, ...)
   local ____r61 = unstash({...})
-  local __x279 = destash33(x, ____r61)
+  local __x281 = destash33(x, ____r61)
   local __t1 = destash33(t, ____r61)
   local ____id52 = ____r61
   local __body37 = cut(____id52, 0)
@@ -947,14 +947,14 @@ setenv("each", {_stash = true, macro = function (x, t, ...)
   local __n3 = unique("n")
   local __i3 = unique("i")
   local __e8 = nil
-  if atom63(__x279) then
-    __e8 = {__i3, __x279}
+  if atom63(__x281) then
+    __e8 = {__i3, __x281}
   else
     local __e9 = nil
-    if _35(__x279) > 1 then
-      __e9 = __x279
+    if _35(__x281) > 1 then
+      __e9 = __x281
     else
-      __e9 = {__i3, hd(__x279)}
+      __e9 = {__i3, hd(__x281)}
     end
     __e8 = __e9
   end
@@ -983,9 +983,9 @@ setenv("step", {_stash = true, macro = function (v, t, ...)
   local __t3 = destash33(t, ____r65)
   local ____id57 = ____r65
   local __body41 = cut(____id57, 0)
-  local __x313 = unique("x")
+  local __x315 = unique("x")
   local __i7 = unique("i")
-  return {"let", {__x313, __t3}, {"for", __i7, {"#", __x313}, join({"let", {__v9, {"at", __x313, __i7}}}, __body41)}}
+  return {"let", {__x315, __t3}, {"for", __i7, {"#", __x315}, join({"let", {__v9, {"at", __x315, __i7}}}, __body41)}}
 end})
 setenv("set-of", {_stash = true, macro = function (...)
   local __xs1 = unstash({...})
@@ -993,8 +993,8 @@ setenv("set-of", {_stash = true, macro = function (...)
   local ____o5 = __xs1
   local ____i9 = nil
   for ____i9 in next, ____o5 do
-    local __x324 = ____o5[____i9]
-    __l3[__x324] = true
+    local __x326 = ____o5[____i9]
+    __l3[__x326] = true
   end
   return join({"obj"}, __l3)
 end})
@@ -1038,8 +1038,8 @@ setenv("dec", {_stash = true, macro = function (n, by)
   return {"set", n, {"-", n, __e12}}
 end})
 setenv("with-indent", {_stash = true, macro = function (form)
-  local __x352 = unique("x")
-  return {"do", {"inc", "indent-level"}, {"with", __x352, form, {"dec", "indent-level"}}}
+  local __x354 = unique("x")
+  return {"do", {"inc", "indent-level"}, {"with", __x354, form, {"dec", "indent-level"}}}
 end})
 setenv("export", {_stash = true, macro = function (...)
   local __names5 = unstash({...})
@@ -1048,16 +1048,16 @@ setenv("export", {_stash = true, macro = function (...)
       return {"set", {"get", "exports", {"quote", k}}, k}
     end, __names5))
   else
-    local __x369 = {}
+    local __x371 = {}
     local ____o7 = __names5
     local ____i11 = nil
     for ____i11 in next, ____o7 do
       local __k6 = ____o7[____i11]
-      __x369[__k6] = __k6
+      __x371[__k6] = __k6
     end
     return {"return", join({"%object"}, mapo(function (x)
       return x
-    end, __x369))}
+    end, __x371))}
   end
 end})
 setenv("when-compiling", {_stash = true, macro = function (...)

--- a/compiler.l
+++ b/compiler.l
@@ -131,7 +131,10 @@
     `(,x ,name ,args ,@(macroexpand body))))
 
 (define expand-macro (form)
-  (macroexpand (expand1 form)))
+  (let expr (expand1 form)
+    (if (hd? expr '%expansion)
+        (at expr 1)
+      (macroexpand expr))))
 
 (define-global expand1 ((name rest: body))
   (apply (macro-function name) body))

--- a/macros.l
+++ b/macros.l
@@ -132,7 +132,7 @@
     (map (fn ((name exp))
            (macroexpand `(define-symbol ,name ,exp)))
          (pair expansions))
-    `(do ,@(macroexpand body))))
+    `(%expansion ,(macroexpand `(do ,@body)))))
 
 (define-macro let-unique (names rest: body)
   (let bs (map (fn (n)


### PR DESCRIPTION
This gives a ~20% speed boost by making ~60% fewer calls to MACROEXPAND.

Here's a breakdown:

```
              current  new
runtime.js    11,914   5,194
macros.js     32,248   12,128
main.js       3,941    1,158
reader.js     3,037    1,654
compiler.js   34,379   13,476
system.js     512      485
runtime.lua   10,152   4,609
macros.lua    31,361   11,619
main.lua      4,109    1,226
reader.lua    2,993    1,610
compiler.lua  32,832   13,096
system.lua    813      603
test.js       188,983  76,320
test.lua      189,325  77,022
total         546,599  220,200
```

Graph (linear scale):
![image](https://user-images.githubusercontent.com/59632/205816408-9c73505c-58b3-467e-9ba6-8c8bac0e77c9.png)

Graph (log scale):
![image](https://user-images.githubusercontent.com/59632/205816708-20d734fb-5e7b-477e-a5ba-eac77be3c0a6.png)

Speedups using LuaJIT:

current:
```
$ make clean 2>/dev/null; time LUMEN_LUA=luajit LUMEN_HOST=luajit make -B >/dev/null
LUMEN_LUA=luajit LUMEN_HOST=luajit make -B > /dev/null  0.40s user 0.09s system 85% cpu 0.572 total
$ make clean 2>/dev/null; time LUMEN_LUA=luajit LUMEN_HOST=luajit make -B >/dev/null
LUMEN_LUA=luajit LUMEN_HOST=luajit make -B > /dev/null  0.40s user 0.08s system 84% cpu 0.565 total
$ make clean 2>/dev/null; time LUMEN_LUA=luajit LUMEN_HOST=luajit make -B >/dev/null
LUMEN_LUA=luajit LUMEN_HOST=luajit make -B > /dev/null  0.40s user 0.08s system 85% cpu 0.553 total
$ make clean 2>/dev/null; time LUMEN_LUA=luajit LUMEN_HOST=luajit make -B >/dev/null
LUMEN_LUA=luajit LUMEN_HOST=luajit make -B > /dev/null  0.39s user 0.08s system 86% cpu 0.548 total
```

new:
```
$ make clean 2>/dev/null; time LUMEN_LUA=luajit LUMEN_HOST=luajit make -B >/dev/null
LUMEN_LUA=luajit LUMEN_HOST=luajit make -B > /dev/null  0.34s user 0.09s system 85% cpu 0.500 total
$ make clean 2>/dev/null; time LUMEN_LUA=luajit LUMEN_HOST=luajit make -B >/dev/null
LUMEN_LUA=luajit LUMEN_HOST=luajit make -B > /dev/null  0.33s user 0.09s system 88% cpu 0.478 total
$ make clean 2>/dev/null; time LUMEN_LUA=luajit LUMEN_HOST=luajit make -B >/dev/null
LUMEN_LUA=luajit LUMEN_HOST=luajit make -B > /dev/null  0.32s user 0.08s system 87% cpu 0.462 total
$ make clean 2>/dev/null; time LUMEN_LUA=luajit LUMEN_HOST=luajit make -B >/dev/null
LUMEN_LUA=luajit LUMEN_HOST=luajit make -B > /dev/null  0.34s user 0.09s system 88% cpu 0.484 total
```

I was going to show node speedups as well (equally significant) but I'm being pulled away from the computer for the moment.