### PR TITLE
Fix LET-MACRO and LET-SYMBOL

### DIFF
--- a/bin/lumen.js
+++ b/bin/lumen.js
@@ -991,7 +991,7 @@ setenv("let-macro", {_stash: true, macro: function (definitions) {
   map(function (m) {
     return macroexpand(join(["define-macro"], m));
   }, __definitions1);
-  var ____x167 = join(["do"], macroexpand(__body29));
+  var ____x167 = macroexpand(join(["do"], __body29));
   drop(environment);
   return ____x167;
 }});
@@ -1007,7 +1007,7 @@ setenv("let-symbol", {_stash: true, macro: function (expansions) {
     var __exp1 = ____id43[1];
     return macroexpand(["define-symbol", __name9, __exp1]);
   }, pair(__expansions1));
-  var ____x174 = join(["do"], macroexpand(__body31));
+  var ____x174 = macroexpand(join(["do"], __body31));
   drop(environment);
   return ____x174;
 }});

--- a/bin/lumen.lua
+++ b/bin/lumen.lua
@@ -879,7 +879,7 @@ setenv("let-macro", {_stash = true, macro = function (definitions, ...)
   map(function (m)
     return macroexpand(join({"define-macro"}, m))
   end, __definitions1)
-  local ____x185 = join({"do"}, macroexpand(__body29))
+  local ____x185 = macroexpand(join({"do"}, __body29))
   drop(environment)
   return ____x185
 end})
@@ -895,7 +895,7 @@ setenv("let-symbol", {_stash = true, macro = function (expansions, ...)
     local __exp1 = ____id43[2]
     return macroexpand({"define-symbol", __name9, __exp1})
   end, pair(__expansions1))
-  local ____x193 = join({"do"}, macroexpand(__body31))
+  local ____x193 = macroexpand(join({"do"}, __body31))
   drop(environment)
   return ____x193
 end})

--- a/macros.l
+++ b/macros.l
@@ -125,14 +125,14 @@
     (map (fn (m)
            (macroexpand `(define-macro ,@m)))
          definitions)
-    `(do ,@(macroexpand body))))
+    (macroexpand `(do ,@body))))
 
 (define-macro let-symbol (expansions rest: body)
   (with-frame
     (map (fn ((name exp))
            (macroexpand `(define-symbol ,name ,exp)))
          (pair expansions))
-    `(do ,@(macroexpand body))))
+    (macroexpand `(do ,@body))))
 
 (define-macro let-unique (names rest: body)
   (let bs (map (fn (n)

--- a/test.l
+++ b/test.l
@@ -762,7 +762,9 @@ c"
                 (let (x 10)
                   (set x 20))
                 `(+ ,x 1)))
-    (test= 2 (a 1))))
+    (test= 2 (a 1)))
+  (test= '(do a 42)
+         (macroexpand '(let-macro ((a (x) `(+ ,x 1))) a 42))))
 
 (define-test let-symbol
   (let-symbol (a 17
@@ -775,7 +777,10 @@ c"
   (let-symbol (a 18)
     (let (b 20)
       (test= 18 a)
-      (test= 20 b))))
+      (test= 20 b)))
+  (test= '(do (do a 42))
+         (macroexpand '(let-macro ((a (x) `(+ ,x 1)))
+                         (let-symbol (b 42) a b)))))
 
 (define-test define-symbol
   (define-symbol zzz 42)


### PR DESCRIPTION
I noticed that `let-macro` and `let-symbol` don't expand their body correctly. This PR fixes that, and adds tests to illustrate the problem.