### PR TITLE
Simplify tests

### DIFF
--- a/test.l
+++ b/test.l
@@ -762,9 +762,7 @@ c"
                 (let (x 10)
                   (set x 20))
                 `(+ ,x 1)))
-    (test= 2 (a 1)))
-  (test= '(do a 42)
-         (macroexpand '(let-macro ((a (x) `(+ ,x 1))) a 42))))
+    (test= 2 (a 1))))
 
 (define-test let-symbol
   (let-symbol (a 17
@@ -777,10 +775,7 @@ c"
   (let-symbol (a 18)
     (let (b 20)
       (test= 18 a)
-      (test= 20 b)))
-  (test= '(do (do a 42))
-         (macroexpand '(let-macro ((a (x) `(+ ,x 1)))
-                         (let-symbol (b 42) a b)))))
+      (test= 20 b))))
 
 (define-test define-symbol
   (define-symbol zzz 42)


### PR DESCRIPTION
I think the tests were clearer prior to #228, so this PR removes them:

```
  (test= '(do (do a 42))
         (macroexpand '(let-macro ((a (x) `(+ ,x 1)))
                         (let-symbol (b 42) a b))))

  (test= '(do a 42)
         (macroexpand '(let-macro ((a (x) `(+ ,x 1))) a 42)))
```

I introduced those mostly to explain the bug I was trying to fix, rather than to ensure the bug doesn't happen again.

Those tests also make it more difficult to change the implementations of `let-macro` and `let-symbol`, because they force implementations to expand into ``` `(do ,@body) ```. (For example, an alternative implementation is to check if`(one? body)` is true, and if so, return`(hd body)`, else return ``` `(do ,@body)```. With the current tests, this implementation would be disallowed, even though it's a valid way of simplifying body expansion without waiting for a lowering pass.)