### PR TITLE
Fix body expansion

### DIFF
--- a/bin/compiler.js
+++ b/bin/compiler.js
@@ -226,7 +226,7 @@ var expand_function = function (__x41) {
     var ____i51 = __e27;
     setenv(____x43, {_stash: true, variable: true});
   }
-  var ____x44 = join(["%function", __args], macroexpand(__body));
+  var ____x44 = join(["%function", __args], map(macroexpand, __body));
   drop(environment);
   return ____x44;
 };
@@ -250,7 +250,7 @@ var expand_definition = function (__x46) {
     var ____i61 = __e28;
     setenv(____x48, {_stash: true, variable: true});
   }
-  var ____x49 = join([__x47, __name1, __args11], macroexpand(__body1));
+  var ____x49 = join([__x47, __name1, __args11], map(macroexpand, __body1));
   drop(environment);
   return ____x49;
 };

--- a/bin/compiler.lua
+++ b/bin/compiler.lua
@@ -198,7 +198,7 @@ local function expand_function(__x41)
     local ____x43 = ____o3[____i5]
     setenv(____x43, {_stash = true, variable = true})
   end
-  local ____x44 = join({"%function", __args}, macroexpand(__body))
+  local ____x44 = join({"%function", __args}, map(macroexpand, __body))
   drop(environment)
   return ____x44
 end
@@ -215,7 +215,7 @@ local function expand_definition(__x46)
     local ____x48 = ____o4[____i6]
     setenv(____x48, {_stash = true, variable = true})
   end
-  local ____x49 = join({__x47, __name1, __args11}, macroexpand(__body1))
+  local ____x49 = join({__x47, __name1, __args11}, map(macroexpand, __body1))
   drop(environment)
   return ____x49
 end

--- a/compiler.l
+++ b/compiler.l
@@ -124,11 +124,11 @@
 
 (define expand-function ((x args rest: body))
   (with-bindings (args)
-    `(%function ,args ,@(macroexpand body))))
+    `(%function ,args ,@(map macroexpand body))))
 
 (define expand-definition ((x name args rest: body))
   (with-bindings (args)
-    `(,x ,name ,args ,@(macroexpand body))))
+    `(,x ,name ,args ,@(map macroexpand body))))
 
 (define expand-macro (form)
   (macroexpand (expand1 form)))


### PR DESCRIPTION
Similar to #228, this PR fixes expansion of function and definition bodies.

e.g. `(macroexpand '(%function (x) let y x y))` currently treats `let y x y` as an expression `(let y x y)` rather than separate expressions `let`, `y`, `x`, and `y`. Ditto for `%local-function` and `%global-function`.

It'd be hard to run into this bug in practice (you'd have to use `%function` expressions without using `bind*`), but it's probably worth fixing if only to demonstrate to new users the correct way to expand a list of expressions.